### PR TITLE
chore: 알림 마이크로서비스 초기 세팅

### DIFF
--- a/popi-api-gateway/src/main/resources/application-local.yml
+++ b/popi-api-gateway/src/main/resources/application-local.yml
@@ -110,9 +110,6 @@ springdoc:
     urls[2]:
       name: 예약 서비스
       url: /reservations/v3/api-docs
-    urls[3]:
-      name: 팝업 서비스
-      url: /popups/v3/api-docs
     urls[4]:
       name: 알림 서비스
       url: /notifications/v3/api-docs

--- a/popi-api-gateway/src/main/resources/application-local.yml
+++ b/popi-api-gateway/src/main/resources/application-local.yml
@@ -62,6 +62,23 @@ spring:
             - RewritePath=/reservations/(?<segment>.*), /$\{segment}
             - JwtAuthenticationFilter
 
+        - id: notification-docs
+          uri: lb://NOTIFICATIONS
+          predicates:
+            - Path=/notifications/v3/api-docs
+          filters:
+            - RemoveRequestHeader=Cookie
+            - RewritePath=/notifications/(?<segment>.*), /$\{segment}
+        - id: notifications-service
+          uri: lb://NOTIFICATIONS
+          predicates:
+            - Path=/notifications/**
+            - Method=GET,POST
+          filters:
+            - RemoveRequestHeader=Cookie
+            - RewritePath=/notifications/(?<segment>.*), /$\{segment}
+            - JwtAuthenticationFilter
+
       globalcors:
         cors-configurations:
           "[/**]":
@@ -93,6 +110,12 @@ springdoc:
     urls[2]:
       name: 예약 서비스
       url: /reservations/v3/api-docs
+    urls[3]:
+      name: 팝업 서비스
+      url: /popups/v3/api-docs
+    urls[4]:
+      name: 알림 서비스
+      url: /notifications/v3/api-docs
 
 jwt:
   access-token-secret: ${JWT_ACCESS_TOKEN_SECRET}

--- a/popi-notification-service/Dockerfile
+++ b/popi-notification-service/Dockerfile
@@ -1,0 +1,4 @@
+FROM openjdk:17-slim
+ARG JAR_FILE=build/libs/*.jar
+COPY ${JAR_FILE} app.jar
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/popi-notification-service/build.gradle
+++ b/popi-notification-service/build.gradle
@@ -10,11 +10,6 @@ dependencies {
 	// Spring Cloud Kubernetes Config Client
 	implementation 'org.springframework.cloud:spring-cloud-starter-kubernetes-client-config'
 
-	// H2
-	runtimeOnly 'com.h2database:h2'
-	// MySQL
-	runtimeOnly 'com.mysql:mysql-connector-j'
-
 	// Swagger
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.0'
 

--- a/popi-notification-service/build.gradle
+++ b/popi-notification-service/build.gradle
@@ -1,5 +1,6 @@
 dependencies {
 	implementation project(':popi-common')
+	implementation project(':popi-domain')
 
 	// Eureka Client
 	implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
@@ -9,6 +10,11 @@ dependencies {
 
 	// Spring Cloud Kubernetes Config Client
 	implementation 'org.springframework.cloud:spring-cloud-starter-kubernetes-client-config'
+
+	// H2
+	runtimeOnly 'com.h2database:h2'
+	// MySQL
+	runtimeOnly 'com.mysql:mysql-connector-j'
 
 	// Swagger
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.0'

--- a/popi-notification-service/build.gradle
+++ b/popi-notification-service/build.gradle
@@ -1,0 +1,23 @@
+dependencies {
+	implementation project(':popi-common')
+
+	// Eureka Client
+	implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
+
+	// Spring Cloud Kubernetes Discovery Client
+	implementation 'org.springframework.cloud:spring-cloud-starter-kubernetes-client'
+
+	// Spring Cloud Kubernetes Config Client
+	implementation 'org.springframework.cloud:spring-cloud-starter-kubernetes-client-config'
+
+	// H2
+	runtimeOnly 'com.h2database:h2'
+	// MySQL
+	runtimeOnly 'com.mysql:mysql-connector-j'
+
+	// Swagger
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.0'
+
+	// Spring Cloud Open Feign
+	implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
+}

--- a/popi-notification-service/build.gradle
+++ b/popi-notification-service/build.gradle
@@ -10,6 +10,11 @@ dependencies {
 	// Spring Cloud Kubernetes Config Client
 	implementation 'org.springframework.cloud:spring-cloud-starter-kubernetes-client-config'
 
+	// H2
+	runtimeOnly 'com.h2database:h2'
+	// MySQL
+	runtimeOnly 'com.mysql:mysql-connector-j'
+
 	// Swagger
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.0'
 

--- a/popi-notification-service/src/main/java/com/lgcns/PopiNotificationServiceApplication.java
+++ b/popi-notification-service/src/main/java/com/lgcns/PopiNotificationServiceApplication.java
@@ -1,0 +1,12 @@
+package com.lgcns;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class PopiNotificationServiceApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(PopiNotificationServiceApplication.class, args);
+    }
+}

--- a/popi-notification-service/src/main/java/com/lgcns/config/SwaggerConfig.java
+++ b/popi-notification-service/src/main/java/com/lgcns/config/SwaggerConfig.java
@@ -1,0 +1,45 @@
+package com.lgcns.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.servers.Server;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@RequiredArgsConstructor
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI openAPI() {
+        return new OpenAPI()
+                .info(
+                        new Info()
+                                .title("PoPI Notification Server API")
+                                .description("PoPI 알림 서비스 API 명세서입니다.")
+                                .version("v0.0.1"))
+                .addServersItem(new Server().url("/notifications"))
+                .components(authSetting())
+                .addSecurityItem(securityRequirement());
+    }
+
+    private Components authSetting() {
+        return new Components()
+                .addSecuritySchemes(
+                        "accessToken",
+                        new SecurityScheme()
+                                .type(SecurityScheme.Type.HTTP)
+                                .scheme("bearer")
+                                .bearerFormat("JWT")
+                                .in(SecurityScheme.In.HEADER)
+                                .name("Authorization"));
+    }
+
+    private SecurityRequirement securityRequirement() {
+        return new SecurityRequirement().addList("accessToken");
+    }
+}

--- a/popi-notification-service/src/main/resources/application-local.yml
+++ b/popi-notification-service/src/main/resources/application-local.yml
@@ -8,6 +8,19 @@ spring:
     kubernetes:
       config:
         enabled: false
+  datasource:
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    url: jdbc:mysql://${MYSQL_HOST}:${MYSQL_PORT}/${RESERVATION_DB_NAME}?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
+    username: ${DB_USERNAME}
+    password: ${DB_PASSWORD}
+  jpa:
+    hibernate:
+      ddl-auto: create
+    properties:
+      hibernate:
+        format_sql: true
+        default_batch_fetch_size: 100
+    open-in-view: false
 
 eureka:
   instance:

--- a/popi-notification-service/src/main/resources/application-local.yml
+++ b/popi-notification-service/src/main/resources/application-local.yml
@@ -1,0 +1,43 @@
+server:
+  port: 0
+
+spring:
+  application:
+    name: notifications
+  cloud:
+    kubernetes:
+      config:
+        enabled: false
+  datasource:
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    url: jdbc:mysql://${MYSQL_HOST}:${MYSQL_PORT}/${RESERVATION_DB_NAME}?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
+    username: ${DB_USERNAME}
+    password: ${DB_PASSWORD}
+  jpa:
+    hibernate:
+      ddl-auto: create
+    properties:
+      hibernate:
+        format_sql: true
+        default_batch_fetch_size: 100
+    open-in-view: false
+
+eureka:
+  instance:
+    instance-id: ${spring.cloud.client.hostname}:${spring.application.instance_id:${random.value}}
+    leaseRenewalIntervalInSeconds: 10
+  client:
+    serviceUrl:
+      defaultZone: http://localhost:8761/eureka/
+
+logging:
+  level:
+    org.hibernate.SQL: debug
+
+spring-doc:
+  api-docs:
+    version: openapi_3_1
+    enabled: true
+  enable-kotlin: false
+  default-consumes-media-type: application/json
+  default-produces-media-type: application/json

--- a/popi-notification-service/src/main/resources/application-local.yml
+++ b/popi-notification-service/src/main/resources/application-local.yml
@@ -8,19 +8,6 @@ spring:
     kubernetes:
       config:
         enabled: false
-  datasource:
-    driver-class-name: com.mysql.cj.jdbc.Driver
-    url: jdbc:mysql://${MYSQL_HOST}:${MYSQL_PORT}/${RESERVATION_DB_NAME}?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
-    username: ${DB_USERNAME}
-    password: ${DB_PASSWORD}
-  jpa:
-    hibernate:
-      ddl-auto: create
-    properties:
-      hibernate:
-        format_sql: true
-        default_batch_fetch_size: 100
-    open-in-view: false
 
 eureka:
   instance:

--- a/popi-notification-service/src/test/java/com/lgcns/PopiNotificationServiceApplicationTests.java
+++ b/popi-notification-service/src/test/java/com/lgcns/PopiNotificationServiceApplicationTests.java
@@ -1,0 +1,11 @@
+package com.lgcns;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class PopiNotificationServiceApplicationTests {
+
+    @Test
+    void contextLoads() {}
+}

--- a/popi-notification-service/src/test/resources/application.yml
+++ b/popi-notification-service/src/test/resources/application.yml
@@ -1,0 +1,3 @@
+spring:
+  datasource:
+    url: jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=false;MODE=MYSQL

--- a/popi-notification-service/src/test/resources/application.yml
+++ b/popi-notification-service/src/test/resources/application.yml
@@ -1,3 +1,0 @@
-spring:
-  datasource:
-    url: jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=false;MODE=MYSQL

--- a/settings.gradle
+++ b/settings.gradle
@@ -8,4 +8,5 @@ include(
         "popi-auth-service",
         "popi-member-service",
         "popi-reservation-service",
+        "popi-notification-service",
 )


### PR DESCRIPTION
## 🌱 관련 이슈

- [LCR-162]

---
## 📌 작업 내용 및 특이사항

- 알림 마이크로서비스 초기 세팅을 진행하였습니다.
- 로컬 환경에서는 Eureka 기반, Kubernetes 환경에서는 Spring Cloud Kubernetes Discovery 기반으로 서비스 디스커버리를 수행하도록 설정을 분리했습니다.
- Docker 이미지 생성을 위한 Dockerfile을 추가하였습니다.
- 알림 서비스 대부분의 API가 인증이 필요하므로 API Gateway에 /notification/** 라우팅을 추가하고, Swagger 문서 경로(/notifications/v3/api-docs)는 인증 필터를 거치지 않도록 별도 라우팅으로 우선 처리하였습니다.
  - FCM 토큰 관리를 위해 DB 의존성을 추가했습니다.


[LCR-162]: https://lgcns-retail.atlassian.net/browse/LCR-162?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ