### PR TITLE
feat: 로그아웃 기능 구현

### DIFF
--- a/.github/workflows/popi-ci.yml
+++ b/.github/workflows/popi-ci.yml
@@ -19,6 +19,9 @@ jobs:
           java-version: '17'
           distribution: 'temurin'
 
+      - name: Start Redis container for test
+        run: docker compose -f ./docker-compose-test.yml up -d
+
       - name: Grant execute permission for gradlew
         run: chmod +x ./gradlew
 

--- a/docker-compose-test.yml
+++ b/docker-compose-test.yml
@@ -1,0 +1,5 @@
+services:
+  redis:
+    image: "redis:alpine"
+    ports:
+      - "6379:6379"

--- a/popi-api-gateway/src/main/resources/application-local.yml
+++ b/popi-api-gateway/src/main/resources/application-local.yml
@@ -17,6 +17,14 @@ spring:
           filters:
             - RemoveRequestHeader=Cookie
             - RewritePath=/auth/(?<segment>.*), /$\{segment}
+        - id: auth-social-login
+          uri: lb://AUTH
+          predicates:
+            - Path=/auth/social-login
+            - Method=POST
+          filters:
+            - RemoveRequestHeader=Cookie
+            - RewritePath=/auth/(?<segment>.*), /$\{segment}
         - id: auth-reissue
           uri: lb://AUTH
           predicates:
@@ -26,14 +34,15 @@ spring:
             - RemoveRequestHeader=Cookie
             - RewritePath=/auth/(?<segment>.*), /$\{segment}
             - RefreshTokenHeaderFilter
-        - id: auth-service
+        - id: auth-logout
           uri: lb://AUTH
           predicates:
-            - Path=/auth/**
-            - Method=GET,POST
+            - Path=/auth/logout
+            - Method=POST
           filters:
             - RemoveRequestHeader=Cookie
             - RewritePath=/auth/(?<segment>.*), /$\{segment}
+            - JwtAuthenticationFilter
 
         - id: member-docs
           uri: lb://MEMBERS

--- a/popi-api-gateway/src/main/resources/application-local.yml
+++ b/popi-api-gateway/src/main/resources/application-local.yml
@@ -10,7 +10,14 @@ spring:
         enabled: false
     gateway:
       routes:
-        - id: auth-service
+        - id: auth-docs
+          uri: lb://AUTH
+          predicates:
+            - Path=/auth/v3/api-docs
+          filters:
+            - RemoveRequestHeader=Cookie
+            - RewritePath=/auth/(?<segment>.*), /$\{segment}
+        - id: auth-reissue
           uri: lb://AUTH
           predicates:
             - Path=/auth/reissue

--- a/popi-auth-service/src/main/java/com/lgcns/config/SwaggerConfig.java
+++ b/popi-auth-service/src/main/java/com/lgcns/config/SwaggerConfig.java
@@ -1,7 +1,10 @@
 package com.lgcns.config;
 
+import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
 import io.swagger.v3.oas.models.servers.Server;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
@@ -19,6 +22,24 @@ public class SwaggerConfig {
                                 .title("PoPI Auth Service API")
                                 .description("PoPI 인증 서비스 API 명세서입니다.")
                                 .version("v0.0.1"))
-                .addServersItem(new Server().url("/auth"));
+                .addServersItem(new Server().url("/auth"))
+                .components(authSetting())
+                .addSecurityItem(securityRequirement());
+    }
+
+    private Components authSetting() {
+        return new Components()
+                .addSecuritySchemes(
+                        "accessToken",
+                        new SecurityScheme()
+                                .type(SecurityScheme.Type.HTTP)
+                                .scheme("bearer")
+                                .bearerFormat("JWT")
+                                .in(SecurityScheme.In.HEADER)
+                                .name("Authorization"));
+    }
+
+    private SecurityRequirement securityRequirement() {
+        return new SecurityRequirement().addList("accessToken");
     }
 }

--- a/popi-auth-service/src/main/java/com/lgcns/config/WebSecurityConfig.java
+++ b/popi-auth-service/src/main/java/com/lgcns/config/WebSecurityConfig.java
@@ -19,6 +19,7 @@ public class WebSecurityConfig {
         http.csrf(AbstractHttpConfigurer::disable)
                 .httpBasic(AbstractHttpConfigurer::disable)
                 .formLogin(AbstractHttpConfigurer::disable)
+                .logout(AbstractHttpConfigurer::disable)
                 .sessionManagement(
                         session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS));
 

--- a/popi-auth-service/src/main/java/com/lgcns/controller/AuthController.java
+++ b/popi-auth-service/src/main/java/com/lgcns/controller/AuthController.java
@@ -51,4 +51,11 @@ public class AuthController {
 
         return ResponseEntity.ok().headers(headers).body(response);
     }
+
+    @PostMapping("/logout")
+    @Operation(summary = "회원 로그아웃", description = "로그아웃 시, 쿠키에 저장된 리프레시 토큰이 삭제됩니다.")
+    public ResponseEntity<Void> memberLogout(@RequestHeader("member-id") String memberId) {
+        authService.logoutMember(memberId);
+        return ResponseEntity.ok().headers(cookieUtil.deleteRefreshTokenCookie()).build();
+    }
 }

--- a/popi-auth-service/src/main/java/com/lgcns/service/AuthService.java
+++ b/popi-auth-service/src/main/java/com/lgcns/service/AuthService.java
@@ -1,91 +1,12 @@
 package com.lgcns.service;
 
-import com.lgcns.domain.Member;
-import com.lgcns.domain.OauthInfo;
 import com.lgcns.domain.OauthProvider;
-import com.lgcns.dto.AccessTokenDto;
-import com.lgcns.dto.RefreshTokenDto;
 import com.lgcns.dto.request.IdTokenRequest;
 import com.lgcns.dto.response.SocialLoginResponse;
 import com.lgcns.dto.response.TokenReissueResponse;
-import com.lgcns.error.exception.CustomException;
-import com.lgcns.exception.AuthErrorCode;
-import com.lgcns.exception.MemberErrorCode;
-import com.lgcns.repository.MemberRepository;
-import java.util.Optional;
-import lombok.RequiredArgsConstructor;
-import org.springframework.security.oauth2.core.oidc.user.OidcUser;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
-@Transactional
-@Service
-@RequiredArgsConstructor
-public class AuthService {
+public interface AuthService {
+    SocialLoginResponse socialLoginMember(OauthProvider provider, IdTokenRequest request);
 
-    private final JwtTokenService jwtTokenService;
-    private final IdTokenVerifier idTokenVerifier;
-    private final MemberRepository memberRepository;
-
-    public SocialLoginResponse socialLoginMember(OauthProvider provider, IdTokenRequest request) {
-        OidcUser oidcUser = idTokenVerifier.getOidcUser(request.idToken(), provider);
-
-        Optional<Member> optionalMember = findByOidcUser(oidcUser);
-        Member member = optionalMember.orElseGet(() -> saveMember(oidcUser, provider));
-
-        return getLoginResponse(member);
-    }
-
-    public TokenReissueResponse reissueToken(String refreshTokenValue) {
-        RefreshTokenDto oldRefreshTokenDto =
-                jwtTokenService.validateRefreshToken(refreshTokenValue);
-
-        if (oldRefreshTokenDto == null) {
-            throw new CustomException(AuthErrorCode.EXPIRED_REFRESH_TOKEN);
-        }
-
-        RefreshTokenDto newRefreshTokenDto =
-                jwtTokenService.reissueRefreshToken(oldRefreshTokenDto);
-        AccessTokenDto newAccessTokenDto =
-                jwtTokenService.reissueAccessToken(getMember(newRefreshTokenDto));
-
-        return TokenReissueResponse.of(
-                newAccessTokenDto.accessTokenValue(), newRefreshTokenDto.refreshTokenValue());
-    }
-
-    private SocialLoginResponse getLoginResponse(Member member) {
-        String accessToken = jwtTokenService.createAccessToken(member.getId(), member.getRole());
-        String refreshToken = jwtTokenService.createRefreshToken(member.getId());
-        return SocialLoginResponse.of(accessToken, refreshToken);
-    }
-
-    private Optional<Member> findByOidcUser(OidcUser oidcUser) {
-        OauthInfo oauthInfo = extractOauthInfo(oidcUser);
-        return memberRepository.findByOauthInfo(oauthInfo);
-    }
-
-    private Member saveMember(OidcUser oidcUser, OauthProvider provider) {
-        OauthInfo oauthInfo = extractOauthInfo(oidcUser);
-        String nickname = getDisplayName(oidcUser, provider);
-
-        Member member = Member.createMember(nickname, oauthInfo);
-        return memberRepository.save(member);
-    }
-
-    private OauthInfo extractOauthInfo(OidcUser oidcUser) {
-        return OauthInfo.createOauthInfo(oidcUser.getSubject(), oidcUser.getIssuer().toString());
-    }
-
-    private String getDisplayName(OidcUser oidcUser, OauthProvider provider) {
-        return switch (provider) {
-            case GOOGLE -> (String) oidcUser.getClaims().get("name");
-            case KAKAO -> (String) oidcUser.getClaims().get("nickname");
-        };
-    }
-
-    private Member getMember(RefreshTokenDto refreshTokenDto) {
-        return memberRepository
-                .findById(refreshTokenDto.memberId())
-                .orElseThrow(() -> new CustomException(MemberErrorCode.MEMBER_NOT_FOUND));
-    }
+    TokenReissueResponse reissueToken(String refreshTokenValue);
 }

--- a/popi-auth-service/src/main/java/com/lgcns/service/AuthService.java
+++ b/popi-auth-service/src/main/java/com/lgcns/service/AuthService.java
@@ -9,4 +9,6 @@ public interface AuthService {
     SocialLoginResponse socialLoginMember(OauthProvider provider, IdTokenRequest request);
 
     TokenReissueResponse reissueToken(String refreshTokenValue);
+
+    void logoutMember(String memberId);
 }

--- a/popi-auth-service/src/main/java/com/lgcns/service/AuthServiceImpl.java
+++ b/popi-auth-service/src/main/java/com/lgcns/service/AuthServiceImpl.java
@@ -12,6 +12,7 @@ import com.lgcns.error.exception.CustomException;
 import com.lgcns.exception.AuthErrorCode;
 import com.lgcns.exception.MemberErrorCode;
 import com.lgcns.repository.MemberRepository;
+import com.lgcns.repository.RefreshTokenRepository;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.oauth2.core.oidc.user.OidcUser;
@@ -26,6 +27,7 @@ public class AuthServiceImpl implements AuthService {
     private final JwtTokenService jwtTokenService;
     private final IdTokenVerifier idTokenVerifier;
     private final MemberRepository memberRepository;
+    private final RefreshTokenRepository refreshTokenRepository;
 
     @Override
     public SocialLoginResponse socialLoginMember(OauthProvider provider, IdTokenRequest request) {
@@ -53,6 +55,13 @@ public class AuthServiceImpl implements AuthService {
 
         return TokenReissueResponse.of(
                 newAccessTokenDto.accessTokenValue(), newRefreshTokenDto.refreshTokenValue());
+    }
+
+    @Override
+    public void logoutMember(String memberId) {
+        refreshTokenRepository
+                .findById(Long.parseLong(memberId))
+                .ifPresent(refreshTokenRepository::delete);
     }
 
     private SocialLoginResponse getLoginResponse(Member member) {

--- a/popi-auth-service/src/main/java/com/lgcns/service/AuthServiceImpl.java
+++ b/popi-auth-service/src/main/java/com/lgcns/service/AuthServiceImpl.java
@@ -1,0 +1,93 @@
+package com.lgcns.service;
+
+import com.lgcns.domain.Member;
+import com.lgcns.domain.OauthInfo;
+import com.lgcns.domain.OauthProvider;
+import com.lgcns.dto.AccessTokenDto;
+import com.lgcns.dto.RefreshTokenDto;
+import com.lgcns.dto.request.IdTokenRequest;
+import com.lgcns.dto.response.SocialLoginResponse;
+import com.lgcns.dto.response.TokenReissueResponse;
+import com.lgcns.error.exception.CustomException;
+import com.lgcns.exception.AuthErrorCode;
+import com.lgcns.exception.MemberErrorCode;
+import com.lgcns.repository.MemberRepository;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class AuthServiceImpl implements AuthService {
+
+    private final JwtTokenService jwtTokenService;
+    private final IdTokenVerifier idTokenVerifier;
+    private final MemberRepository memberRepository;
+
+    @Override
+    public SocialLoginResponse socialLoginMember(OauthProvider provider, IdTokenRequest request) {
+        OidcUser oidcUser = idTokenVerifier.getOidcUser(request.idToken(), provider);
+
+        Optional<Member> optionalMember = findByOidcUser(oidcUser);
+        Member member = optionalMember.orElseGet(() -> saveMember(oidcUser, provider));
+
+        return getLoginResponse(member);
+    }
+
+    @Override
+    public TokenReissueResponse reissueToken(String refreshTokenValue) {
+        RefreshTokenDto oldRefreshTokenDto =
+                jwtTokenService.validateRefreshToken(refreshTokenValue);
+
+        if (oldRefreshTokenDto == null) {
+            throw new CustomException(AuthErrorCode.EXPIRED_REFRESH_TOKEN);
+        }
+
+        RefreshTokenDto newRefreshTokenDto =
+                jwtTokenService.reissueRefreshToken(oldRefreshTokenDto);
+        AccessTokenDto newAccessTokenDto =
+                jwtTokenService.reissueAccessToken(getMember(newRefreshTokenDto));
+
+        return TokenReissueResponse.of(
+                newAccessTokenDto.accessTokenValue(), newRefreshTokenDto.refreshTokenValue());
+    }
+
+    private SocialLoginResponse getLoginResponse(Member member) {
+        String accessToken = jwtTokenService.createAccessToken(member.getId(), member.getRole());
+        String refreshToken = jwtTokenService.createRefreshToken(member.getId());
+        return SocialLoginResponse.of(accessToken, refreshToken);
+    }
+
+    private Optional<Member> findByOidcUser(OidcUser oidcUser) {
+        OauthInfo oauthInfo = extractOauthInfo(oidcUser);
+        return memberRepository.findByOauthInfo(oauthInfo);
+    }
+
+    private Member saveMember(OidcUser oidcUser, OauthProvider provider) {
+        OauthInfo oauthInfo = extractOauthInfo(oidcUser);
+        String nickname = getDisplayName(oidcUser, provider);
+
+        Member member = Member.createMember(nickname, oauthInfo);
+        return memberRepository.save(member);
+    }
+
+    private OauthInfo extractOauthInfo(OidcUser oidcUser) {
+        return OauthInfo.createOauthInfo(oidcUser.getSubject(), oidcUser.getIssuer().toString());
+    }
+
+    private String getDisplayName(OidcUser oidcUser, OauthProvider provider) {
+        return switch (provider) {
+            case GOOGLE -> (String) oidcUser.getClaims().get("name");
+            case KAKAO -> (String) oidcUser.getClaims().get("nickname");
+        };
+    }
+
+    private Member getMember(RefreshTokenDto refreshTokenDto) {
+        return memberRepository
+                .findById(refreshTokenDto.memberId())
+                .orElseThrow(() -> new CustomException(MemberErrorCode.MEMBER_NOT_FOUND));
+    }
+}

--- a/popi-auth-service/src/main/java/com/lgcns/util/CookieUtil.java
+++ b/popi-auth-service/src/main/java/com/lgcns/util/CookieUtil.java
@@ -24,4 +24,20 @@ public class CookieUtil {
 
         return headers;
     }
+
+    public HttpHeaders deleteRefreshTokenCookie() {
+        ResponseCookie refreshTokenCookie =
+                ResponseCookie.from(REFRESH_TOKEN_COOKIE_NAME, "")
+                        .path("/")
+                        .maxAge(0)
+                        .secure(true)
+                        .sameSite(Cookie.SameSite.NONE.attributeValue())
+                        .httpOnly(true)
+                        .build();
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.add(HttpHeaders.SET_COOKIE, refreshTokenCookie.toString());
+
+        return headers;
+    }
 }

--- a/popi-auth-service/src/test/java/com/lgcns/service/AuthServiceTest.java
+++ b/popi-auth-service/src/test/java/com/lgcns/service/AuthServiceTest.java
@@ -1,0 +1,67 @@
+package com.lgcns.service;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+import com.lgcns.domain.Member;
+import com.lgcns.domain.OauthInfo;
+import com.lgcns.domain.RefreshToken;
+import com.lgcns.repository.MemberRepository;
+import com.lgcns.repository.RefreshTokenRepository;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+
+@SpringBootTest
+public class AuthServiceTest {
+
+    @Autowired private AuthService memberService;
+    @Autowired private MemberRepository memberRepository;
+    @Autowired private RefreshTokenRepository refreshTokenRepository;
+
+    private Member registerAuthenticatedMember() {
+        Member member =
+                Member.createMember(
+                        "testNickName",
+                        OauthInfo.createOauthInfo("testOauthId", "testOauthProvider"));
+        memberRepository.save(member);
+
+        UserDetails userDetails =
+                User.withUsername(member.getId().toString())
+                        .password("")
+                        .authorities(member.getRole().toString())
+                        .build();
+        UsernamePasswordAuthenticationToken token =
+                new UsernamePasswordAuthenticationToken(
+                        userDetails, null, userDetails.getAuthorities());
+        SecurityContextHolder.getContext().setAuthentication(token);
+
+        return member;
+    }
+
+    @Nested
+    class 로그아웃_시 {
+        @Test
+        void 로그아웃하면_리프레시_토큰이_삭제된다() {
+            // given
+            Member member = registerAuthenticatedMember();
+
+            RefreshToken refreshToken =
+                    RefreshToken.builder()
+                            .memberId(member.getId())
+                            .token("testRefreshToken")
+                            .build();
+            refreshTokenRepository.save(refreshToken);
+
+            // when
+            memberService.logoutMember(member.getId().toString());
+
+            // then
+            assertThat(refreshTokenRepository.findById(member.getId())).isEmpty();
+        }
+    }
+}

--- a/popi-auth-service/src/test/resources/application.yml
+++ b/popi-auth-service/src/test/resources/application.yml
@@ -3,7 +3,7 @@ spring:
     url: jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=false;MODE=MYSQL
   data:
     redis:
-      host: ${REDIS_HOST}
+      host: ${REDIS_HOST:localhost}
       port: ${REDIS_PORT:6379}
       password: ${REDIS_PASSWORD:}
 


### PR DESCRIPTION
## 🌱 관련 이슈

- [LCR-165]

---
## 📌 작업 내용 및 특이사항


- 인증 서비스에 `POST /logout` API를 추가하였습니다.  
  - 로그아웃 시 쿠키에서 refreshToken이 제거되도록 처리하였습니다.
- `WebSecurityConfig`에서 Spring Security의 기본 로그아웃 처리를 비활성화하였습니다.  
  - `http.logout(AbstractHttpConfigurer::disable)`을 추가하여 커스텀 로그아웃 컨트롤러가 정상 동작하도록 설정하였습니다.
- Spring Cloud Gateway에서 `/auth/logout` 요청에 `JwtAuthenticationFilter`를 적용하였습니다.  
  - 로그아웃 요청이 인증된 사용자만 접근 가능하도록 설정하였습니다.
- Swagger 문서 요청(`/auth/v3/api-docs`)은 인증 필터를 통과하지 않도록 라우팅을 별도로 분리하였습니다.  

[LCR-165]: https://lgcns-retail.atlassian.net/browse/LCR-165?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ