### PR TITLE
chore: 예약/인증 서비스 Redis 논리 DB 분리

### DIFF
--- a/popi-auth-service/src/main/resources/application-local.yml
+++ b/popi-auth-service/src/main/resources/application-local.yml
@@ -26,6 +26,7 @@ spring:
       host: ${REDIS_HOST}
       port: ${REDIS_PORT}
       password: ${REDIS_PASSWORD:}
+      database: 0
 
 oidc:
   kakao:

--- a/popi-reservation-service/build.gradle
+++ b/popi-reservation-service/build.gradle
@@ -22,6 +22,9 @@ dependencies {
 	// Swagger
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.0'
 
+	// Redis
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
 	// Spring Cloud Open Feign
 	implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
 

--- a/popi-reservation-service/src/main/java/com/lgcns/PopiReservationServiceApplication.java
+++ b/popi-reservation-service/src/main/java/com/lgcns/PopiReservationServiceApplication.java
@@ -1,4 +1,4 @@
-package com.lgcns.popireservationservice;
+package com.lgcns;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;

--- a/popi-reservation-service/src/main/java/com/lgcns/config/SwaggerConfig.java
+++ b/popi-reservation-service/src/main/java/com/lgcns/config/SwaggerConfig.java
@@ -1,0 +1,43 @@
+package com.lgcns.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.servers.Server;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@RequiredArgsConstructor
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI openAPI() {
+        return new OpenAPI()
+                .info(
+                        new Info()
+                                .title("PoPI Reservation Service API")
+                                .description("PoPI 예약 서비스 API 명세서입니다.")
+                                .version("v0.0.1"))
+                .addServersItem(new Server().url("/reservation"));
+    }
+
+    private Components authSetting() {
+        return new Components()
+                .addSecuritySchemes(
+                        "accessToken",
+                        new SecurityScheme()
+                                .type(SecurityScheme.Type.HTTP)
+                                .scheme("bearer")
+                                .bearerFormat("JWT")
+                                .in(SecurityScheme.In.HEADER)
+                                .name("Authorization"));
+    }
+
+    private SecurityRequirement securityRequirement() {
+        return new SecurityRequirement().addList("accessToken");
+    }
+}

--- a/popi-reservation-service/src/main/java/com/lgcns/config/SwaggerConfig.java
+++ b/popi-reservation-service/src/main/java/com/lgcns/config/SwaggerConfig.java
@@ -22,7 +22,7 @@ public class SwaggerConfig {
                                 .title("PoPI Reservation Service API")
                                 .description("PoPI 예약 서비스 API 명세서입니다.")
                                 .version("v0.0.1"))
-                .addServersItem(new Server().url("/reservation"));
+                .addServersItem(new Server().url("/reservations"));
     }
 
     private Components authSetting() {

--- a/popi-reservation-service/src/main/java/com/lgcns/infra/properties/PropertiesConfig.java
+++ b/popi-reservation-service/src/main/java/com/lgcns/infra/properties/PropertiesConfig.java
@@ -1,0 +1,9 @@
+package com.lgcns.infra.properties;
+
+import com.lgcns.infra.redis.RedisProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@EnableConfigurationProperties(RedisProperties.class)
+@Configuration
+public class PropertiesConfig {}

--- a/popi-reservation-service/src/main/java/com/lgcns/infra/redis/RedisConfig.java
+++ b/popi-reservation-service/src/main/java/com/lgcns/infra/redis/RedisConfig.java
@@ -1,0 +1,37 @@
+package com.lgcns.infra.redis;
+
+import java.time.Duration;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+
+@Configuration
+@RequiredArgsConstructor
+public class RedisConfig {
+
+    private final RedisProperties redisProperties;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        RedisStandaloneConfiguration redisStandaloneConfig =
+                new RedisStandaloneConfiguration(redisProperties.host(), redisProperties.port());
+
+        redisStandaloneConfig.setDatabase(redisProperties.database());
+
+        if (!redisProperties.password().isBlank()) {
+            redisStandaloneConfig.setPassword(redisProperties.password());
+        }
+
+        LettuceClientConfiguration lettuceClientConfig =
+                LettuceClientConfiguration.builder()
+                        .commandTimeout(Duration.ofSeconds(1))
+                        .shutdownTimeout(Duration.ZERO)
+                        .build();
+
+        return new LettuceConnectionFactory(redisStandaloneConfig, lettuceClientConfig);
+    }
+}

--- a/popi-reservation-service/src/main/java/com/lgcns/infra/redis/RedisProperties.java
+++ b/popi-reservation-service/src/main/java/com/lgcns/infra/redis/RedisProperties.java
@@ -1,0 +1,6 @@
+package com.lgcns.infra.redis;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties("spring.data.redis")
+public record RedisProperties(String host, int port, String password, int database) {}

--- a/popi-reservation-service/src/main/resources/application-local.yml
+++ b/popi-reservation-service/src/main/resources/application-local.yml
@@ -21,6 +21,12 @@ spring:
         format_sql: true
         default_batch_fetch_size: 100
     open-in-view: false
+  data:
+    redis:
+      host: ${REDIS_HOST}
+      port: ${REDIS_PORT}
+      password: ${REDIS_PASSWORD:}
+      database: 1
 
 eureka:
   instance:

--- a/popi-reservation-service/src/test/java/com/lgcns/PopiReservationServiceApplicationTests.java
+++ b/popi-reservation-service/src/test/java/com/lgcns/PopiReservationServiceApplicationTests.java
@@ -1,4 +1,4 @@
-package com.lgcns.popireservationservice;
+package com.lgcns;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;

--- a/popi-reservation-service/src/test/resources/application.yml
+++ b/popi-reservation-service/src/test/resources/application.yml
@@ -6,3 +6,4 @@ spring:
       host: ${REDIS_HOST}
       port: ${REDIS_PORT:6379}
       password: ${REDIS_PASSWORD:}
+      database: 1

--- a/popi-reservation-service/src/test/resources/application.yml
+++ b/popi-reservation-service/src/test/resources/application.yml
@@ -1,3 +1,8 @@
 spring:
   datasource:
     url: jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=false;MODE=MYSQL
+  data:
+    redis:
+      host: ${REDIS_HOST}
+      port: ${REDIS_PORT:6379}
+      password: ${REDIS_PASSWORD:}


### PR DESCRIPTION
## 🌱 관련 이슈

- [LCR-170]

---
## 📌 작업 내용 및 특이사항

- auth 서비스는 Redis의 기본 DB인 db 0을 사용하도록 유지하고, reservation 서비스는 db 1을 사용하도록 설정하여 두 서비스 간의 데이터 충돌을 방지합니다.
- RedisProperties 클래스에 database 필드를 추가하여 Redis DB 인덱스를 설정할 수 있도록 개선하였습니다.
- RedisConfig 클래스에서 setDatabase() 메서드를 사용하여 지정된 DB 인덱스를 적용하도록 수정하였습니다.
- Reservation 파일들을 com.lgcns 패키지로 이동하였습니다.
- reservation 서비스에 Swagger 설정을 추가하였습니다.

---
## 📚 참고사항

- redis 내부에 접속 후 아래와 같이 명령어 입력하여 해당 서비스 db에 접속하시면 됩니다.
```
select 1
```


[LCR-170]: https://lgcns-retail.atlassian.net/browse/LCR-170?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ