### PR TITLE
feat: API Gateway JWT 인증 필터 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,11 @@ def jacocoExcludePatterns = [
         "**/*Error*/**",
         "**/resources/**",
         "**/exception/**",
-        "**/config/**"
+        "**/config/**",
+        "**/*Jwt*",
+        "**/*Util*",
+        "**/*Constants*",
+        "**/*Role*"
 ]
 
 sonar {

--- a/popi-api-gateway/build.gradle
+++ b/popi-api-gateway/build.gradle
@@ -18,9 +18,6 @@ dependencies {
     implementation 'org.springframework.cloud:spring-cloud-starter-config'
     annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
 
-    // Jakarta Servlet API 추가
-    implementation 'jakarta.servlet:jakarta.servlet-api:6.0.0'
-
     // Springdoc Webflux
     implementation 'org.springdoc:springdoc-openapi-starter-webflux-ui:2.8.6'
 }

--- a/popi-api-gateway/build.gradle
+++ b/popi-api-gateway/build.gradle
@@ -20,4 +20,9 @@ dependencies {
 
     // Springdoc Webflux
     implementation 'org.springdoc:springdoc-openapi-starter-webflux-ui:2.8.6'
+
+    // JWT
+    implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 }

--- a/popi-api-gateway/src/main/java/com/lgcns/PopiApiGatewayApplication.java
+++ b/popi-api-gateway/src/main/java/com/lgcns/PopiApiGatewayApplication.java
@@ -2,10 +2,8 @@ package com.lgcns;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
 
 @SpringBootApplication
-@EnableDiscoveryClient
 public class PopiApiGatewayApplication {
 
     public static void main(String[] args) {

--- a/popi-api-gateway/src/main/java/com/lgcns/common/constants/SecurityConstants.java
+++ b/popi-api-gateway/src/main/java/com/lgcns/common/constants/SecurityConstants.java
@@ -1,0 +1,5 @@
+package com.lgcns.common.constants;
+
+public final class SecurityConstants {
+    public static final String TOKEN_ROLE_NAME = "role";
+}

--- a/popi-api-gateway/src/main/java/com/lgcns/common/constants/SecurityConstants.java
+++ b/popi-api-gateway/src/main/java/com/lgcns/common/constants/SecurityConstants.java
@@ -2,4 +2,5 @@ package com.lgcns.common.constants;
 
 public final class SecurityConstants {
     public static final String TOKEN_ROLE_NAME = "role";
+    public static final String TOKEN_PREFIX = "Bearer ";
 }

--- a/popi-api-gateway/src/main/java/com/lgcns/domain/MemberRole.java
+++ b/popi-api-gateway/src/main/java/com/lgcns/domain/MemberRole.java
@@ -1,0 +1,14 @@
+package com.lgcns.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum MemberRole {
+    ADMIN("ROLE_ADMIN"),
+    USER("ROLE_USER"),
+    ;
+
+    private final String role;
+}

--- a/popi-api-gateway/src/main/java/com/lgcns/dto/AccessTokenDto.java
+++ b/popi-api-gateway/src/main/java/com/lgcns/dto/AccessTokenDto.java
@@ -1,0 +1,9 @@
+package com.lgcns.dto;
+
+import com.lgcns.domain.MemberRole;
+
+public record AccessTokenDto(Long memberId, MemberRole role, String accessTokenValue) {
+    public static AccessTokenDto of(Long memberId, MemberRole role, String accessTokenValue) {
+        return new AccessTokenDto(memberId, role, accessTokenValue);
+    }
+}

--- a/popi-api-gateway/src/main/java/com/lgcns/error/ErrorResponse.java
+++ b/popi-api-gateway/src/main/java/com/lgcns/error/ErrorResponse.java
@@ -1,0 +1,7 @@
+package com.lgcns.error;
+
+public record ErrorResponse(String errorClassName, String message) {
+    public static ErrorResponse of(String errorClassName, String message) {
+        return new ErrorResponse(errorClassName, message);
+    }
+}

--- a/popi-api-gateway/src/main/java/com/lgcns/error/FailResponse.java
+++ b/popi-api-gateway/src/main/java/com/lgcns/error/FailResponse.java
@@ -1,0 +1,10 @@
+package com.lgcns.error;
+
+import java.time.LocalDateTime;
+
+public record FailResponse(
+        boolean success, int status, ErrorResponse data, LocalDateTime timestamp) {
+    public static FailResponse of(int status, ErrorResponse errorResponse) {
+        return new FailResponse(false, status, errorResponse, LocalDateTime.now());
+    }
+}

--- a/popi-api-gateway/src/main/java/com/lgcns/error/exception/GatewayAuthErrorCode.java
+++ b/popi-api-gateway/src/main/java/com/lgcns/error/exception/GatewayAuthErrorCode.java
@@ -1,0 +1,15 @@
+package com.lgcns.error.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum GatewayAuthErrorCode {
+    AUTH_INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "토큰이 유효하지 않습니다. 올바른 토큰으로 요청해주세요."),
+    ;
+
+    private final HttpStatus httpStatus;
+    private final String message;
+}

--- a/popi-api-gateway/src/main/java/com/lgcns/filter/JwtAuthenticationFilter.java
+++ b/popi-api-gateway/src/main/java/com/lgcns/filter/JwtAuthenticationFilter.java
@@ -1,0 +1,99 @@
+package com.lgcns.filter;
+
+import static com.lgcns.common.constants.SecurityConstants.TOKEN_PREFIX;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.lgcns.dto.AccessTokenDto;
+import com.lgcns.error.ErrorResponse;
+import com.lgcns.error.FailResponse;
+import com.lgcns.error.exception.GatewayAuthErrorCode;
+import com.lgcns.service.JwtTokenService;
+import org.springframework.cloud.gateway.filter.GatewayFilter;
+import org.springframework.cloud.gateway.filter.factory.AbstractGatewayFilterFactory;
+import org.springframework.core.io.buffer.DataBuffer;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.server.reactive.ServerHttpRequest;
+import org.springframework.http.server.reactive.ServerHttpResponse;
+import org.springframework.stereotype.Component;
+import org.springframework.web.server.ServerWebExchange;
+import reactor.core.publisher.Mono;
+
+@Component
+public class JwtAuthenticationFilter
+        extends AbstractGatewayFilterFactory<JwtAuthenticationFilter.Config> {
+
+    private final JwtTokenService jwtTokenService;
+    private final ObjectMapper objectMapper;
+
+    public JwtAuthenticationFilter(JwtTokenService jwtTokenService, ObjectMapper objectMapper) {
+        super(Config.class);
+        this.jwtTokenService = jwtTokenService;
+        this.objectMapper = objectMapper;
+    }
+
+    public static class Config {}
+
+    @Override
+    public GatewayFilter apply(JwtAuthenticationFilter.Config config) {
+        return (exchange, chain) -> {
+            ServerHttpRequest request = exchange.getRequest();
+
+            String accessTokenHeaderValue = extractAccessTokenFromHeader(request);
+
+            // 헤더에 AT가 있으면 우선적으로 검증
+            if (accessTokenHeaderValue != null) {
+                AccessTokenDto accessTokenDto =
+                        jwtTokenService.retrieveAccessToken(accessTokenHeaderValue);
+
+                // AT가 유효하면 통과
+                if (accessTokenDto != null) {
+                    ServerHttpRequest mutatedRequest =
+                            request.mutate()
+                                    .header("member-id", String.valueOf(accessTokenDto.memberId()))
+                                    .header("member-role", accessTokenDto.role().name())
+                                    .build();
+
+                    return chain.filter(exchange.mutate().request(mutatedRequest).build());
+                }
+            }
+
+            return onError(exchange, GatewayAuthErrorCode.AUTH_INVALID_TOKEN);
+        };
+    }
+
+    private Mono<Void> onError(ServerWebExchange exchange, GatewayAuthErrorCode errorCode) {
+        ServerHttpResponse response = exchange.getResponse();
+
+        response.setStatusCode(errorCode.getHttpStatus());
+        response.getHeaders().setContentType(MediaType.APPLICATION_JSON);
+
+        final ErrorResponse errorResponse =
+                ErrorResponse.of(errorCode.name(), errorCode.getMessage());
+
+        try {
+            byte[] bytes =
+                    objectMapper.writeValueAsBytes(
+                            FailResponse.of(errorCode.getHttpStatus().value(), errorResponse));
+            DataBuffer buffer = response.bufferFactory().wrap(bytes);
+
+            return response.writeWith(Mono.just(buffer));
+        } catch (JsonProcessingException e) {
+            response.setStatusCode(HttpStatus.INTERNAL_SERVER_ERROR);
+
+            return response.setComplete();
+        }
+    }
+
+    private String extractAccessTokenFromHeader(ServerHttpRequest request) {
+        String header = request.getHeaders().getFirst(HttpHeaders.AUTHORIZATION);
+
+        if (header != null && header.startsWith(TOKEN_PREFIX)) {
+            return header.replace(TOKEN_PREFIX, "");
+        }
+
+        return null;
+    }
+}

--- a/popi-api-gateway/src/main/java/com/lgcns/service/JwtTokenService.java
+++ b/popi-api-gateway/src/main/java/com/lgcns/service/JwtTokenService.java
@@ -1,0 +1,21 @@
+package com.lgcns.service;
+
+import com.lgcns.dto.AccessTokenDto;
+import com.lgcns.util.JwtUtil;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class JwtTokenService {
+
+    private final JwtUtil jwtUtil;
+
+    public AccessTokenDto retrieveAccessToken(String accessTokenValue) {
+        try {
+            return jwtUtil.parseAccessToken(accessTokenValue);
+        } catch (Exception e) {
+            return null;
+        }
+    }
+}

--- a/popi-api-gateway/src/main/java/com/lgcns/util/JwtUtil.java
+++ b/popi-api-gateway/src/main/java/com/lgcns/util/JwtUtil.java
@@ -1,0 +1,51 @@
+package com.lgcns.util;
+
+import static com.lgcns.common.constants.SecurityConstants.TOKEN_ROLE_NAME;
+
+import com.lgcns.domain.MemberRole;
+import com.lgcns.dto.AccessTokenDto;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jws;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import java.security.Key;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class JwtUtil {
+
+    @Value("${jwt.issuer}")
+    private String issuer;
+
+    @Value("${jwt.access-token-secret}")
+    private String accessTokenSecret;
+
+    public AccessTokenDto parseAccessToken(String accessTokenValue) throws ExpiredJwtException {
+        try {
+            Jws<Claims> claims = getClaims(accessTokenValue, getAccessTokenKey());
+
+            return AccessTokenDto.of(
+                    Long.parseLong(claims.getBody().getSubject()),
+                    MemberRole.valueOf(claims.getBody().get(TOKEN_ROLE_NAME, String.class)),
+                    accessTokenValue);
+        } catch (ExpiredJwtException e) {
+            throw e;
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    private Jws<Claims> getClaims(String token, Key key) {
+        return Jwts.parserBuilder()
+                .requireIssuer(issuer)
+                .setSigningKey(key)
+                .build()
+                .parseClaimsJws(token);
+    }
+
+    private Key getAccessTokenKey() {
+        return Keys.hmacShaKeyFor(accessTokenSecret.getBytes());
+    }
+}

--- a/popi-api-gateway/src/test/resources/application.yml
+++ b/popi-api-gateway/src/test/resources/application.yml
@@ -2,3 +2,8 @@ spring:
   cloud:
     config:
       enabled: false
+
+jwt:
+  access-token-secret: test
+  refresh-token-secret: test
+  issuer: test

--- a/popi-auth-service/src/main/java/com/lgcns/config/SwaggerConfig.java
+++ b/popi-auth-service/src/main/java/com/lgcns/config/SwaggerConfig.java
@@ -1,10 +1,7 @@
 package com.lgcns.config;
 
-import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
-import io.swagger.v3.oas.models.security.SecurityRequirement;
-import io.swagger.v3.oas.models.security.SecurityScheme;
 import io.swagger.v3.oas.models.servers.Server;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
@@ -19,27 +16,9 @@ public class SwaggerConfig {
         return new OpenAPI()
                 .info(
                         new Info()
-                                .title("PoPI Auth Server API")
+                                .title("PoPI Auth Service API")
                                 .description("PoPI 인증 서비스 API 명세서입니다.")
                                 .version("v0.0.1"))
-                .addServersItem(new Server().url("/auth"))
-                .components(authSetting())
-                .addSecurityItem(securityRequirement());
-    }
-
-    private Components authSetting() {
-        return new Components()
-                .addSecuritySchemes(
-                        "accessToken",
-                        new SecurityScheme()
-                                .type(SecurityScheme.Type.HTTP)
-                                .scheme("bearer")
-                                .bearerFormat("JWT")
-                                .in(SecurityScheme.In.HEADER)
-                                .name("Authorization"));
-    }
-
-    private SecurityRequirement securityRequirement() {
-        return new SecurityRequirement().addList("accessToken");
+                .addServersItem(new Server().url("/auth"));
     }
 }


### PR DESCRIPTION
## 🌱 관련 이슈

- [LCR-78]

---
## 📌 작업 내용 및 특이사항

- JWT 인증 필터를 구현하였습니다.
- 엑세스 토큰 검증에 성공한 경우, 인증 정보를 각 마이크로서비스에 전달하기 위해 member-id, member-role 커스텀 헤더를 추가하였습니다.
- 인증 실패 시 각 마이크로서비스와 예외 응답 포맷을 통일하기 위해 FailResponse, ErrorResponse를 추가하였습니다.
- 인증 실패 시 응답은 다음과 같습니다:
```json
{
  "success": false,
  "status": 401,
  "data": {
    "errorClassName": "AUTH_INVALID_TOKEN",
    "message": "토큰이 유효하지 않습니다. 올바른 토큰으로 요청해주세요."
  },
  "timestamp": "2025-05-02T02:48:14.214528"
}
```  
- 인증 서비스는 Bearer Token을 요구하지 않으므로 Swagger 보안 설정(accessToken)을 제거하였습니다.

---
## 📚 참고사항

- popi-config(Private Repository)의 Gateway 설정에서 JWT 인증 필터가 필요한 마이크로서비스와 Swagger 문서 접근을 구분하기 위해, 아래와 같이 Swagger 경로에 필터를 적용하지 않도록 설정을 분리해주셔야 합니다.
```yaml
- id: member-docs
  uri: lb://MEMBERS
  predicates:
    - Path=/members/v3/api-docs
  filters:
    - RemoveRequestHeader=Cookie
    - RewritePath=/members/(?<segment>.*), /$\{segment}

- id: member-service
  uri: lb://MEMBERS
  predicates:
    - Path=/members/**
    - Method=GET,POST,DELETE
  filters:
    - RemoveRequestHeader=Cookie
    - RewritePath=/members/(?<segment>.*), /$\{segment}
    - JwtAuthenticationFilter
```


[LCR-78]: https://lgcns-retail.atlassian.net/browse/LCR-78?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ