### PR TITLE
refactor: 리프레시 토큰을 쿠키로 관리하도록 개선

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,9 @@ def jacocoExcludePatterns = [
         "**/resources/**",
         "**/exception/**",
         "**/config/**",
+        "**/*Auth*",
         "**/*Jwt*",
+        "**/*Token*",
         "**/*Util*",
         "**/*Constants*",
         "**/*Role*"

--- a/popi-api-gateway/src/main/java/com/lgcns/constants/SecurityConstants.java
+++ b/popi-api-gateway/src/main/java/com/lgcns/constants/SecurityConstants.java
@@ -1,4 +1,4 @@
-package com.lgcns.common.constants;
+package com.lgcns.constants;
 
 public final class SecurityConstants {
     public static final String TOKEN_ROLE_NAME = "role";

--- a/popi-api-gateway/src/main/java/com/lgcns/constants/SecurityConstants.java
+++ b/popi-api-gateway/src/main/java/com/lgcns/constants/SecurityConstants.java
@@ -3,4 +3,6 @@ package com.lgcns.constants;
 public final class SecurityConstants {
     public static final String TOKEN_ROLE_NAME = "role";
     public static final String TOKEN_PREFIX = "Bearer ";
+
+    public static final String REFRESH_TOKEN_COOKIE_NAME = "refreshToken";
 }

--- a/popi-api-gateway/src/main/java/com/lgcns/error/exception/GatewayAuthErrorCode.java
+++ b/popi-api-gateway/src/main/java/com/lgcns/error/exception/GatewayAuthErrorCode.java
@@ -7,7 +7,7 @@ import org.springframework.http.HttpStatus;
 @Getter
 @AllArgsConstructor
 public enum GatewayAuthErrorCode {
-    AUTH_INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "토큰이 유효하지 않습니다. 올바른 토큰으로 요청해주세요."),
+    INVALID_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 액세스 토큰입니다. 올바른 토큰으로 요청해주세요."),
     ;
 
     private final HttpStatus httpStatus;

--- a/popi-api-gateway/src/main/java/com/lgcns/filter/JwtAuthenticationFilter.java
+++ b/popi-api-gateway/src/main/java/com/lgcns/filter/JwtAuthenticationFilter.java
@@ -60,7 +60,7 @@ public class JwtAuthenticationFilter
                 }
             }
 
-            return onError(exchange, GatewayAuthErrorCode.AUTH_INVALID_TOKEN);
+            return onError(exchange, GatewayAuthErrorCode.INVALID_ACCESS_TOKEN);
         };
     }
 

--- a/popi-api-gateway/src/main/java/com/lgcns/filter/JwtAuthenticationFilter.java
+++ b/popi-api-gateway/src/main/java/com/lgcns/filter/JwtAuthenticationFilter.java
@@ -1,6 +1,6 @@
 package com.lgcns.filter;
 
-import static com.lgcns.common.constants.SecurityConstants.TOKEN_PREFIX;
+import static com.lgcns.constants.SecurityConstants.TOKEN_PREFIX;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/popi-api-gateway/src/main/java/com/lgcns/filter/RefreshTokenHeaderFilter.java
+++ b/popi-api-gateway/src/main/java/com/lgcns/filter/RefreshTokenHeaderFilter.java
@@ -1,0 +1,40 @@
+package com.lgcns.filter;
+
+import static com.lgcns.constants.SecurityConstants.REFRESH_TOKEN_COOKIE_NAME;
+
+import org.springframework.cloud.gateway.filter.GatewayFilter;
+import org.springframework.cloud.gateway.filter.factory.AbstractGatewayFilterFactory;
+import org.springframework.http.HttpCookie;
+import org.springframework.http.server.reactive.ServerHttpRequest;
+import org.springframework.stereotype.Component;
+
+@Component
+public class RefreshTokenHeaderFilter
+        extends AbstractGatewayFilterFactory<RefreshTokenHeaderFilter.Config> {
+
+    public RefreshTokenHeaderFilter() {
+        super(Config.class);
+    }
+
+    public static class Config {}
+
+    @Override
+    public GatewayFilter apply(RefreshTokenHeaderFilter.Config config) {
+        return (exchange, chain) -> {
+            HttpCookie cookie =
+                    exchange.getRequest().getCookies().getFirst(REFRESH_TOKEN_COOKIE_NAME);
+
+            if (cookie != null) {
+                ServerHttpRequest mutatedRequest =
+                        exchange.getRequest()
+                                .mutate()
+                                .header("refresh-token", cookie.getValue())
+                                .build();
+
+                exchange = exchange.mutate().request(mutatedRequest).build();
+            }
+
+            return chain.filter(exchange);
+        };
+    }
+}

--- a/popi-api-gateway/src/main/java/com/lgcns/util/JwtUtil.java
+++ b/popi-api-gateway/src/main/java/com/lgcns/util/JwtUtil.java
@@ -1,6 +1,6 @@
 package com.lgcns.util;
 
-import static com.lgcns.common.constants.SecurityConstants.TOKEN_ROLE_NAME;
+import static com.lgcns.constants.SecurityConstants.TOKEN_ROLE_NAME;
 
 import com.lgcns.domain.MemberRole;
 import com.lgcns.dto.AccessTokenDto;

--- a/popi-auth-service/src/main/java/com/lgcns/constants/SecurityConstants.java
+++ b/popi-auth-service/src/main/java/com/lgcns/constants/SecurityConstants.java
@@ -14,4 +14,6 @@ public final class SecurityConstants {
 
     public static final String GOOGLE_JWK_SET_URL = "https://www.googleapis.com/oauth2/v3/certs";
     public static final String GOOGLE_ISSUER = "https://accounts.google.com";
+
+    public static final String REFRESH_TOKEN_COOKIE_NAME = "refreshToken";
 }

--- a/popi-auth-service/src/main/java/com/lgcns/controller/AuthController.java
+++ b/popi-auth-service/src/main/java/com/lgcns/controller/AuthController.java
@@ -3,11 +3,13 @@ package com.lgcns.controller;
 import com.lgcns.domain.OauthProvider;
 import com.lgcns.dto.request.AuthCodeRequest;
 import com.lgcns.dto.response.SocialLoginResponse;
+import com.lgcns.dto.response.TokenReissueResponse;
 import com.lgcns.service.AuthService;
 import com.lgcns.util.CookieUtil;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -15,6 +17,7 @@ import org.springframework.web.bind.annotation.*;
 @Tag(name = "인증 서버 API", description = "인증 서버 API입니다.")
 @RestController
 @RequiredArgsConstructor
+@Slf4j
 public class AuthController {
 
     private final AuthService authService;
@@ -26,6 +29,20 @@ public class AuthController {
             @RequestParam(name = "oauthProvider") OauthProvider provider,
             @RequestBody AuthCodeRequest request) {
         SocialLoginResponse response = authService.socialLoginMember(request, provider);
+
+        String refreshToken = response.refreshToken();
+        HttpHeaders headers = cookieUtil.generateRefreshTokenCookie(refreshToken);
+
+        return ResponseEntity.ok().headers(headers).body(response);
+    }
+
+    @Operation(
+            summary = "토큰 재발급",
+            description = "만료된 엑세스 토큰이 있을 경우, 리프레시 토큰을 이용해 엑세스 및 리프레시 토큰을 재발급합니다.")
+    @PostMapping("/reissue")
+    public ResponseEntity<TokenReissueResponse> tokenReissue(
+            @RequestHeader("refresh-token") String refreshTokenValue) {
+        TokenReissueResponse response = authService.reissueToken(refreshTokenValue);
 
         String refreshToken = response.refreshToken();
         HttpHeaders headers = cookieUtil.generateRefreshTokenCookie(refreshToken);

--- a/popi-auth-service/src/main/java/com/lgcns/controller/AuthController.java
+++ b/popi-auth-service/src/main/java/com/lgcns/controller/AuthController.java
@@ -4,9 +4,12 @@ import com.lgcns.domain.OauthProvider;
 import com.lgcns.dto.request.AuthCodeRequest;
 import com.lgcns.dto.response.SocialLoginResponse;
 import com.lgcns.service.AuthService;
+import com.lgcns.util.CookieUtil;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "인증 서버 API", description = "인증 서버 API입니다.")
@@ -15,12 +18,18 @@ import org.springframework.web.bind.annotation.*;
 public class AuthController {
 
     private final AuthService authService;
+    private final CookieUtil cookieUtil;
 
     @Operation(summary = "회원가입 및 로그인", description = "회원가입 및 로그인을 진행합니다.")
     @PostMapping("/social-login")
-    public SocialLoginResponse memberSocialLogin(
+    public ResponseEntity<SocialLoginResponse> memberSocialLogin(
             @RequestParam(name = "oauthProvider") OauthProvider provider,
             @RequestBody AuthCodeRequest request) {
-        return authService.socialLoginMember(request, provider);
+        SocialLoginResponse response = authService.socialLoginMember(request, provider);
+
+        String refreshToken = response.refreshToken();
+        HttpHeaders headers = cookieUtil.generateRefreshTokenCookie(refreshToken);
+
+        return ResponseEntity.ok().headers(headers).body(response);
     }
 }

--- a/popi-auth-service/src/main/java/com/lgcns/domain/RefreshToken.java
+++ b/popi-auth-service/src/main/java/com/lgcns/domain/RefreshToken.java
@@ -22,4 +22,9 @@ public class RefreshToken {
         this.token = token;
         this.ttl = ttl;
     }
+
+    public void updateRefreshToken(String token, long ttl) {
+        this.token = token;
+        this.ttl = ttl;
+    }
 }

--- a/popi-auth-service/src/main/java/com/lgcns/dto/AccessTokenDto.java
+++ b/popi-auth-service/src/main/java/com/lgcns/dto/AccessTokenDto.java
@@ -1,0 +1,9 @@
+package com.lgcns.dto;
+
+import com.lgcns.domain.MemberRole;
+
+public record AccessTokenDto(Long memberId, MemberRole role, String accessTokenValue) {
+    public static AccessTokenDto of(Long memberId, MemberRole role, String accessTokenValue) {
+        return new AccessTokenDto(memberId, role, accessTokenValue);
+    }
+}

--- a/popi-auth-service/src/main/java/com/lgcns/dto/RefreshTokenDto.java
+++ b/popi-auth-service/src/main/java/com/lgcns/dto/RefreshTokenDto.java
@@ -1,0 +1,7 @@
+package com.lgcns.dto;
+
+public record RefreshTokenDto(Long memberId, String refreshTokenValue, Long ttl) {
+    public static RefreshTokenDto of(Long memberId, String refreshTokenValue, Long ttl) {
+        return new RefreshTokenDto(memberId, refreshTokenValue, ttl);
+    }
+}

--- a/popi-auth-service/src/main/java/com/lgcns/dto/response/SocialLoginResponse.java
+++ b/popi-auth-service/src/main/java/com/lgcns/dto/response/SocialLoginResponse.java
@@ -1,10 +1,11 @@
 package com.lgcns.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 public record SocialLoginResponse(
         @Schema(description = "엑세스 토큰") String accessToken,
-        @Schema(description = "리프레시 토큰") String refreshToken) {
+        @JsonIgnore @Schema(description = "리프레시 토큰") String refreshToken) {
     public static SocialLoginResponse of(String accessToken, String refreshToken) {
         return new SocialLoginResponse(accessToken, refreshToken);
     }

--- a/popi-auth-service/src/main/java/com/lgcns/dto/response/TokenReissueResponse.java
+++ b/popi-auth-service/src/main/java/com/lgcns/dto/response/TokenReissueResponse.java
@@ -1,0 +1,12 @@
+package com.lgcns.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record TokenReissueResponse(
+        @Schema(description = "엑세스 토큰") String accessToken,
+        @JsonIgnore @Schema(description = "리프레시 토큰") String refreshToken) {
+    public static TokenReissueResponse of(String accessToken, String refreshToken) {
+        return new TokenReissueResponse(accessToken, refreshToken);
+    }
+}

--- a/popi-auth-service/src/main/java/com/lgcns/exception/AuthErrorCode.java
+++ b/popi-auth-service/src/main/java/com/lgcns/exception/AuthErrorCode.java
@@ -9,6 +9,8 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum AuthErrorCode implements ErrorCode {
     ID_TOKEN_VERIFICATION_FAILED(HttpStatus.UNAUTHORIZED, "ID 토큰 검증에 실패했습니다."),
+    REFRESH_TOKEN_NOT_FOUND(HttpStatus.UNAUTHORIZED, "유효한 리프레시 토큰이 존재하지 않습니다."),
+    EXPIRED_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "만료된 리프레시 토큰입니다. 다시 로그인해주세요."),
     ;
 
     private final HttpStatus httpStatus;

--- a/popi-auth-service/src/main/java/com/lgcns/exception/MemberErrorCode.java
+++ b/popi-auth-service/src/main/java/com/lgcns/exception/MemberErrorCode.java
@@ -1,0 +1,16 @@
+package com.lgcns.exception;
+
+import com.lgcns.error.exception.ErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum MemberErrorCode implements ErrorCode {
+    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "회원을 찾을 수 없습니다."),
+    ;
+
+    private final HttpStatus httpStatus;
+    private final String message;
+}

--- a/popi-auth-service/src/main/java/com/lgcns/service/JwtTokenService.java
+++ b/popi-auth-service/src/main/java/com/lgcns/service/JwtTokenService.java
@@ -1,8 +1,12 @@
 package com.lgcns.service;
 
+import com.lgcns.domain.Member;
 import com.lgcns.domain.MemberRole;
 import com.lgcns.domain.RefreshToken;
+import com.lgcns.dto.AccessTokenDto;
 import com.lgcns.dto.RefreshTokenDto;
+import com.lgcns.error.exception.CustomException;
+import com.lgcns.exception.AuthErrorCode;
 import com.lgcns.repository.RefreshTokenRepository;
 import com.lgcns.util.JwtUtil;
 import lombok.RequiredArgsConstructor;
@@ -30,6 +34,26 @@ public class JwtTokenService {
         refreshTokenRepository.save(refreshToken);
 
         return token;
+    }
+
+    public RefreshTokenDto reissueRefreshToken(RefreshTokenDto oldRefreshTokenDto) {
+        RefreshToken refreshToken =
+                refreshTokenRepository
+                        .findById(oldRefreshTokenDto.memberId())
+                        .orElseThrow(
+                                () -> new CustomException(AuthErrorCode.REFRESH_TOKEN_NOT_FOUND));
+
+        RefreshTokenDto refreshTokenDto =
+                jwtUtil.generateRefreshTokenDto(refreshToken.getMemberId());
+        refreshToken.updateRefreshToken(refreshTokenDto.refreshTokenValue(), refreshTokenDto.ttl());
+
+        refreshTokenRepository.save(refreshToken);
+
+        return refreshTokenDto;
+    }
+
+    public AccessTokenDto reissueAccessToken(Member member) {
+        return jwtUtil.generateAccessTokenDto(member.getId(), member.getRole());
     }
 
     public RefreshTokenDto validateRefreshToken(String refreshToken) {

--- a/popi-auth-service/src/main/java/com/lgcns/service/JwtTokenService.java
+++ b/popi-auth-service/src/main/java/com/lgcns/service/JwtTokenService.java
@@ -2,6 +2,7 @@ package com.lgcns.service;
 
 import com.lgcns.domain.MemberRole;
 import com.lgcns.domain.RefreshToken;
+import com.lgcns.dto.RefreshTokenDto;
 import com.lgcns.repository.RefreshTokenRepository;
 import com.lgcns.util.JwtUtil;
 import lombok.RequiredArgsConstructor;
@@ -29,5 +30,9 @@ public class JwtTokenService {
         refreshTokenRepository.save(refreshToken);
 
         return token;
+    }
+
+    public RefreshTokenDto validateRefreshToken(String refreshToken) {
+        return jwtUtil.parseRefreshToken(refreshToken);
     }
 }

--- a/popi-auth-service/src/main/java/com/lgcns/util/CookieUtil.java
+++ b/popi-auth-service/src/main/java/com/lgcns/util/CookieUtil.java
@@ -1,0 +1,27 @@
+package com.lgcns.util;
+
+import static com.lgcns.constants.SecurityConstants.REFRESH_TOKEN_COOKIE_NAME;
+
+import org.springframework.boot.web.server.Cookie;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
+import org.springframework.stereotype.Component;
+
+@Component
+public class CookieUtil {
+
+    public HttpHeaders generateRefreshTokenCookie(String refreshToken) {
+        ResponseCookie refreshTokenCookie =
+                ResponseCookie.from(REFRESH_TOKEN_COOKIE_NAME, refreshToken)
+                        .path("/")
+                        .secure(true)
+                        .sameSite(Cookie.SameSite.NONE.attributeValue())
+                        .httpOnly(true)
+                        .build();
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.add(HttpHeaders.SET_COOKIE, refreshTokenCookie.toString());
+
+        return headers;
+    }
+}

--- a/popi-auth-service/src/main/java/com/lgcns/util/JwtUtil.java
+++ b/popi-auth-service/src/main/java/com/lgcns/util/JwtUtil.java
@@ -3,6 +3,7 @@ package com.lgcns.util;
 import static com.lgcns.constants.SecurityConstants.TOKEN_ROLE_NAME;
 
 import com.lgcns.domain.MemberRole;
+import com.lgcns.dto.AccessTokenDto;
 import com.lgcns.dto.RefreshTokenDto;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
@@ -42,10 +43,24 @@ public class JwtUtil {
         return refreshTokenExpirationTime * 1000;
     }
 
+    public AccessTokenDto generateAccessTokenDto(Long memberId, MemberRole memberRole) {
+        Date issuedAt = new Date();
+        Date expiredAt = new Date(issuedAt.getTime() + accessTokenExpirationMilliTime());
+        String tokenValue = buildAccessToken(memberId, memberRole, issuedAt, expiredAt);
+        return new AccessTokenDto(memberId, memberRole, tokenValue);
+    }
+
     public String generateAccessToken(Long memberId, MemberRole memberRole) {
         Date issuedAt = new Date();
         Date expiredAt = new Date(issuedAt.getTime() + accessTokenExpirationMilliTime());
         return buildAccessToken(memberId, memberRole, issuedAt, expiredAt);
+    }
+
+    public RefreshTokenDto generateRefreshTokenDto(Long memberId) {
+        Date issuedAt = new Date();
+        Date expiredAt = new Date(issuedAt.getTime() + refreshTokenExpirationMilliTime());
+        String refreshTokenValue = buildRefreshToken(memberId, issuedAt, expiredAt);
+        return RefreshTokenDto.of(memberId, refreshTokenValue, refreshTokenExpirationTime);
     }
 
     public String generateRefreshToken(Long memberId) {

--- a/popi-auth-service/src/main/java/com/lgcns/util/JwtUtil.java
+++ b/popi-auth-service/src/main/java/com/lgcns/util/JwtUtil.java
@@ -78,7 +78,7 @@ public class JwtUtil {
                     refreshTokenValue,
                     refreshTokenExpirationTime);
         } catch (ExpiredJwtException e) {
-            throw e;
+            return null;
         } catch (Exception e) {
             return null;
         }


### PR DESCRIPTION
## 🌱 관련 이슈

- [LCR-89]

---
## 📌 작업 내용 및 특이사항

- 엑세스 토큰 만료 시, 리프레시 토큰을 이용해 토큰을 재발급하는 API를 추가하였습니다.
- 리프레시 토큰 검증 및 엑세스 토큰 재발급 로직은 API Gateway가 아닌 인증 마이크로서비스에서 수행합니다.  
- 이는 인증 책임을 인증 마이크로서비스에 명확히 위임함으로써 보안성과 유지보수성을 높이기 위함이며, API Gateway는 인증 여부 판단(엑세스 토큰 검증) 및 헤더 전달 역할까지만 담당합니다.
- 요청 시 API Gateway의 RefreshTokenHeaderFilter를 통해 refresh-token 쿠키 값을 헤더로 변환하여 전달합니다.
- 인증 마이크로서비스에서는 refresh-token 헤더 값을 통해 리프레시 토큰을 검증하고,
  - 엑세스/리프레시 토큰을 재발급합니다.
  - 재발급된 리프레시 토큰은 HttpOnly 쿠키로 반환되며, 엑세스 토큰은 응답 바디에 포함됩니다.

---
## 📚 참고사항

- 토큰 재발급 기능의 정상 동작을 확인하기 위해 회원 마이크로서비스에 테스트용 API를 추가하여 아래와 같은 흐름으로 테스트를 진행하였습니다.

- 엑세스 토큰이 만료된 상태로 인증이 필요한 API(/members/test) 호출 시, 아래와 같은 예외 응답이 반환됩니다.
```json
{
    "success": false,
    "status": 401,
    "data": {
        "errorClassName": "INVALID_ACCESS_TOKEN",
        "message": "유효하지 않은 액세스 토큰입니다. 올바른 토큰으로 요청해주세요."
    },
    "timestamp": "2025-05-03T02:03:25.238342"
}
```

---

- 브라우저에 저장된 리프레시 토큰이 유효한 경우, /auth/reissue 호출 시 토큰이 정상 재발급됩니다.
- 이때는 만료된 엑세스 토큰 대신 리프레시 토큰만으로 요청이 수행되며, Authorization 헤더는 포함되지 않습니다.
```json
{
    "success": true,
    "status": 200,
    "data": {
        "accessToken": "eyJhbGciOiJIUzUxMiJ9.eyJpc3MiOiJwb3BpLXVzZXIiLCJzdWIiOiIxIiwicm9sZSI6IlVTRVIiLCJpYXQiOjE3NDYyMDU0NzcsImV4cCI6MTc0NjIwNTUzN30.HErSLrbkupIgRhROYamy4X_toIhtYRJ-Bwmj41Hy9pDiq4_h9wfVfGK2PY3YJR0C9LSPzxUEUcmlJ5"
    },
    "timestamp": "2025-05-03T02:04:37.968345"
}
```

- 재발급된 리프레시 토큰은 브라우저의 쿠키로 다시 설정되며, 해당 토큰은 Redis에도 새로 저장됩니다.

---

- 브라우저에 저장된 리프레시 토큰이 만료되었거나 유효하지 않은 경우, /auth/reissue 호출 시 아래와 같은 예외 응답이 반환됩니다.
```json
{
    "success": false,
    "status": 401,
    "data": {
        "errorClassName": "EXPIRED_REFRESH_TOKEN",
        "message": "만료된 리프레시 토큰입니다. 다시 로그인해주세요."
    },
    "timestamp": "2025-05-03T02:29:06.48372"
}
```

[LCR-89]: https://lgcns-retail.atlassian.net/browse/LCR-89?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ