### PR TITLE
feat: 회원 도메인 구현 및 Security 설정

### DIFF
--- a/popi-auth-service/build.gradle
+++ b/popi-auth-service/build.gradle
@@ -1,5 +1,5 @@
 dependencies {
-    implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation project(':popi-common')
 
     // Spring Cloud Config
     implementation 'org.springframework.cloud:spring-cloud-starter-config'

--- a/popi-auth-service/build.gradle
+++ b/popi-auth-service/build.gradle
@@ -7,4 +7,8 @@ dependencies {
 
     // Redis
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
+    // Spring Security
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.security:spring-security-test'
 }

--- a/popi-auth-service/src/main/java/com/lgcns/config/WebSecurityConfig.java
+++ b/popi-auth-service/src/main/java/com/lgcns/config/WebSecurityConfig.java
@@ -1,0 +1,30 @@
+package com.lgcns.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class WebSecurityConfig {
+
+    @Bean
+    public SecurityFilterChain defaultSecurityFilterChain(HttpSecurity http) throws Exception {
+        http.csrf(AbstractHttpConfigurer::disable)
+                .httpBasic(AbstractHttpConfigurer::disable)
+                .formLogin(AbstractHttpConfigurer::disable)
+                .sessionManagement(
+                        session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS));
+
+        http.authorizeHttpRequests(
+                auth -> auth.requestMatchers("/**").permitAll().anyRequest().authenticated());
+
+        return http.build();
+    }
+}

--- a/popi-auth-service/src/main/java/com/lgcns/domain/Member.java
+++ b/popi-auth-service/src/main/java/com/lgcns/domain/Member.java
@@ -1,0 +1,63 @@
+package com.lgcns.domain;
+
+import com.lgcns.model.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Member extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "member_id")
+    private Long id;
+
+    private String nickname;
+
+    @Embedded private OauthInfo oauthInfo;
+
+    private String phoneNumber;
+
+    private int age;
+
+    @Enumerated(EnumType.STRING)
+    private MemberGender gender;
+
+    @Enumerated(EnumType.STRING)
+    private MemberStatus status;
+
+    @Enumerated(EnumType.STRING)
+    private MemberRole role;
+
+    @Builder(access = AccessLevel.PRIVATE)
+    private Member(
+            String nickname,
+            OauthInfo oauthInfo,
+            String phoneNumber,
+            int age,
+            MemberGender gender,
+            MemberStatus status,
+            MemberRole role) {
+        this.nickname = nickname;
+        this.phoneNumber = phoneNumber;
+        this.gender = gender;
+        this.age = age;
+        this.oauthInfo = oauthInfo;
+        this.status = status;
+        this.role = role;
+    }
+
+    public static Member createMember(String nickname, OauthInfo oauthInfo) {
+        return Member.builder()
+                .nickname(nickname)
+                .oauthInfo(oauthInfo)
+                .status(MemberStatus.NORMAL)
+                .role(MemberRole.USER)
+                .build();
+    }
+}

--- a/popi-auth-service/src/main/java/com/lgcns/domain/MemberGender.java
+++ b/popi-auth-service/src/main/java/com/lgcns/domain/MemberGender.java
@@ -1,0 +1,14 @@
+package com.lgcns.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum MemberGender {
+    MALE("MALE"),
+    FEMALE("FEMALE"),
+    ;
+
+    private final String gender;
+}

--- a/popi-auth-service/src/main/java/com/lgcns/domain/MemberRole.java
+++ b/popi-auth-service/src/main/java/com/lgcns/domain/MemberRole.java
@@ -1,0 +1,14 @@
+package com.lgcns.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum MemberRole {
+    ADMIN("ROLE_ADMIN"),
+    USER("ROLE_USER"),
+    ;
+
+    private final String role;
+}

--- a/popi-auth-service/src/main/java/com/lgcns/domain/MemberStatus.java
+++ b/popi-auth-service/src/main/java/com/lgcns/domain/MemberStatus.java
@@ -1,0 +1,15 @@
+package com.lgcns.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum MemberStatus {
+    NORMAL("NORMAL"),
+    DELETED("DELETED"),
+    FORBIDDEN("FORBIDDEN"),
+    ;
+
+    private final String status;
+}

--- a/popi-auth-service/src/main/java/com/lgcns/domain/OauthInfo.java
+++ b/popi-auth-service/src/main/java/com/lgcns/domain/OauthInfo.java
@@ -1,0 +1,24 @@
+package com.lgcns.domain;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class OauthInfo {
+
+    private String oauthId;
+    private String oauthProvider;
+
+    @Builder(access = AccessLevel.PRIVATE)
+    private OauthInfo(String oauthId, String oauthProvider) {
+        this.oauthId = oauthId;
+        this.oauthProvider = oauthProvider;
+    }
+
+    public static OauthInfo createOauthInfo(String oauthId, String oauthProvider) {
+        return OauthInfo.builder().oauthId(oauthId).oauthProvider(oauthProvider).build();
+    }
+}

--- a/popi-auth-service/src/main/java/com/lgcns/repository/MemberRepository.java
+++ b/popi-auth-service/src/main/java/com/lgcns/repository/MemberRepository.java
@@ -1,0 +1,6 @@
+package com.lgcns.repository;
+
+import com.lgcns.domain.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {}

--- a/popi-common/build.gradle
+++ b/popi-common/build.gradle
@@ -13,7 +13,4 @@ dependencies {
 
     //QueryDSL
     api 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
-    annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
-    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
-    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 }

--- a/popi-common/build.gradle
+++ b/popi-common/build.gradle
@@ -1,14 +1,18 @@
+plugins {
+    id 'java-library'
+}
+
 bootJar { enabled = false }
 jar { enabled = true }
 
 dependencies {
-    implementation 'org.springframework.boot:spring-boot-starter-web'
+    api 'org.springframework.boot:spring-boot-starter-web'
     
     // JPA
-    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    api 'org.springframework.boot:spring-boot-starter-data-jpa'
 
     //QueryDSL
-    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    api 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
     annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
     annotationProcessor "jakarta.annotation:jakarta.annotation-api"
     annotationProcessor "jakarta.persistence:jakarta.persistence-api"


### PR DESCRIPTION
## 🌱 관련 이슈

- [LCR-52]

---
## 📌 작업 내용 및 특이사항

- common 모듈의 build.gradle을 수정하였습니다.
  - java-library 플러그인 적용
  - web, jpa, querydsl 의존성 api로 선언하여 하위 모듈에서 사용 가능하도록 개선
  - 제거한 querydsl annotationProcessor 의존성은 페이징이 필요한 마이크로 서비스에서 의존성 추가하여 사용하시기 바랍니다.

- 회원 도메인을 구현했습니다.

- Spring Security 설정을 추가하였습니다.
  - CSRF 비활성화
  - 임시로 모든 url 요청 허용
  - 인증 서비스는 외부와 직접 통신하지 않으므로 CORS 설정은 API Gateway에서만 관리합니다.

---
## 📚 참고사항

- 로컬에 h2 db 실행시키시면 됩니다.
- 회원 엔티티 생성 시 내부에서는 빌더 / 외부에서는 정적 팩토리 메서드를 사용합니다. 다른 도메인 구현 시 참고 바랍니다.


[LCR-52]: https://lgcns-retail.atlassian.net/browse/LCR-52?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ