### PR TITLE
chore: Gradle 루트 프로젝트 이름 변경

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -1,4 +1,4 @@
-rootProject.name = 'popi'
+rootProject.name = 'popi-user-server'
 
 include(
         "popi-eureka-server",


### PR DESCRIPTION
## 🌱 관련 이슈

- [LCR-163]

---
## 📌 작업 내용 및 특이사항

- settings.gradle의 `rootProject.name`을 `'popi-user-server'`로 변경했습니다.

[LCR-163]: https://lgcns-retail.atlassian.net/browse/LCR-163?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ