### PR TITLE
feat: Config Server 설정

### DIFF
--- a/.github/workflows/popi-ci.yml
+++ b/.github/workflows/popi-ci.yml
@@ -30,5 +30,8 @@ jobs:
         run: chmod +x ./gradlew
 
       - name: Test
+        env:
+          GIT_USERNAME: ${{ secrets.GIT_USERNAME }}
+          GIT_TOKEN: ${{ secrets.GIT_TOKEN }}
         run: |
           ./gradlew test

--- a/.github/workflows/popi-ci.yml
+++ b/.github/workflows/popi-ci.yml
@@ -30,8 +30,5 @@ jobs:
         run: chmod +x ./gradlew
 
       - name: Test
-        env:
-          GIT_USERNAME: ${{ secrets.GIT_USERNAME }}
-          GIT_TOKEN: ${{ secrets.GIT_TOKEN }}
         run: |
           ./gradlew test

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,7 @@ out/
 
 ### VS Code ###
 .vscode/
+
+### Custom ###
+.DS_Store
+.env

--- a/popi-config-server/build.gradle
+++ b/popi-config-server/build.gradle
@@ -1,0 +1,13 @@
+dependencies {
+
+	implementation 'org.springframework.boot:spring-boot-starter-web'
+
+	implementation 'org.springframework.cloud:spring-cloud-config-server'
+
+	// Actuator
+	implementation 'org.springframework.boot:spring-boot-starter-actuator'
+
+	// RabbitMQ
+	implementation 'org.springframework.boot:spring-boot-starter-amqp'
+	testImplementation 'org.springframework.amqp:spring-rabbit-test'
+}

--- a/popi-config-server/src/main/java/com/lgcns/PopiConfigServerApplication.java
+++ b/popi-config-server/src/main/java/com/lgcns/PopiConfigServerApplication.java
@@ -1,0 +1,15 @@
+package com.lgcns;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.config.server.EnableConfigServer;
+
+@SpringBootApplication
+@EnableConfigServer
+public class PopiConfigServerApplication {
+
+	public static void main(String[] args) {
+		SpringApplication.run(PopiConfigServerApplication.class, args);
+	}
+
+}

--- a/popi-config-server/src/main/resources/application.yml
+++ b/popi-config-server/src/main/resources/application.yml
@@ -5,7 +5,7 @@ spring:
   application:
     name: config-server
   rabbitmq:
-    host: localhost
+    host: ${RABBITMQ_HOST:localhost}
     port: 5672
     username: guest
     password: guest

--- a/popi-config-server/src/main/resources/application.yml
+++ b/popi-config-server/src/main/resources/application.yml
@@ -1,0 +1,26 @@
+server:
+  port: 8888
+
+spring:
+  application:
+    name: config-server
+  rabbitmq:
+    host: localhost
+    port: 5672
+    username: guest
+    password: guest
+  profiles:
+    active: git
+  cloud:
+    config:
+      server:
+        git:
+          uri: https://${GITHUB_USERNAME}:${GITHUB_TOKEN}@github.com/chic2chic/popi-config.git
+          default-label: main
+          skipSslValidation: true
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health, busrefresh, refresh, metrics

--- a/popi-config-server/src/main/resources/application.yml
+++ b/popi-config-server/src/main/resources/application.yml
@@ -15,7 +15,7 @@ spring:
     config:
       server:
         git:
-          uri: https://${GITHUB_USERNAME}:${GITHUB_TOKEN}@github.com/chic2chic/popi-config.git
+          uri: https://${GIT_USERNAME}:${GIT_TOKEN}@github.com/chic2chic/popi-config.git
           default-label: main
           skipSslValidation: true
 

--- a/popi-config-server/src/test/java/com/lgcns/PopiConfigServerApplicationTests.java
+++ b/popi-config-server/src/test/java/com/lgcns/PopiConfigServerApplicationTests.java
@@ -1,0 +1,13 @@
+package com.lgcns;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class PopiConfigServerApplicationTests {
+
+	@Test
+	void contextLoads() {
+	}
+
+}

--- a/popi-eureka-server/build.gradle
+++ b/popi-eureka-server/build.gradle
@@ -1,3 +1,9 @@
 dependencies {
 	implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-server'
+
+	// Spring Cloud Config
+	implementation 'org.springframework.cloud:spring-cloud-starter-config'
+	implementation 'org.springframework.boot:spring-boot-starter-actuator'
+	implementation 'org.springframework.boot:spring-boot-starter-amqp'
+	annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
 }

--- a/popi-eureka-server/build.gradle
+++ b/popi-eureka-server/build.gradle
@@ -4,6 +4,7 @@ dependencies {
 	// Spring Cloud Config
 	implementation 'org.springframework.cloud:spring-cloud-starter-config'
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
-	implementation 'org.springframework.boot:spring-boot-starter-amqp'
 	annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
+	implementation 'org.springframework.boot:spring-boot-starter-amqp'
+	testImplementation 'org.springframework.amqp:spring-rabbit-test'
 }

--- a/popi-eureka-server/build.gradle
+++ b/popi-eureka-server/build.gradle
@@ -4,7 +4,6 @@ dependencies {
 	// Spring Cloud Config
 	implementation 'org.springframework.cloud:spring-cloud-starter-config'
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
-	annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
 	implementation 'org.springframework.boot:spring-boot-starter-amqp'
-	testImplementation 'org.springframework.amqp:spring-rabbit-test'
+	annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
 }

--- a/popi-eureka-server/src/main/resources/application.yml
+++ b/popi-eureka-server/src/main/resources/application.yml
@@ -1,11 +1,8 @@
-server:
-  port: 8761
-
 spring:
   application:
     name: eureka-server
-
-eureka:
-  client:
-    register-with-eureka: false
-    fetch-registry: false
+  cloud:
+    config:
+      name: ${SPRING_CLOUD_CONFIG_NAME:eureka-server}
+  config:
+    import: configserver:http://localhost:8888

--- a/popi-eureka-server/src/main/resources/application.yml
+++ b/popi-eureka-server/src/main/resources/application.yml
@@ -5,4 +5,4 @@ spring:
     config:
       name: ${SPRING_CLOUD_CONFIG_NAME:eureka-server}
   config:
-    import: configserver:http://localhost:8888
+    import: configserver:http://${CONFIG_SERVER_NAME:localhost}:8888

--- a/popi-eureka-server/src/test/resources/application.yml
+++ b/popi-eureka-server/src/test/resources/application.yml
@@ -1,0 +1,4 @@
+spring:
+  cloud:
+    config:
+      enabled: false

--- a/settings.gradle
+++ b/settings.gradle
@@ -2,5 +2,6 @@ rootProject.name = 'popi'
 
 include(
         "popi-eureka-server",
-        "popi-common"
+        "popi-common",
+        "popi-config-server"
 )


### PR DESCRIPTION
## 🌱 관련 이슈

- [LCR-35]

---
## 📌 작업 내용 및 특이사항

- Config Server 설정
- settings.gradle에 모듈 추가
- build.gradle 의존성 : Spring Web, Config Server, Actuator, RabbitMQ
- Application에 @EnableConfigServer 어노테이션 추가
- eureka-server config 적용 완료 

---
## 📚 참고사항

- eureka-server가 config-server에서 설정 파일(eureka-server.yml)을 가져오도록 하기 위한 application.yml 예시

```yml
spring:
  application:
    name: eureka-server
  cloud:
    config:
      name: ${SPRING_CLOUD_CONFIG_NAME:eureka-server}
  config:
    import: configserver:http://localhost:8888
```


[LCR-35]: https://lgcns-retail.atlassian.net/browse/LCR-35?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ