### PR TITLE
chore: Common 모듈 JPA 의존성 제거

### DIFF
--- a/popi-auth-service/build.gradle
+++ b/popi-auth-service/build.gradle
@@ -15,6 +15,9 @@ dependencies {
     // MySQL
     runtimeOnly 'com.mysql:mysql-connector-j'
 
+    // JPA
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+
     // Swagger
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.0'
 

--- a/popi-common/build.gradle
+++ b/popi-common/build.gradle
@@ -9,7 +9,7 @@ dependencies {
     api 'org.springframework.boot:spring-boot-starter-web'
     
     // JPA
-    api 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 
     //QueryDSL
     api 'com.querydsl:querydsl-jpa:5.0.0:jakarta'

--- a/popi-member-service/build.gradle
+++ b/popi-member-service/build.gradle
@@ -15,6 +15,9 @@ dependencies {
     // MySQL
     runtimeOnly 'com.mysql:mysql-connector-j'
 
+    // JPA
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+
     // Swagger
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.0'
 

--- a/popi-reservation-service/build.gradle
+++ b/popi-reservation-service/build.gradle
@@ -15,6 +15,9 @@ dependencies {
 	// MySQL
 	runtimeOnly 'com.mysql:mysql-connector-j'
 
+	// JPA
+	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+
 	// Swagger
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.0'
 


### PR DESCRIPTION
## 🌱 관련 이슈

- [LCR-178]

---
## 📌 작업 내용 및 특이사항

- DB 의존성이 필요하지 않은 마이크로서비스에도 JPA 의존성이 전달되는 문제로 인해 common 모듈에서 JPA 의존성을 api → implementation으로 변경했습니다.
- 이에 따라 JPA가 필요한 각 마이크로서비스에 의존성을 개별적으로 추가했습니다.

[LCR-178]: https://lgcns-retail.atlassian.net/browse/LCR-178?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ