### PR TITLE
feat: 소셜 로그인 구현

### DIFF
--- a/popi-auth-service/build.gradle
+++ b/popi-auth-service/build.gradle
@@ -11,4 +11,7 @@ dependencies {
     // Spring Security
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.security:spring-security-test'
+
+    // Spring Cloud Open Feign
+    implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
 }

--- a/popi-auth-service/build.gradle
+++ b/popi-auth-service/build.gradle
@@ -14,4 +14,9 @@ dependencies {
 
     // Spring Cloud Open Feign
     implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
+
+    // JWT
+    implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 }

--- a/popi-auth-service/build.gradle
+++ b/popi-auth-service/build.gradle
@@ -19,4 +19,7 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
+    // Oauth2 Jose
+    implementation 'org.springframework.security:spring-security-oauth2-jose'
 }

--- a/popi-auth-service/build.gradle
+++ b/popi-auth-service/build.gradle
@@ -1,6 +1,12 @@
 dependencies {
     implementation project(':popi-common')
 
+    // h2
+    runtimeOnly 'com.h2database:h2'
+
+    // Eureka Client
+    implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
+
     // Spring Cloud Config
     implementation 'org.springframework.cloud:spring-cloud-starter-config'
     annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'

--- a/popi-auth-service/build.gradle
+++ b/popi-auth-service/build.gradle
@@ -1,15 +1,15 @@
 dependencies {
     implementation project(':popi-common')
 
-    // h2
-    runtimeOnly 'com.h2database:h2'
-
     // Eureka Client
     implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
 
     // Spring Cloud Config
     implementation 'org.springframework.cloud:spring-cloud-starter-config'
     annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
+
+    // MySQL
+    runtimeOnly 'com.mysql:mysql-connector-j'
 
     // Swagger
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.0'

--- a/popi-auth-service/build.gradle
+++ b/popi-auth-service/build.gradle
@@ -11,6 +11,9 @@ dependencies {
     implementation 'org.springframework.cloud:spring-cloud-starter-config'
     annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
 
+    // Swagger
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.0'
+
     // Redis
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 

--- a/popi-auth-service/src/main/java/com/lgcns/client/GoogleOauthClient.java
+++ b/popi-auth-service/src/main/java/com/lgcns/client/GoogleOauthClient.java
@@ -1,0 +1,21 @@
+package com.lgcns.client;
+
+import static com.lgcns.constants.SecurityConstants.GOOGLE_LOGIN_ENDPOINT;
+import static com.lgcns.constants.SecurityConstants.GOOGLE_LOGIN_URL;
+
+import com.lgcns.config.FeignConfig;
+import com.lgcns.dto.response.IdTokenResponse;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@FeignClient(name = "googleOauthClient", url = GOOGLE_LOGIN_URL, configuration = FeignConfig.class)
+public interface GoogleOauthClient {
+    @PostMapping(value = GOOGLE_LOGIN_ENDPOINT)
+    IdTokenResponse getIdToken(
+            @RequestParam("grant_type") String grantType,
+            @RequestParam("client_id") String clientId,
+            @RequestParam("redirect_uri") String redirectUri,
+            @RequestParam("code") String code,
+            @RequestParam("client_secret") String clientSecret);
+}

--- a/popi-auth-service/src/main/java/com/lgcns/client/KakaoOauthClient.java
+++ b/popi-auth-service/src/main/java/com/lgcns/client/KakaoOauthClient.java
@@ -1,0 +1,21 @@
+package com.lgcns.client;
+
+import static com.lgcns.constants.SecurityConstants.KAKAO_LOGIN_ENDPOINT;
+import static com.lgcns.constants.SecurityConstants.KAKAO_LOGIN_URL;
+
+import com.lgcns.config.FeignConfig;
+import com.lgcns.dto.response.IdTokenResponse;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@FeignClient(name = "kakaoOauthClient", url = KAKAO_LOGIN_URL, configuration = FeignConfig.class)
+public interface KakaoOauthClient {
+    @PostMapping(value = KAKAO_LOGIN_ENDPOINT)
+    IdTokenResponse getIdToken(
+            @RequestParam("grant_type") String grantType,
+            @RequestParam("client_id") String clientId,
+            @RequestParam("redirect_uri") String redirectUri,
+            @RequestParam("code") String code,
+            @RequestParam("client_secret") String clientSecret);
+}

--- a/popi-auth-service/src/main/java/com/lgcns/config/FeignConfig.java
+++ b/popi-auth-service/src/main/java/com/lgcns/config/FeignConfig.java
@@ -1,0 +1,18 @@
+package com.lgcns.config;
+
+import feign.RequestInterceptor;
+import org.springframework.cloud.openfeign.EnableFeignClients;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableFeignClients(basePackages = "com.lgcns.client")
+public class FeignConfig {
+
+    @Bean
+    public RequestInterceptor requestInterceptor() {
+        return requestTemplate ->
+                requestTemplate.header(
+                        "Content-Type", "application/x-www-form-urlencoded;charset=utf-8");
+    }
+}

--- a/popi-auth-service/src/main/java/com/lgcns/config/FeignConfig.java
+++ b/popi-auth-service/src/main/java/com/lgcns/config/FeignConfig.java
@@ -11,8 +11,13 @@ public class FeignConfig {
 
     @Bean
     public RequestInterceptor requestInterceptor() {
-        return requestTemplate ->
-                requestTemplate.header(
-                        "Content-Type", "application/x-www-form-urlencoded;charset=utf-8");
+        return requestTemplate -> {
+            requestTemplate.header(
+                    "Content-Type", "application/x-www-form-urlencoded;charset=utf-8");
+
+            if (requestTemplate.body() == null) {
+                requestTemplate.body("");
+            }
+        };
     }
 }

--- a/popi-auth-service/src/main/java/com/lgcns/config/SwaggerConfig.java
+++ b/popi-auth-service/src/main/java/com/lgcns/config/SwaggerConfig.java
@@ -1,0 +1,45 @@
+package com.lgcns.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.servers.Server;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@RequiredArgsConstructor
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI openAPI() {
+        return new OpenAPI()
+                .info(
+                        new Info()
+                                .title("PoPI Auth Server API")
+                                .description("PoPI 인증 서비스 API 명세서입니다.")
+                                .version("v0.0.1"))
+                .addServersItem(new Server().url("/auth"))
+                .components(authSetting())
+                .addSecurityItem(securityRequirement());
+    }
+
+    private Components authSetting() {
+        return new Components()
+                .addSecuritySchemes(
+                        "accessToken",
+                        new SecurityScheme()
+                                .type(SecurityScheme.Type.HTTP)
+                                .scheme("bearer")
+                                .bearerFormat("JWT")
+                                .in(SecurityScheme.In.HEADER)
+                                .name("Authorization"));
+    }
+
+    private SecurityRequirement securityRequirement() {
+        return new SecurityRequirement().addList("accessToken");
+    }
+}

--- a/popi-auth-service/src/main/java/com/lgcns/constants/SecurityConstants.java
+++ b/popi-auth-service/src/main/java/com/lgcns/constants/SecurityConstants.java
@@ -1,6 +1,8 @@
 package com.lgcns.constants;
 
 public final class SecurityConstants {
+    public static final String TOKEN_ROLE_NAME = "role";
+
     public static final String KAKAO_LOGIN_URL = "https://kauth.kakao.com";
     public static final String KAKAO_LOGIN_ENDPOINT = "/oauth/token";
 

--- a/popi-auth-service/src/main/java/com/lgcns/constants/SecurityConstants.java
+++ b/popi-auth-service/src/main/java/com/lgcns/constants/SecurityConstants.java
@@ -8,4 +8,10 @@ public final class SecurityConstants {
 
     public static final String GOOGLE_LOGIN_URL = "https://oauth2.googleapis.com";
     public static final String GOOGLE_LOGIN_ENDPOINT = "/token";
+
+    public static final String KAKAO_JWK_SET_URL = "https://kauth.kakao.com/.well-known/jwks.json";
+    public static final String KAKAO_ISSUER = "https://kauth.kakao.com";
+
+    public static final String GOOGLE_JWK_SET_URL = "https://www.googleapis.com/oauth2/v3/certs";
+    public static final String GOOGLE_ISSUER = "https://accounts.google.com";
 }

--- a/popi-auth-service/src/main/java/com/lgcns/constants/SecurityConstants.java
+++ b/popi-auth-service/src/main/java/com/lgcns/constants/SecurityConstants.java
@@ -1,0 +1,9 @@
+package com.lgcns.constants;
+
+public final class SecurityConstants {
+    public static final String KAKAO_LOGIN_URL = "https://kauth.kakao.com";
+    public static final String KAKAO_LOGIN_ENDPOINT = "/oauth/token";
+
+    public static final String GOOGLE_LOGIN_URL = "https://oauth2.googleapis.com";
+    public static final String GOOGLE_LOGIN_ENDPOINT = "/token";
+}

--- a/popi-auth-service/src/main/java/com/lgcns/controller/AuthController.java
+++ b/popi-auth-service/src/main/java/com/lgcns/controller/AuthController.java
@@ -4,15 +4,19 @@ import com.lgcns.domain.OauthProvider;
 import com.lgcns.dto.request.AuthCodeRequest;
 import com.lgcns.dto.response.SocialLoginResponse;
 import com.lgcns.service.AuthService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
+@Tag(name = "인증 서버 API", description = "인증 서버 API입니다.")
 @RestController
 @RequiredArgsConstructor
 public class AuthController {
 
     private final AuthService authService;
 
+    @Operation(summary = "회원가입 및 로그인", description = "회원가입 및 로그인을 진행합니다.")
     @PostMapping("/social-login")
     public SocialLoginResponse memberSocialLogin(
             @RequestParam(name = "oauthProvider") OauthProvider provider,

--- a/popi-auth-service/src/main/java/com/lgcns/controller/AuthController.java
+++ b/popi-auth-service/src/main/java/com/lgcns/controller/AuthController.java
@@ -1,0 +1,22 @@
+package com.lgcns.controller;
+
+import com.lgcns.domain.OauthProvider;
+import com.lgcns.dto.request.AuthCodeRequest;
+import com.lgcns.dto.response.SocialLoginResponse;
+import com.lgcns.service.AuthService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+public class AuthController {
+
+    private final AuthService authService;
+
+    @PostMapping("/social-login")
+    public SocialLoginResponse memberSocialLogin(
+            @RequestParam(name = "oauthProvider") OauthProvider provider,
+            @RequestBody AuthCodeRequest request) {
+        return authService.socialLoginMember(request, provider);
+    }
+}

--- a/popi-auth-service/src/main/java/com/lgcns/domain/OauthProvider.java
+++ b/popi-auth-service/src/main/java/com/lgcns/domain/OauthProvider.java
@@ -1,0 +1,24 @@
+package com.lgcns.domain;
+
+import static com.lgcns.constants.SecurityConstants.*;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum OauthProvider {
+    KAKAO(KAKAO_JWK_SET_URL, KAKAO_ISSUER),
+    GOOGLE(GOOGLE_JWK_SET_URL, GOOGLE_ISSUER),
+    ;
+
+    private final String jwkSetUrl;
+    private final String issuer;
+
+    public String getClientId(String googleClientId, String kakaoClientId) {
+        return switch (this) {
+            case GOOGLE -> googleClientId;
+            case KAKAO -> kakaoClientId;
+        };
+    }
+}

--- a/popi-auth-service/src/main/java/com/lgcns/domain/RefreshToken.java
+++ b/popi-auth-service/src/main/java/com/lgcns/domain/RefreshToken.java
@@ -1,0 +1,25 @@
+package com.lgcns.domain;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+import org.springframework.data.redis.core.TimeToLive;
+
+@Getter
+@RedisHash(value = "refreshToken")
+public class RefreshToken {
+
+    @Id private Long memberId;
+
+    private String token;
+
+    @TimeToLive private long ttl;
+
+    @Builder
+    private RefreshToken(Long memberId, String token, long ttl) {
+        this.memberId = memberId;
+        this.token = token;
+        this.ttl = ttl;
+    }
+}

--- a/popi-auth-service/src/main/java/com/lgcns/dto/request/AuthCodeRequest.java
+++ b/popi-auth-service/src/main/java/com/lgcns/dto/request/AuthCodeRequest.java
@@ -1,0 +1,5 @@
+package com.lgcns.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+
+public record AuthCodeRequest(@NotNull(message = "인증코드는 필수입니다") String code) {}

--- a/popi-auth-service/src/main/java/com/lgcns/dto/request/AuthCodeRequest.java
+++ b/popi-auth-service/src/main/java/com/lgcns/dto/request/AuthCodeRequest.java
@@ -1,5 +1,8 @@
 package com.lgcns.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 
-public record AuthCodeRequest(@NotNull(message = "인증코드는 필수입니다") String code) {}
+public record AuthCodeRequest(
+        @NotNull(message = "인증코드는 필수입니다") @Schema(description = "구글, 카카오 로그인을 통한 인증코드")
+                String code) {}

--- a/popi-auth-service/src/main/java/com/lgcns/dto/response/IdTokenResponse.java
+++ b/popi-auth-service/src/main/java/com/lgcns/dto/response/IdTokenResponse.java
@@ -1,0 +1,3 @@
+package com.lgcns.dto.response;
+
+public record IdTokenResponse(String id_token) {}

--- a/popi-auth-service/src/main/java/com/lgcns/dto/response/SocialLoginResponse.java
+++ b/popi-auth-service/src/main/java/com/lgcns/dto/response/SocialLoginResponse.java
@@ -1,0 +1,7 @@
+package com.lgcns.dto.response;
+
+public record SocialLoginResponse(String accessToken, String refreshToken) {
+    public static SocialLoginResponse of(String accessToken, String refreshToken) {
+        return new SocialLoginResponse(accessToken, refreshToken);
+    }
+}

--- a/popi-auth-service/src/main/java/com/lgcns/dto/response/SocialLoginResponse.java
+++ b/popi-auth-service/src/main/java/com/lgcns/dto/response/SocialLoginResponse.java
@@ -1,6 +1,10 @@
 package com.lgcns.dto.response;
 
-public record SocialLoginResponse(String accessToken, String refreshToken) {
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record SocialLoginResponse(
+        @Schema(description = "엑세스 토큰") String accessToken,
+        @Schema(description = "리프레시 토큰") String refreshToken) {
     public static SocialLoginResponse of(String accessToken, String refreshToken) {
         return new SocialLoginResponse(accessToken, refreshToken);
     }

--- a/popi-auth-service/src/main/java/com/lgcns/exception/AuthErrorCode.java
+++ b/popi-auth-service/src/main/java/com/lgcns/exception/AuthErrorCode.java
@@ -1,0 +1,21 @@
+package com.lgcns.exception;
+
+import com.lgcns.error.exception.ErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum AuthErrorCode implements ErrorCode {
+    ID_TOKEN_VERIFICATION_FAILED(HttpStatus.UNAUTHORIZED, "ID 토큰 검증에 실패했습니다."),
+    ;
+
+    private final HttpStatus httpStatus;
+    private final String message;
+
+    @Override
+    public String getErrorName() {
+        return this.name();
+    }
+}

--- a/popi-auth-service/src/main/java/com/lgcns/repository/MemberRepository.java
+++ b/popi-auth-service/src/main/java/com/lgcns/repository/MemberRepository.java
@@ -1,6 +1,10 @@
 package com.lgcns.repository;
 
 import com.lgcns.domain.Member;
+import com.lgcns.domain.OauthInfo;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface MemberRepository extends JpaRepository<Member, Long> {}
+public interface MemberRepository extends JpaRepository<Member, Long> {
+    Optional<Member> findByOauthInfo(OauthInfo oauthInfo);
+}

--- a/popi-auth-service/src/main/java/com/lgcns/repository/RefreshTokenRepository.java
+++ b/popi-auth-service/src/main/java/com/lgcns/repository/RefreshTokenRepository.java
@@ -1,0 +1,6 @@
+package com.lgcns.repository;
+
+import com.lgcns.domain.RefreshToken;
+import org.springframework.data.repository.CrudRepository;
+
+public interface RefreshTokenRepository extends CrudRepository<RefreshToken, Long> {}

--- a/popi-auth-service/src/main/java/com/lgcns/service/AuthService.java
+++ b/popi-auth-service/src/main/java/com/lgcns/service/AuthService.java
@@ -1,0 +1,73 @@
+package com.lgcns.service;
+
+import com.lgcns.domain.Member;
+import com.lgcns.domain.OauthInfo;
+import com.lgcns.domain.OauthProvider;
+import com.lgcns.dto.request.AuthCodeRequest;
+import com.lgcns.dto.response.SocialLoginResponse;
+import com.lgcns.repository.MemberRepository;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+
+    private final KakaoService kakaoService;
+    private final GoogleService googleService;
+    private final JwtTokenService jwtTokenService;
+    private final IdTokenVerifier idTokenVerifier;
+    private final MemberRepository memberRepository;
+
+    public SocialLoginResponse socialLoginMember(AuthCodeRequest request, OauthProvider provider) {
+        String idToken = getIdToken(request.code(), provider);
+
+        OidcUser oidcUser = idTokenVerifier.getOidcUser(idToken, provider);
+
+        Optional<Member> optionalMember = findByOidcUser(oidcUser);
+        Member member = optionalMember.orElseGet(() -> saveMember(oidcUser, provider));
+
+        return getLoginResponse(member);
+    }
+
+    private SocialLoginResponse getLoginResponse(Member member) {
+        String accessToken = jwtTokenService.createAccessToken(member.getId(), member.getRole());
+        String refreshToken = jwtTokenService.createRefreshToken(member.getId());
+        return SocialLoginResponse.of(accessToken, refreshToken);
+    }
+
+    private String getIdToken(String code, OauthProvider provider) {
+        return switch (provider) {
+            case GOOGLE -> googleService.getIdToken(code);
+            case KAKAO -> kakaoService.getIdToken(code);
+        };
+    }
+
+    private Optional<Member> findByOidcUser(OidcUser oidcUser) {
+        OauthInfo oauthInfo = extractOauthInfo(oidcUser);
+        return memberRepository.findByOauthInfo(oauthInfo);
+    }
+
+    private Member saveMember(OidcUser oidcUser, OauthProvider provider) {
+        OauthInfo oauthInfo = extractOauthInfo(oidcUser);
+        String nickname = getDisplayName(oidcUser, provider);
+
+        Member member = Member.createMember(nickname, oauthInfo);
+        return memberRepository.save(member);
+    }
+
+    private OauthInfo extractOauthInfo(OidcUser oidcUser) {
+        return OauthInfo.createOauthInfo(oidcUser.getSubject(), oidcUser.getIssuer().toString());
+    }
+
+    private String getDisplayName(OidcUser oidcUser, OauthProvider provider) {
+        return switch (provider) {
+            case GOOGLE -> (String) oidcUser.getClaims().get("name");
+            case KAKAO -> (String) oidcUser.getClaims().get("nickname");
+        };
+    }
+}

--- a/popi-auth-service/src/main/java/com/lgcns/service/GoogleService.java
+++ b/popi-auth-service/src/main/java/com/lgcns/service/GoogleService.java
@@ -1,0 +1,38 @@
+package com.lgcns.service;
+
+import com.lgcns.client.GoogleOauthClient;
+import com.lgcns.dto.response.IdTokenResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class GoogleService {
+
+    private final GoogleOauthClient googleOauthClient;
+
+    @Value("${oauth.google.client-id}")
+    private String googleClientId;
+
+    @Value("${oauth.google.client-secret}")
+    private String googleClientSecret;
+
+    @Value("${oauth.google.redirect-uri}")
+    private String googleRedirectUri;
+
+    @Value("${oauth.google.grant-type}")
+    private String googleGrantType;
+
+    public String getIdToken(String code) {
+        IdTokenResponse response =
+                googleOauthClient.getIdToken(
+                        googleGrantType,
+                        googleClientId,
+                        googleRedirectUri,
+                        code,
+                        googleClientSecret);
+
+        return response.id_token();
+    }
+}

--- a/popi-auth-service/src/main/java/com/lgcns/service/IdTokenVerifier.java
+++ b/popi-auth-service/src/main/java/com/lgcns/service/IdTokenVerifier.java
@@ -1,0 +1,80 @@
+package com.lgcns.service;
+
+import com.lgcns.domain.OauthProvider;
+import com.lgcns.error.exception.CustomException;
+import com.lgcns.exception.AuthErrorCode;
+import java.time.Instant;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.oauth2.core.oidc.OidcIdToken;
+import org.springframework.security.oauth2.core.oidc.user.DefaultOidcUser;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class IdTokenVerifier {
+
+    @Value("${oauth.google.client-id}")
+    private String googleClientId;
+
+    @Value("${oauth.kakao.client-id}")
+    private String kakaoClientId;
+
+    private final Map<OauthProvider, JwtDecoder> decoders =
+            Map.of(
+                    OauthProvider.GOOGLE, buildDecoder(OauthProvider.GOOGLE.getJwkSetUrl()),
+                    OauthProvider.KAKAO, buildDecoder(OauthProvider.KAKAO.getJwkSetUrl()));
+
+    private JwtDecoder buildDecoder(String jwkSetUrl) {
+        return NimbusJwtDecoder.withJwkSetUri(jwkSetUrl).build();
+    }
+
+    public OidcUser getOidcUser(String idToken, OauthProvider provider) {
+        Jwt jwt = getJwt(idToken, provider);
+        OidcIdToken oidcIdToken = getOidcIdToken(jwt);
+
+        validateAudience(oidcIdToken, provider.getClientId(googleClientId, kakaoClientId));
+        validateIssuer(oidcIdToken, provider.getIssuer());
+        validateExpiresAt(oidcIdToken);
+
+        return new DefaultOidcUser(null, oidcIdToken);
+    }
+
+    private Jwt getJwt(String idToken, OauthProvider provider) {
+        return decoders.get(provider).decode(idToken);
+    }
+
+    private OidcIdToken getOidcIdToken(Jwt jwt) {
+        return new OidcIdToken(
+                jwt.getTokenValue(), jwt.getIssuedAt(), jwt.getExpiresAt(), jwt.getClaims());
+    }
+
+    private void validateAudience(OidcIdToken oidcIdToken, String clientId) {
+        String idTokenAudience = oidcIdToken.getAudience().get(0);
+
+        if (idTokenAudience == null || !idTokenAudience.equals(clientId)) {
+            throw new CustomException(AuthErrorCode.ID_TOKEN_VERIFICATION_FAILED);
+        }
+    }
+
+    private void validateIssuer(OidcIdToken oidcIdToken, String issuer) {
+        String idTokenIssuer = oidcIdToken.getIssuer().toString();
+
+        if (idTokenIssuer == null || !idTokenIssuer.equals(issuer)) {
+            throw new CustomException(AuthErrorCode.ID_TOKEN_VERIFICATION_FAILED);
+        }
+    }
+
+    private void validateExpiresAt(OidcIdToken oidcIdToken) {
+        Instant expiresAt = oidcIdToken.getExpiresAt();
+
+        if (expiresAt == null || expiresAt.isBefore(Instant.now())) {
+            throw new CustomException(AuthErrorCode.ID_TOKEN_VERIFICATION_FAILED);
+        }
+    }
+}

--- a/popi-auth-service/src/main/java/com/lgcns/service/JwtTokenService.java
+++ b/popi-auth-service/src/main/java/com/lgcns/service/JwtTokenService.java
@@ -1,0 +1,33 @@
+package com.lgcns.service;
+
+import com.lgcns.domain.MemberRole;
+import com.lgcns.domain.RefreshToken;
+import com.lgcns.repository.RefreshTokenRepository;
+import com.lgcns.util.JwtUtil;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class JwtTokenService {
+
+    private final JwtUtil jwtUtil;
+    private final RefreshTokenRepository refreshTokenRepository;
+
+    public String createAccessToken(Long memberId, MemberRole memberRole) {
+        return jwtUtil.generateAccessToken(memberId, memberRole);
+    }
+
+    public String createRefreshToken(Long memberId) {
+        String token = jwtUtil.generateRefreshToken(memberId);
+        RefreshToken refreshToken =
+                RefreshToken.builder()
+                        .memberId(memberId)
+                        .token(token)
+                        .ttl(jwtUtil.getRefreshTokenExpirationTime())
+                        .build();
+        refreshTokenRepository.save(refreshToken);
+
+        return token;
+    }
+}

--- a/popi-auth-service/src/main/java/com/lgcns/service/KakaoService.java
+++ b/popi-auth-service/src/main/java/com/lgcns/service/KakaoService.java
@@ -1,0 +1,34 @@
+package com.lgcns.service;
+
+import com.lgcns.client.KakaoOauthClient;
+import com.lgcns.dto.response.IdTokenResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class KakaoService {
+
+    private final KakaoOauthClient kakaoOauthClient;
+
+    @Value("${oauth.kakao.client-id}")
+    private String kakaoClientId;
+
+    @Value("${oauth.kakao.client-secret}")
+    private String kakaoClientSecret;
+
+    @Value("${oauth.kakao.redirect-uri}")
+    private String kakaoRedirectUri;
+
+    @Value("${oauth.kakao.grant-type}")
+    private String kakaoGrantType;
+
+    public String getIdToken(String code) {
+        IdTokenResponse response =
+                kakaoOauthClient.getIdToken(
+                        kakaoGrantType, kakaoClientId, kakaoRedirectUri, code, kakaoClientSecret);
+
+        return response.id_token();
+    }
+}

--- a/popi-auth-service/src/main/java/com/lgcns/util/JwtUtil.java
+++ b/popi-auth-service/src/main/java/com/lgcns/util/JwtUtil.java
@@ -1,0 +1,86 @@
+package com.lgcns.util;
+
+import static com.lgcns.constants.SecurityConstants.TOKEN_ROLE_NAME;
+
+import com.lgcns.domain.MemberRole;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import java.security.Key;
+import java.util.Date;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class JwtUtil {
+
+    @Value("${jwt.access-token-secret}")
+    private String accessTokenSecret;
+
+    @Value("${jwt.refresh-token-secret}")
+    private String refreshTokenSecret;
+
+    @Value("${jwt.access-token-expiration-time}")
+    private Long accessTokenExpirationTime;
+
+    @Value("${jwt.refresh-token-expiration-time}")
+    private Long refreshTokenExpirationTime;
+
+    @Value("${jwt.issuer}")
+    private String issuer;
+
+    private Long accessTokenExpirationMilliTime() {
+        return accessTokenExpirationTime * 1000;
+    }
+
+    private Long refreshTokenExpirationMilliTime() {
+        return refreshTokenExpirationTime * 1000;
+    }
+
+    public String generateAccessToken(Long memberId, MemberRole memberRole) {
+        Date issuedAt = new Date();
+        Date expiredAt = new Date(issuedAt.getTime() + accessTokenExpirationMilliTime());
+        return buildAccessToken(memberId, memberRole, issuedAt, expiredAt);
+    }
+
+    public String generateRefreshToken(Long memberId) {
+        Date issuedAt = new Date();
+        Date expiredAt = new Date(issuedAt.getTime() + refreshTokenExpirationMilliTime());
+        return buildRefreshToken(memberId, issuedAt, expiredAt);
+    }
+
+    public long getRefreshTokenExpirationTime() {
+        return refreshTokenExpirationTime;
+    }
+
+    private Key getAccessTokenKey() {
+        return Keys.hmacShaKeyFor(accessTokenSecret.getBytes());
+    }
+
+    private Key getRefreshTokenKey() {
+        return Keys.hmacShaKeyFor(refreshTokenSecret.getBytes());
+    }
+
+    private String buildAccessToken(
+            Long memberId, MemberRole memberRole, Date issuedAt, Date expiredAt) {
+        return Jwts.builder()
+                .setIssuer(issuer)
+                .setSubject(memberId.toString())
+                .claim(TOKEN_ROLE_NAME, memberRole.name())
+                .setIssuedAt(issuedAt)
+                .setExpiration(expiredAt)
+                .signWith(getAccessTokenKey())
+                .compact();
+    }
+
+    private String buildRefreshToken(Long memberId, Date issuedAt, Date expiredAt) {
+        return Jwts.builder()
+                .setIssuer(issuer)
+                .setSubject(memberId.toString())
+                .setIssuedAt(issuedAt)
+                .setExpiration(expiredAt)
+                .signWith(getRefreshTokenKey())
+                .compact();
+    }
+}

--- a/popi-common/build.gradle
+++ b/popi-common/build.gradle
@@ -16,4 +16,10 @@ dependencies {
 
     // Validation
     api 'org.springframework.boot:spring-boot-starter-validation'
+
+    // Actuator
+    api 'org.springframework.boot:spring-boot-starter-actuator'
+
+    // RabbitMQ
+    api 'org.springframework.boot:spring-boot-starter-amqp'
 }

--- a/popi-common/build.gradle
+++ b/popi-common/build.gradle
@@ -13,4 +13,7 @@ dependencies {
 
     //QueryDSL
     api 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+
+    // Validation
+    api 'org.springframework.boot:spring-boot-starter-validation'
 }


### PR DESCRIPTION
## 🌱 관련 이슈

- [LCR-42]

---
## 📌 작업 내용 및 특이사항

- OIDC 인증을 통한 소셜 로그인을 구현하였습니다. (구글, 카카오)
  - 구글, 카카오 인증서버로부터 ID토큰을 발급받기 위해 OpenFeign을 사용하였습니다.
  - 발급받은 ID 토큰을 검증하는 로직을 추가하였습니다.
  - 소셜 로그인 성공 시 백엔드 서버에서 액세스 토큰과 리프레시 토큰을 바디에 담아 응답합니다.
- Redis를 사용하여 리프레시 토큰에 TTL을 적용하였습니다.
- 인증 서비스에 Swagger를 적용하였습니다.
- DB를 H2에서 Mysql로 변경하였습니다.

---
## 📚 참고사항

- JWT 인증 필터는 백로그 하나 파서 API Gateway에서 처리하도록 하겠습니다!


[LCR-42]: https://lgcns-retail.atlassian.net/browse/LCR-42?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ