### PR TITLE
feat: 회원탈퇴 기능 구현

### DIFF
--- a/popi-api-gateway/src/main/resources/application-local.yml
+++ b/popi-api-gateway/src/main/resources/application-local.yml
@@ -43,6 +43,15 @@ spring:
             - RemoveRequestHeader=Cookie
             - RewritePath=/auth/(?<segment>.*), /$\{segment}
             - JwtAuthenticationFilter
+        - id: auth-withdrawal
+          uri: lb://AUTH
+          predicates:
+            - Path=/auth/withdrawal
+            - Method=DELETE
+          filters:
+            - RemoveRequestHeader=Cookie
+            - RewritePath=/auth/(?<segment>.*), /$\{segment}
+            - JwtAuthenticationFilter
 
         - id: member-docs
           uri: lb://MEMBERS

--- a/popi-auth-service/src/main/java/com/lgcns/controller/AuthController.java
+++ b/popi-auth-service/src/main/java/com/lgcns/controller/AuthController.java
@@ -12,10 +12,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestHeader;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -56,6 +53,13 @@ public class AuthController {
     @Operation(summary = "회원 로그아웃", description = "로그아웃 시, 쿠키에 저장된 리프레시 토큰이 삭제됩니다.")
     public ResponseEntity<Void> memberLogout(@RequestHeader("member-id") String memberId) {
         authService.logoutMember(memberId);
+        return ResponseEntity.ok().headers(cookieUtil.deleteRefreshTokenCookie()).build();
+    }
+
+    @DeleteMapping("/withdrawal")
+    @Operation(summary = "회원 탈퇴", description = "회원 탈퇴를 진행합니다.")
+    public ResponseEntity<Void> memberWithdrawal(@RequestHeader("member-id") String memberId) {
+        authService.withdrawalMember(memberId);
         return ResponseEntity.ok().headers(cookieUtil.deleteRefreshTokenCookie()).build();
     }
 }

--- a/popi-auth-service/src/main/java/com/lgcns/domain/Member.java
+++ b/popi-auth-service/src/main/java/com/lgcns/domain/Member.java
@@ -67,4 +67,8 @@ public class Member extends BaseTimeEntity {
 
         this.status = MemberStatus.DELETED;
     }
+
+    public void reEnroll() {
+        this.status = MemberStatus.NORMAL;
+    }
 }

--- a/popi-auth-service/src/main/java/com/lgcns/domain/Member.java
+++ b/popi-auth-service/src/main/java/com/lgcns/domain/Member.java
@@ -1,6 +1,8 @@
 package com.lgcns.domain;
 
 import com.lgcns.entity.BaseTimeEntity;
+import com.lgcns.error.exception.CustomException;
+import com.lgcns.exception.MemberErrorCode;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -56,5 +58,13 @@ public class Member extends BaseTimeEntity {
                 .status(MemberStatus.NORMAL)
                 .role(MemberRole.USER)
                 .build();
+    }
+
+    public void withdrawal() {
+        if (this.status == MemberStatus.DELETED) {
+            throw new CustomException(MemberErrorCode.MEMBER_ALREADY_DELETED);
+        }
+
+        this.status = MemberStatus.DELETED;
     }
 }

--- a/popi-auth-service/src/main/java/com/lgcns/exception/MemberErrorCode.java
+++ b/popi-auth-service/src/main/java/com/lgcns/exception/MemberErrorCode.java
@@ -9,6 +9,8 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum MemberErrorCode implements ErrorCode {
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "회원을 찾을 수 없습니다."),
+
+    MEMBER_ALREADY_DELETED(HttpStatus.BAD_REQUEST, "이미 탈퇴한 회원입니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/popi-auth-service/src/main/java/com/lgcns/service/AuthService.java
+++ b/popi-auth-service/src/main/java/com/lgcns/service/AuthService.java
@@ -11,4 +11,6 @@ public interface AuthService {
     TokenReissueResponse reissueToken(String refreshTokenValue);
 
     void logoutMember(String memberId);
+
+    void withdrawalMember(String memberId);
 }

--- a/popi-auth-service/src/main/java/com/lgcns/service/AuthServiceImpl.java
+++ b/popi-auth-service/src/main/java/com/lgcns/service/AuthServiceImpl.java
@@ -64,6 +64,20 @@ public class AuthServiceImpl implements AuthService {
                 .ifPresent(refreshTokenRepository::delete);
     }
 
+    @Override
+    public void withdrawalMember(String memberId) {
+        refreshTokenRepository
+                .findById(Long.parseLong(memberId))
+                .ifPresent(refreshTokenRepository::delete);
+
+        Member member =
+                memberRepository
+                        .findById(Long.parseLong(memberId))
+                        .orElseThrow(() -> new CustomException(MemberErrorCode.MEMBER_NOT_FOUND));
+
+        member.withdrawal();
+    }
+
     private SocialLoginResponse getLoginResponse(Member member) {
         String accessToken = jwtTokenService.createAccessToken(member.getId(), member.getRole());
         String refreshToken = jwtTokenService.createRefreshToken(member.getId());

--- a/popi-auth-service/src/main/java/com/lgcns/service/AuthServiceImpl.java
+++ b/popi-auth-service/src/main/java/com/lgcns/service/AuthServiceImpl.java
@@ -1,6 +1,7 @@
 package com.lgcns.service;
 
 import com.lgcns.domain.Member;
+import com.lgcns.domain.MemberStatus;
 import com.lgcns.domain.OauthInfo;
 import com.lgcns.domain.OauthProvider;
 import com.lgcns.dto.AccessTokenDto;
@@ -35,6 +36,10 @@ public class AuthServiceImpl implements AuthService {
 
         Optional<Member> optionalMember = findByOidcUser(oidcUser);
         Member member = optionalMember.orElseGet(() -> saveMember(oidcUser, provider));
+
+        if (member.getStatus() == MemberStatus.DELETED) {
+            member.reEnroll();
+        }
 
         return getLoginResponse(member);
     }


### PR DESCRIPTION
## 🌱 관련 이슈

- [LCR-166]

---
## 📌 작업 내용 및 특이사항

- 인증 서비스에 `POST /withdrawal` API를 추가하였습니다.
- 탈퇴 요청 시 회원의 상태를 `WITHDRAWAL`로 변경되도록 처리하였습니다.
- 탈퇴한 회원이 추후 소셜 로그인 시, 기존 회원 정보를 복구하여 `NORMAL` 상태로 전환되도록 처리하였습니다.
- 탈퇴 처리는 **소프트 삭제 방식**으로 구현하였습니다.
- 이미 탈퇴된 회원이 다시 탈퇴를 시도할 경우 예외가 발생하도록 처리하였습니다.
- Spring Cloud Gateway에서 `/auth/withdrawal` 요청에 `JwtAuthenticationFilter`를 적용하였습니다.
  - 회원탈퇴 요청이 인증된 사용자만 접근 가능하도록 설정하였습니다.


[LCR-166]: https://lgcns-retail.atlassian.net/browse/LCR-166?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ