### PR TITLE
feat: 회원 마이크로서비스 초기 세팅

### DIFF
--- a/popi-api-gateway/src/main/resources/application-local.yml
+++ b/popi-api-gateway/src/main/resources/application-local.yml
@@ -27,6 +27,25 @@ spring:
           filters:
             - RemoveRequestHeader=Cookie
             - RewritePath=/auth/(?<segment>.*), /$\{segment}
+
+        - id: member-service
+          uri: lb://MEMBERS
+          predicates:
+            - Path=/members/**
+            - Method=GET,POST,DELETE
+          filters:
+            - RemoveRequestHeader=Cookie
+            - RewritePath=/members/(?<segment>.*), /$\{segment}
+            - JwtAuthenticationFilter
+
+        - id: member-docs
+          uri: lb://MEMBERS
+          predicates:
+            - Path=/members/v3/api-docs
+          filters:
+            - RemoveRequestHeader=Cookie
+            - RewritePath=/members/(?<segment>.*), /$\{segment}
+
       globalcors:
         cors-configurations:
           "[/**]":

--- a/popi-api-gateway/src/main/resources/application-local.yml
+++ b/popi-api-gateway/src/main/resources/application-local.yml
@@ -28,6 +28,13 @@ spring:
             - RemoveRequestHeader=Cookie
             - RewritePath=/auth/(?<segment>.*), /$\{segment}
 
+        - id: member-docs
+          uri: lb://MEMBERS
+          predicates:
+            - Path=/members/v3/api-docs
+          filters:
+            - RemoveRequestHeader=Cookie
+            - RewritePath=/members/(?<segment>.*), /$\{segment}
         - id: member-service
           uri: lb://MEMBERS
           predicates:
@@ -37,14 +44,6 @@ spring:
             - RemoveRequestHeader=Cookie
             - RewritePath=/members/(?<segment>.*), /$\{segment}
             - JwtAuthenticationFilter
-
-        - id: member-docs
-          uri: lb://MEMBERS
-          predicates:
-            - Path=/members/v3/api-docs
-          filters:
-            - RemoveRequestHeader=Cookie
-            - RewritePath=/members/(?<segment>.*), /$\{segment}
 
       globalcors:
         cors-configurations:

--- a/popi-api-gateway/src/main/resources/application-local.yml
+++ b/popi-api-gateway/src/main/resources/application-local.yml
@@ -71,6 +71,9 @@ springdoc:
     urls[0]:
       name: 인증 서비스
       url: /auth/v3/api-docs
+    urls[1]:
+      name: 회원 서비스
+      url: /members/v3/api-docs
 
 jwt:
   access-token-secret: ${JWT_ACCESS_TOKEN_SECRET}

--- a/popi-auth-service/src/main/resources/application-local.yml
+++ b/popi-auth-service/src/main/resources/application-local.yml
@@ -10,7 +10,7 @@ spring:
         enabled: false
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
-    url: jdbc:mysql://${MYSQL_HOST}:${MYSQL_PORT}/${DB_NAME}?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
+    url: jdbc:mysql://${MYSQL_HOST}:${MYSQL_PORT}/${AUTH_DB_NAME}?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
     username: ${DB_USERNAME}
     password: ${DB_PASSWORD}
   jpa:

--- a/popi-member-service/Dockerfile
+++ b/popi-member-service/Dockerfile
@@ -1,0 +1,4 @@
+FROM openjdk:17-slim
+ARG JAR_FILE=build/libs/*.jar
+COPY ${JAR_FILE} app.jar
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/popi-member-service/build.gradle
+++ b/popi-member-service/build.gradle
@@ -1,0 +1,23 @@
+dependencies {
+    implementation project(':popi-common')
+
+    // Eureka Client
+    implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
+
+    // Spring Cloud Kubernetes Discovery Client
+    implementation 'org.springframework.cloud:spring-cloud-starter-kubernetes-client'
+
+    // Spring Cloud Kubernetes Config Client
+    implementation 'org.springframework.cloud:spring-cloud-starter-kubernetes-client-config'
+
+    // H2
+    runtimeOnly 'com.h2database:h2'
+    // MySQL
+    runtimeOnly 'com.mysql:mysql-connector-j'
+
+    // Swagger
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.0'
+
+    // Spring Cloud Open Feign
+    implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
+}

--- a/popi-member-service/src/main/java/com/lgcns/PopiMemberServiceApplication.java
+++ b/popi-member-service/src/main/java/com/lgcns/PopiMemberServiceApplication.java
@@ -1,0 +1,12 @@
+package com.lgcns;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class PopiMemberServiceApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(PopiMemberServiceApplication.class, args);
+    }
+}

--- a/popi-member-service/src/main/java/com/lgcns/SwaggerConfig.java
+++ b/popi-member-service/src/main/java/com/lgcns/SwaggerConfig.java
@@ -1,0 +1,46 @@
+package com.lgcns;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.servers.Server;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@RequiredArgsConstructor
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI openAPI() {
+        return new OpenAPI()
+                .info(
+                        new Info()
+                                .title("PoPI Member Server API")
+                                .description("PoPI 회원 서비스 API 명세서입니다.")
+                                .version("v0.0.1"))
+                .addServersItem(new Server().url("/auth"))
+                .addServersItem(new Server().url("/members"))
+                .components(authSetting())
+                .addSecurityItem(securityRequirement());
+    }
+
+    private Components authSetting() {
+        return new Components()
+                .addSecuritySchemes(
+                        "accessToken",
+                        new SecurityScheme()
+                                .type(SecurityScheme.Type.HTTP)
+                                .scheme("bearer")
+                                .bearerFormat("JWT")
+                                .in(SecurityScheme.In.HEADER)
+                                .name("Authorization"));
+    }
+
+    private SecurityRequirement securityRequirement() {
+        return new SecurityRequirement().addList("accessToken");
+    }
+}

--- a/popi-member-service/src/main/java/com/lgcns/config/SwaggerConfig.java
+++ b/popi-member-service/src/main/java/com/lgcns/config/SwaggerConfig.java
@@ -1,4 +1,4 @@
-package com.lgcns;
+package com.lgcns.config;
 
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
@@ -22,7 +22,6 @@ public class SwaggerConfig {
                                 .title("PoPI Member Server API")
                                 .description("PoPI 회원 서비스 API 명세서입니다.")
                                 .version("v0.0.1"))
-                .addServersItem(new Server().url("/auth"))
                 .addServersItem(new Server().url("/members"))
                 .components(authSetting())
                 .addSecurityItem(securityRequirement());

--- a/popi-member-service/src/main/resources/application-local.yml
+++ b/popi-member-service/src/main/resources/application-local.yml
@@ -1,0 +1,35 @@
+server:
+  port: 0
+
+spring:
+  application:
+    name: members
+  cloud:
+    kubernetes:
+      config:
+        enabled: false
+  datasource:
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    url: jdbc:mysql://${MYSQL_HOST}:${MYSQL_PORT}/${MEMBER_DB_NAME}?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
+    username: ${DB_USERNAME}
+    password: ${DB_PASSWORD}
+  jpa:
+    hibernate:
+      ddl-auto: create
+    properties:
+      hibernate:
+        format_sql: true
+        default_batch_fetch_size: 100
+    open-in-view: false
+
+eureka:
+  instance:
+    instance-id: ${spring.cloud.client.hostname}:${spring.application.instance_id:${random.value}}
+    leaseRenewalIntervalInSeconds: 10
+  client:
+    serviceUrl:
+      defaultZone: http://localhost:8761/eureka/
+
+logging:
+  level:
+    org.hibernate.SQL: debug

--- a/popi-member-service/src/main/resources/application-local.yml
+++ b/popi-member-service/src/main/resources/application-local.yml
@@ -33,3 +33,11 @@ eureka:
 logging:
   level:
     org.hibernate.SQL: debug
+
+spring-doc:
+  api-docs:
+    version: openapi_3_1
+    enabled: true
+  enable-kotlin: false
+  default-consumes-media-type: application/json
+  default-produces-media-type: application/json

--- a/popi-member-service/src/test/java/com/lgcns/PopiMemberServiceApplicationTests.java
+++ b/popi-member-service/src/test/java/com/lgcns/PopiMemberServiceApplicationTests.java
@@ -1,0 +1,11 @@
+package com.lgcns;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class PopiMemberServiceApplicationTests {
+
+    @Test
+    void contextLoads() {}
+}

--- a/popi-member-service/src/test/resources/application.yml
+++ b/popi-member-service/src/test/resources/application.yml
@@ -1,0 +1,3 @@
+spring:
+  datasource:
+    url: jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=false;MODE=MYSQL

--- a/settings.gradle
+++ b/settings.gradle
@@ -4,5 +4,6 @@ include(
         "popi-eureka-server",
         "popi-common",
         "popi-api-gateway",
-        "popi-auth-service"
+        "popi-auth-service",
+        "popi-member-service"
 )


### PR DESCRIPTION
## 🌱 관련 이슈

- [LCR-128]

---
## 📌 작업 내용 및 특이사항

- 회원 마이크로서비스 초기 세팅을 진행하였습니다.
  - `application-local.yml`과 `application-test.yml`을 작성하였고, 기본적인 DB 접속 정보만 포함하였으며 로컬 환경에서는 Eureka 기반, Kubernetes 환경에서는 Spring Cloud Kubernetes Discovery 기반으로 서비스 디스커버리를 수행하도록 설정을 분리했습니다.
  - Docker 이미지 생성을 위한 Dockerfile을 추가하였습니다.
  - 회원 서비스 대부분의 API가 인증이 필요하므로 API Gateway에 /members/** 라우팅을 추가하고, Swagger 문서 경로(/members/v3/api-docs)는 인증 필터를 거치지 않도록 별도 라우팅으로 우선 처리하였습니다.
  - Swagger UI를 통해 인증 서비스와 회원 서비스의 API 문서를 모두 확인할 수 있도록, API Gateway에서 springdoc 설정을 통합 관리하고 라우팅을 구성했습니다.
  - Kubernetes 배포는 `popi-ops` 레포지토리의 Helm 차트로 관리되며 ArgoCD에서 해당 마이크로서비스용 APP을 최초 1회 생성한 이후에는 GitOps 레포지토리에 변경 사항을 푸시하면 자동으로 배포됩니다.
---
## 📚 참고사항

- API Gateway 서버에서 모든 마이크로서비스의 API 문서를 확인할 수 있습니다.
<img width="1434" alt="image" src="https://github.com/user-attachments/assets/ecd2fb92-90b3-4b3e-91a8-0b95bc1413b6" />
<img width="1434" alt="image" src="https://github.com/user-attachments/assets/7e52e8ed-05d2-4530-8821-43809b130b37" />



[LCR-128]: https://lgcns-retail.atlassian.net/browse/LCR-128?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ