### PR TITLE
fix: 소셜 로그인 API JSON 바인딩 실패 오류 수정

### DIFF
--- a/popi-auth-service/src/main/java/com/lgcns/controller/AuthController.java
+++ b/popi-auth-service/src/main/java/com/lgcns/controller/AuthController.java
@@ -26,7 +26,7 @@ public class AuthController {
     @Operation(summary = "회원가입 및 로그인", description = "회원가입 및 로그인을 진행합니다.")
     public ResponseEntity<SocialLoginResponse> memberSocialLogin(
             @RequestParam(name = "oauthProvider") OauthProvider provider,
-            @Valid IdTokenRequest request) {
+            @Valid @RequestBody IdTokenRequest request) {
         SocialLoginResponse response = authService.socialLoginMember(provider, request);
 
         String refreshToken = response.refreshToken();


### PR DESCRIPTION
## 🌱 관련 이슈

- [LCR-192]

---
## 📌 작업 내용 및 특이사항

- 소셜 로그인 Request DTO(IdTokenRequest)에 @RequestBody 어노테이션이 누락되어 JSON 요청이 바인딩되지 않던 문제를 수정했습니다.

[LCR-192]: https://lgcns-retail.atlassian.net/browse/LCR-192?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ