### PR TITLE
fix: Google audience 설정 키명 수정

### DIFF
--- a/popi-auth-service/src/main/resources/application-local.yml
+++ b/popi-auth-service/src/main/resources/application-local.yml
@@ -35,9 +35,9 @@ oidc:
   google:
     jwk-set-uri: https://www.googleapis.com/oauth2/v3/certs
     issuer: https://accounts.google.com
-    audience:
-      - ${GOOGLE_WEB_CLIENT_ID}
-      - ${GOOGLE_ANDROID_CLIENT_ID}
+    audiences:
+      - ${GOOGLE_WEB_CLIENT_ID:}
+      - ${GOOGLE_ANDROID_CLIENT_ID:}
 
 jwt:
   access-token-secret: ${JWT_ACCESS_TOKEN_SECRET}


### PR DESCRIPTION
## 🌱 관련 이슈

- [LCR-172]

---
## 📌 작업 내용 및 특이사항

- application-local.yml의 oidc.google.audience 설정 키명을 audiences로 수정했습니다.
- Google ID 토큰 검증 시 웹/안드로이드 client_id를 모두 허용하기 위해 List<String> 형태로 처리하고 있었으나, 잘못된 키명으로 인해 값이 바인딩되지 않아 검증 실패가 발생하였습니다.
- 설정 키명 오타를 수정하여 다중 audience 값이 정상적으로 주입되도록 반영했습니다.

[LCR-172]: https://lgcns-retail.atlassian.net/browse/LCR-172?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ