### PR TITLE
chore: 도메인 모델 분리 및 모듈 구성

### DIFF
--- a/popi-auth-service/build.gradle
+++ b/popi-auth-service/build.gradle
@@ -1,4 +1,5 @@
 dependencies {
+    implementation project(':popi-domain')
     implementation project(':popi-common')
 
     // Eureka Client

--- a/popi-auth-service/src/main/java/com/lgcns/domain/Member.java
+++ b/popi-auth-service/src/main/java/com/lgcns/domain/Member.java
@@ -1,6 +1,6 @@
 package com.lgcns.domain;
 
-import com.lgcns.model.BaseTimeEntity;
+import com.lgcns.common.entity.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;

--- a/popi-auth-service/src/main/java/com/lgcns/dto/AccessTokenDto.java
+++ b/popi-auth-service/src/main/java/com/lgcns/dto/AccessTokenDto.java
@@ -1,6 +1,6 @@
 package com.lgcns.dto;
 
-import com.lgcns.domain.MemberRole;
+import com.lgcns.member.MemberRole;
 
 public record AccessTokenDto(Long memberId, MemberRole role, String accessTokenValue) {
     public static AccessTokenDto of(Long memberId, MemberRole role, String accessTokenValue) {

--- a/popi-auth-service/src/main/java/com/lgcns/repository/MemberRepository.java
+++ b/popi-auth-service/src/main/java/com/lgcns/repository/MemberRepository.java
@@ -1,7 +1,7 @@
 package com.lgcns.repository;
 
-import com.lgcns.domain.Member;
-import com.lgcns.domain.OauthInfo;
+import com.lgcns.member.Member;
+import com.lgcns.member.OauthInfo;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 

--- a/popi-auth-service/src/main/java/com/lgcns/service/AuthService.java
+++ b/popi-auth-service/src/main/java/com/lgcns/service/AuthService.java
@@ -1,7 +1,5 @@
 package com.lgcns.service;
 
-import com.lgcns.domain.Member;
-import com.lgcns.domain.OauthInfo;
 import com.lgcns.domain.OauthProvider;
 import com.lgcns.dto.AccessTokenDto;
 import com.lgcns.dto.RefreshTokenDto;
@@ -11,6 +9,8 @@ import com.lgcns.dto.response.TokenReissueResponse;
 import com.lgcns.error.exception.CustomException;
 import com.lgcns.exception.AuthErrorCode;
 import com.lgcns.exception.MemberErrorCode;
+import com.lgcns.member.Member;
+import com.lgcns.member.OauthInfo;
 import com.lgcns.repository.MemberRepository;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;

--- a/popi-auth-service/src/main/java/com/lgcns/service/JwtTokenService.java
+++ b/popi-auth-service/src/main/java/com/lgcns/service/JwtTokenService.java
@@ -1,12 +1,12 @@
 package com.lgcns.service;
 
-import com.lgcns.domain.Member;
-import com.lgcns.domain.MemberRole;
 import com.lgcns.domain.RefreshToken;
 import com.lgcns.dto.AccessTokenDto;
 import com.lgcns.dto.RefreshTokenDto;
 import com.lgcns.error.exception.CustomException;
 import com.lgcns.exception.AuthErrorCode;
+import com.lgcns.member.Member;
+import com.lgcns.member.MemberRole;
 import com.lgcns.repository.RefreshTokenRepository;
 import com.lgcns.util.JwtUtil;
 import lombok.RequiredArgsConstructor;

--- a/popi-auth-service/src/main/java/com/lgcns/util/JwtUtil.java
+++ b/popi-auth-service/src/main/java/com/lgcns/util/JwtUtil.java
@@ -2,9 +2,9 @@ package com.lgcns.util;
 
 import static com.lgcns.constants.SecurityConstants.TOKEN_ROLE_NAME;
 
-import com.lgcns.domain.MemberRole;
 import com.lgcns.dto.AccessTokenDto;
 import com.lgcns.dto.RefreshTokenDto;
+import com.lgcns.member.MemberRole;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.Jws;

--- a/popi-common/build.gradle
+++ b/popi-common/build.gradle
@@ -7,9 +7,6 @@ jar { enabled = true }
 
 dependencies {
     api 'org.springframework.boot:spring-boot-starter-web'
-    
-    //QueryDSL
-    api 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
 
     // Validation
     api 'org.springframework.boot:spring-boot-starter-validation'

--- a/popi-common/build.gradle
+++ b/popi-common/build.gradle
@@ -8,9 +8,6 @@ jar { enabled = true }
 dependencies {
     api 'org.springframework.boot:spring-boot-starter-web'
     
-    // JPA
-    api 'org.springframework.boot:spring-boot-starter-data-jpa'
-
     //QueryDSL
     api 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
 

--- a/popi-domain/build.gradle
+++ b/popi-domain/build.gradle
@@ -1,0 +1,5 @@
+bootJar { enabled = false }
+jar { enabled = true }
+
+dependencies {
+}

--- a/popi-domain/build.gradle
+++ b/popi-domain/build.gradle
@@ -1,5 +1,11 @@
+plugins {
+    id 'java-library'
+}
+
 bootJar { enabled = false }
 jar { enabled = true }
 
 dependencies {
+    // JPA
+    api 'org.springframework.boot:spring-boot-starter-data-jpa'
 }

--- a/popi-domain/build.gradle
+++ b/popi-domain/build.gradle
@@ -8,4 +8,7 @@ jar { enabled = true }
 dependencies {
     // JPA
     api 'org.springframework.boot:spring-boot-starter-data-jpa'
+
+    //QueryDSL
+    api 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
 }

--- a/popi-domain/src/main/java/com/lgcns/common/config/JpaAuditingConfig.java
+++ b/popi-domain/src/main/java/com/lgcns/common/config/JpaAuditingConfig.java
@@ -1,4 +1,4 @@
-package com.lgcns.config;
+package com.lgcns.common.config;
 
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;

--- a/popi-domain/src/main/java/com/lgcns/common/config/QueryDslConfig.java
+++ b/popi-domain/src/main/java/com/lgcns/common/config/QueryDslConfig.java
@@ -1,4 +1,4 @@
-package com.lgcns.config;
+package com.lgcns.common.config;
 
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import jakarta.persistence.EntityManager;

--- a/popi-domain/src/main/java/com/lgcns/common/entity/BaseTimeEntity.java
+++ b/popi-domain/src/main/java/com/lgcns/common/entity/BaseTimeEntity.java
@@ -1,4 +1,4 @@
-package com.lgcns.model;
+package com.lgcns.common.entity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.EntityListeners;

--- a/popi-domain/src/main/java/com/lgcns/member/Member.java
+++ b/popi-domain/src/main/java/com/lgcns/member/Member.java
@@ -1,4 +1,4 @@
-package com.lgcns.domain;
+package com.lgcns.member;
 
 import com.lgcns.common.entity.BaseTimeEntity;
 import jakarta.persistence.*;

--- a/popi-domain/src/main/java/com/lgcns/member/MemberGender.java
+++ b/popi-domain/src/main/java/com/lgcns/member/MemberGender.java
@@ -1,4 +1,4 @@
-package com.lgcns.domain;
+package com.lgcns.member;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;

--- a/popi-domain/src/main/java/com/lgcns/member/MemberRole.java
+++ b/popi-domain/src/main/java/com/lgcns/member/MemberRole.java
@@ -1,4 +1,4 @@
-package com.lgcns.domain;
+package com.lgcns.member;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;

--- a/popi-domain/src/main/java/com/lgcns/member/MemberStatus.java
+++ b/popi-domain/src/main/java/com/lgcns/member/MemberStatus.java
@@ -1,4 +1,4 @@
-package com.lgcns.domain;
+package com.lgcns.member;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;

--- a/popi-domain/src/main/java/com/lgcns/member/OauthInfo.java
+++ b/popi-domain/src/main/java/com/lgcns/member/OauthInfo.java
@@ -1,4 +1,4 @@
-package com.lgcns.domain;
+package com.lgcns.member;
 
 import lombok.AccessLevel;
 import lombok.Builder;

--- a/settings.gradle
+++ b/settings.gradle
@@ -6,5 +6,6 @@ include(
         "popi-api-gateway",
         "popi-auth-service",
         "popi-member-service",
+        "popi-domain",
         "popi-reservation-service",
 )


### PR DESCRIPTION
## 🌱 관련 이슈

- [LCR-171]

---
## 📌 작업 내용 및 특이사항

- popi-domain 모듈은 공통 유틸을 모으는 목적이 아닌, 각 마이크로서비스에서 사용하는 도메인 모델을 한 곳에서 통합 관리하기 위한 구조입니다.
- 각 마이크로서비스는 필요한 도메인만 의존성을 통해 참조하고, 도메인 로직(Service, Repository 등)은 서비스 내부에서 개별적으로 구현합니다.
- 이 구조를 통해 도메인 모델의 중복을 방지하고, 도메인 중심의 구조를 일관되게 유지할 수 있습니다.
- 특히 이번 작업은 회원 서비스와 인증 서비스가 같은 DB를 공유하고 있어, Member, OauthInfo와 같은 공통 도메인을 분리해낸 것입니다.

---
## 📚 참고사항

- popi-domain에 여러 도메인이 함께 존재할 경우, 이를 참조한 서비스에서 spring.jpa.hibernate.ddl-auto 설정을 사용할 경우 불필요한 도메인의 테이블까지 함께 생성될 수 있습니다.
- 이를 방지하기 위해 다음 중 하나의 방식이 필요하므로 의견 남겨주시면 감사하겠습니다.
  - Flyway를 통한 스키마 관리
  - 도메인 모듈을 도메인 단위로 분리하여 필요한 모듈만 의존
    - ex) popi-member-domain, popi-reservation-domain 

[LCR-171]: https://lgcns-retail.atlassian.net/browse/LCR-171?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ