### PR TITLE
chore: 예약 마이크로서비스 초기 세팅

### DIFF
--- a/popi-api-gateway/src/main/resources/application-local.yml
+++ b/popi-api-gateway/src/main/resources/application-local.yml
@@ -45,6 +45,23 @@ spring:
             - RewritePath=/members/(?<segment>.*), /$\{segment}
             - JwtAuthenticationFilter
 
+        - id: reservation-docs
+          uri: lb://RESERVATIONS
+          predicates:
+              - Path=/reservations/v3/api-docs
+          filters:
+              - RemoveRequestHeader=Cookie
+              - RewritePath=/reservations/(?<segment>.*), /$\{segment}
+        - id: reservation-service
+          uri: lb://RESERVATIONS
+          predicates:
+            - Path=/reservations/**
+            - Method=GET,POST,DELETE
+          filters:
+            - RemoveRequestHeader=Cookie
+            - RewritePath=/reservations/(?<segment>.*), /$\{segment}
+            - JwtAuthenticationFilter
+
       globalcors:
         cors-configurations:
           "[/**]":
@@ -73,6 +90,9 @@ springdoc:
     urls[1]:
       name: 회원 서비스
       url: /members/v3/api-docs
+    urls[2]:
+      name: 예약 서비스
+      url: /reservations/v3/api-docs
 
 jwt:
   access-token-secret: ${JWT_ACCESS_TOKEN_SECRET}

--- a/popi-reservation-service/Dockerfile
+++ b/popi-reservation-service/Dockerfile
@@ -1,0 +1,4 @@
+FROM openjdk:17-slim
+ARG JAR_FILE=build/libs/*.jar
+COPY ${JAR_FILE} app.jar
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/popi-reservation-service/build.gradle
+++ b/popi-reservation-service/build.gradle
@@ -1,0 +1,31 @@
+dependencies {
+	implementation project(':popi-common')
+
+	// Eureka Client
+	implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
+
+	// Spring Cloud Kubernetes Discovery Client
+	implementation 'org.springframework.cloud:spring-cloud-starter-kubernetes-client'
+
+	// Spring Cloud Kubernetes Config Client
+	implementation 'org.springframework.cloud:spring-cloud-starter-kubernetes-client-config'
+
+	// H2
+	runtimeOnly 'com.h2database:h2'
+	// MySQL
+	runtimeOnly 'com.mysql:mysql-connector-j'
+
+	// Swagger
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.0'
+
+	// Spring Cloud Open Feign
+	implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
+
+	// Lombok
+	compileOnly 'org.projectlombok:lombok'
+	annotationProcessor 'org.projectlombok:lombok'
+
+	// Test
+	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+}

--- a/popi-reservation-service/build.gradle
+++ b/popi-reservation-service/build.gradle
@@ -21,11 +21,4 @@ dependencies {
 	// Spring Cloud Open Feign
 	implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
 
-	// Lombok
-	compileOnly 'org.projectlombok:lombok'
-	annotationProcessor 'org.projectlombok:lombok'
-
-	// Test
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }

--- a/popi-reservation-service/src/main/java/com/lgcns/popireservationservice/PopiReservationServiceApplication.java
+++ b/popi-reservation-service/src/main/java/com/lgcns/popireservationservice/PopiReservationServiceApplication.java
@@ -1,0 +1,12 @@
+package com.lgcns.popireservationservice;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class PopiReservationServiceApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(PopiReservationServiceApplication.class, args);
+    }
+}

--- a/popi-reservation-service/src/main/resources/application-local.yml
+++ b/popi-reservation-service/src/main/resources/application-local.yml
@@ -1,0 +1,43 @@
+server:
+  port: 0
+
+spring:
+  application:
+    name: reservations
+  cloud:
+    kubernetes:
+      config:
+        enabled: false
+  datasource:
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    url: jdbc:mysql://${MYSQL_HOST}:${MYSQL_PORT}/${RESERVATION_DB_NAME}?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
+    username: ${DB_USERNAME}
+    password: ${DB_PASSWORD}
+  jpa:
+    hibernate:
+      ddl-auto: create
+    properties:
+      hibernate:
+        format_sql: true
+        default_batch_fetch_size: 100
+    open-in-view: false
+
+eureka:
+  instance:
+    instance-id: ${spring.cloud.client.hostname}:${spring.application.instance_id:${random.value}}
+    leaseRenewalIntervalInSeconds: 10
+  client:
+    serviceUrl:
+      defaultZone: http://localhost:8761/eureka/
+
+logging:
+  level:
+    org.hibernate.SQL: debug
+
+spring-doc:
+  api-docs:
+    version: openapi_3_1
+    enabled: true
+  enable-kotlin: false
+  default-consumes-media-type: application/json
+  default-produces-media-type: application/json

--- a/popi-reservation-service/src/test/java/com/lgcns/popireservationservice/PopiReservationServiceApplicationTests.java
+++ b/popi-reservation-service/src/test/java/com/lgcns/popireservationservice/PopiReservationServiceApplicationTests.java
@@ -1,0 +1,11 @@
+package com.lgcns.popireservationservice;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class PopiReservationServiceApplicationTests {
+
+    @Test
+    void contextLoads() {}
+}

--- a/popi-reservation-service/src/test/resources/application.yml
+++ b/popi-reservation-service/src/test/resources/application.yml
@@ -1,0 +1,3 @@
+spring:
+  datasource:
+    url: jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=false;MODE=MYSQL

--- a/settings.gradle
+++ b/settings.gradle
@@ -5,5 +5,6 @@ include(
         "popi-common",
         "popi-api-gateway",
         "popi-auth-service",
-        "popi-member-service"
+        "popi-member-service",
+        "popi-reservation-service",
 )


### PR DESCRIPTION
## 🌱 관련 이슈

- [LCR-130]

---
## 📌 작업 내용 및 특이사항

- 예약 마이크로서비스 초기 세팅을 진행하였습니다.
  - `application-local.yml`과 `application-test.yml`을 작성하였고, 기본적인 DB 접속 정보만 포함하였으며 로컬 환경에서는 Eureka 기반, Kubernetes 환경에서는 Spring Cloud Kubernetes Discovery 기반으로 서비스 디스커버리를 수행하도록 설정을 분리했습니다.
  - Docker 이미지 생성을 위한 Dockerfile을 추가하였습니다.
  - 예약 서비스 대부분의 API가 인증이 필요하므로 API Gateway에 /reservation/** 라우팅을 추가하고, Swagger 문서 경로(/reservations/v3/api-docs)는 인증 필터를 거치지 않도록 별도 라우팅으로 우선 처리하였습니다.
  - Swagger UI를 통해 예약 서비스의 API 문서를 모두 확인할 수 있도록, API Gateway에서 springdoc 설정을 통합 관리하고 라우팅을 구성했습니다.
  - Kubernetes 배포는 `popi-ops` 레포지토리의 Helm 차트로 관리되며 ArgoCD에서 해당 마이크로서비스용 APP을 최초 1회 생성한 이후에는 GitOps 레포지토리에 변경 사항을 푸시하면 자동으로 배포됩니다.
---
## 📚 참고사항

- API Gateway 서버에서 모든 마이크로서비스의 API 문서를 확인할 수 있습니다.
<img width="1395" alt="image" src="https://github.com/user-attachments/assets/496dc19d-30dd-428b-9f57-89ac5dfd1d30" />


[LCR-130]: https://lgcns-retail.atlassian.net/browse/LCR-130?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ