### PR TITLE
feat: Register Token 기반 회원가입 기능 구현

### DIFF
--- a/popi-api-gateway/src/main/resources/application-local.yml
+++ b/popi-api-gateway/src/main/resources/application-local.yml
@@ -25,6 +25,14 @@ spring:
           filters:
             - RemoveRequestHeader=Cookie
             - RewritePath=/auth/(?<segment>.*), /$\{segment}
+        - id: auth-register
+          uri: lb://AUTH
+          predicates:
+            - Path=/auth/register
+            - Method=POST
+          filters:
+            - RemoveRequestHeader=Cookie
+            - RewritePath=/auth/(?<segment>.*), /$\{segment}
         - id: auth-reissue
           uri: lb://AUTH
           predicates:

--- a/popi-auth-service/src/main/java/com/lgcns/controller/AuthController.java
+++ b/popi-auth-service/src/main/java/com/lgcns/controller/AuthController.java
@@ -2,6 +2,7 @@ package com.lgcns.controller;
 
 import com.lgcns.domain.OauthProvider;
 import com.lgcns.dto.request.IdTokenRequest;
+import com.lgcns.dto.request.RegisterTokenRequest;
 import com.lgcns.dto.response.SocialLoginResponse;
 import com.lgcns.dto.response.TokenReissueResponse;
 import com.lgcns.service.AuthService;
@@ -23,11 +24,24 @@ public class AuthController {
     private final CookieUtil cookieUtil;
 
     @PostMapping("/social-login")
-    @Operation(summary = "회원가입 및 로그인", description = "회원가입 및 로그인을 진행합니다.")
+    @Operation(summary = "소셜 로그인", description = "소셜 로그인을 진행합니다.")
     public ResponseEntity<SocialLoginResponse> memberSocialLogin(
             @RequestParam(name = "oauthProvider") OauthProvider provider,
             @Valid @RequestBody IdTokenRequest request) {
         SocialLoginResponse response = authService.socialLoginMember(provider, request);
+
+        String refreshToken = response.refreshToken();
+        HttpHeaders headers = cookieUtil.generateRefreshTokenCookie(refreshToken);
+
+        return ResponseEntity.ok().headers(headers).body(response);
+    }
+
+    @PostMapping("/register")
+    @Operation(summary = "회원가입", description = "신규 유저의 경우 추가 정보를 등록하고 회원가입을 진행합니다.")
+    public ResponseEntity<SocialLoginResponse> memberRegister(
+            @RequestHeader("register-token") String registerTokenValue,
+            @Valid @RequestBody RegisterTokenRequest request) {
+        SocialLoginResponse response = authService.registerMember(registerTokenValue, request);
 
         String refreshToken = response.refreshToken();
         HttpHeaders headers = cookieUtil.generateRefreshTokenCookie(refreshToken);

--- a/popi-auth-service/src/main/java/com/lgcns/domain/Member.java
+++ b/popi-auth-service/src/main/java/com/lgcns/domain/Member.java
@@ -19,9 +19,9 @@ public class Member extends BaseTimeEntity {
     @Column(name = "member_id")
     private Long id;
 
-    private String nickname;
-
     @Embedded private OauthInfo oauthInfo;
+
+    private String nickname;
 
     @Enumerated(EnumType.STRING)
     private MemberAge age;
@@ -37,8 +37,8 @@ public class Member extends BaseTimeEntity {
 
     @Builder(access = AccessLevel.PRIVATE)
     private Member(
-            String nickname,
             OauthInfo oauthInfo,
+            String nickname,
             MemberAge age,
             MemberGender gender,
             MemberStatus status,
@@ -51,10 +51,13 @@ public class Member extends BaseTimeEntity {
         this.role = role;
     }
 
-    public static Member createMember(String nickname, OauthInfo oauthInfo) {
+    public static Member createMember(
+            OauthInfo oauthInfo, String nickname, MemberGender gender, MemberAge age) {
         return Member.builder()
-                .nickname(nickname)
                 .oauthInfo(oauthInfo)
+                .nickname(nickname)
+                .gender(gender)
+                .age(age)
                 .status(MemberStatus.NORMAL)
                 .role(MemberRole.USER)
                 .build();

--- a/popi-auth-service/src/main/java/com/lgcns/dto/RegisterTokenDto.java
+++ b/popi-auth-service/src/main/java/com/lgcns/dto/RegisterTokenDto.java
@@ -1,0 +1,8 @@
+package com.lgcns.dto;
+
+public record RegisterTokenDto(String oauthId, String oauthProvider, String registerTokenValue) {
+    public static RegisterTokenDto of(
+            String oauthId, String oauthProvider, String registerTokenValue) {
+        return new RegisterTokenDto(oauthId, oauthProvider, registerTokenValue);
+    }
+}

--- a/popi-auth-service/src/main/java/com/lgcns/dto/request/RegisterTokenRequest.java
+++ b/popi-auth-service/src/main/java/com/lgcns/dto/request/RegisterTokenRequest.java
@@ -1,0 +1,16 @@
+package com.lgcns.dto.request;
+
+import com.lgcns.domain.MemberAge;
+import com.lgcns.domain.MemberGender;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record RegisterTokenRequest(
+        @Schema(description = "사용자 닉네임", example = "nickname")
+                @NotBlank(message = "닉네임은 비워둘 수 없습니다.")
+                String nickname,
+        @Schema(description = "연령대", example = "TWENTIES") @NotNull(message = "연령대는 비워둘 수 없습니다.")
+                MemberAge age,
+        @Schema(description = "성별", example = "MALE") @NotNull(message = "성별은 비워둘 수 없습니다.")
+                MemberGender gender) {}

--- a/popi-auth-service/src/main/java/com/lgcns/dto/response/SocialLoginResponse.java
+++ b/popi-auth-service/src/main/java/com/lgcns/dto/response/SocialLoginResponse.java
@@ -1,8 +1,10 @@
 package com.lgcns.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.v3.oas.annotations.media.Schema;
 
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public record SocialLoginResponse(
         @Schema(description = "엑세스 토큰") String accessToken,
         @JsonIgnore @Schema(description = "리프레시 토큰") String refreshToken,

--- a/popi-auth-service/src/main/java/com/lgcns/dto/response/SocialLoginResponse.java
+++ b/popi-auth-service/src/main/java/com/lgcns/dto/response/SocialLoginResponse.java
@@ -5,8 +5,14 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 public record SocialLoginResponse(
         @Schema(description = "엑세스 토큰") String accessToken,
-        @JsonIgnore @Schema(description = "리프레시 토큰") String refreshToken) {
-    public static SocialLoginResponse of(String accessToken, String refreshToken) {
-        return new SocialLoginResponse(accessToken, refreshToken);
+        @JsonIgnore @Schema(description = "리프레시 토큰") String refreshToken,
+        @Schema(description = "레지스터 토큰") String registerToken,
+        @Schema(description = "신규 유저 등록 여부") boolean isRegistered) {
+    public static SocialLoginResponse registered(String accessToken, String refreshToken) {
+        return new SocialLoginResponse(accessToken, refreshToken, null, true);
+    }
+
+    public static SocialLoginResponse notRegistered(String registerToken) {
+        return new SocialLoginResponse(null, null, registerToken, false);
     }
 }

--- a/popi-auth-service/src/main/java/com/lgcns/exception/AuthErrorCode.java
+++ b/popi-auth-service/src/main/java/com/lgcns/exception/AuthErrorCode.java
@@ -11,6 +11,9 @@ public enum AuthErrorCode implements ErrorCode {
     ID_TOKEN_VERIFICATION_FAILED(HttpStatus.UNAUTHORIZED, "ID 토큰 검증에 실패했습니다."),
     REFRESH_TOKEN_NOT_FOUND(HttpStatus.UNAUTHORIZED, "유효한 리프레시 토큰이 존재하지 않습니다."),
     EXPIRED_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "만료된 리프레시 토큰입니다. 다시 로그인해주세요."),
+
+    EXPIRED_REGISTER_TOKEN(HttpStatus.UNAUTHORIZED, "회원가입 시간이 만료되었습니다. 소셜 로그인을 다시 진행해주세요."),
+    ALREADY_REGISTERED(HttpStatus.CONFLICT, "이미 가입된 사용자입니다. 로그인 후 이용해주세요."),
     ;
 
     private final HttpStatus httpStatus;

--- a/popi-auth-service/src/main/java/com/lgcns/infra/jwt/JwtProperties.java
+++ b/popi-auth-service/src/main/java/com/lgcns/infra/jwt/JwtProperties.java
@@ -8,6 +8,8 @@ public record JwtProperties(
         String refreshTokenSecret,
         Long accessTokenExpirationTime,
         Long refreshTokenExpirationTime,
+        String registerTokenSecret,
+        Long registerTokenExpirationTime,
         String issuer) {
     public Long accessTokenExpirationMilliTime() {
         return accessTokenExpirationTime * 1000;
@@ -15,5 +17,9 @@ public record JwtProperties(
 
     public Long refreshTokenExpirationMilliTime() {
         return refreshTokenExpirationTime * 1000;
+    }
+
+    public Long registerTokenExpirationMilliTime() {
+        return registerTokenExpirationTime * 1000;
     }
 }

--- a/popi-auth-service/src/main/java/com/lgcns/repository/MemberRepository.java
+++ b/popi-auth-service/src/main/java/com/lgcns/repository/MemberRepository.java
@@ -7,4 +7,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findByOauthInfo(OauthInfo oauthInfo);
+
+    boolean existsByOauthInfo(OauthInfo oauthInfo);
 }

--- a/popi-auth-service/src/main/java/com/lgcns/service/AuthService.java
+++ b/popi-auth-service/src/main/java/com/lgcns/service/AuthService.java
@@ -2,11 +2,14 @@ package com.lgcns.service;
 
 import com.lgcns.domain.OauthProvider;
 import com.lgcns.dto.request.IdTokenRequest;
+import com.lgcns.dto.request.RegisterTokenRequest;
 import com.lgcns.dto.response.SocialLoginResponse;
 import com.lgcns.dto.response.TokenReissueResponse;
 
 public interface AuthService {
     SocialLoginResponse socialLoginMember(OauthProvider provider, IdTokenRequest request);
+
+    SocialLoginResponse registerMember(String registerTokenValue, RegisterTokenRequest request);
 
     TokenReissueResponse reissueToken(String refreshTokenValue);
 

--- a/popi-auth-service/src/main/java/com/lgcns/service/JwtTokenService.java
+++ b/popi-auth-service/src/main/java/com/lgcns/service/JwtTokenService.java
@@ -5,6 +5,7 @@ import com.lgcns.domain.MemberRole;
 import com.lgcns.domain.RefreshToken;
 import com.lgcns.dto.AccessTokenDto;
 import com.lgcns.dto.RefreshTokenDto;
+import com.lgcns.dto.RegisterTokenDto;
 import com.lgcns.error.exception.CustomException;
 import com.lgcns.exception.AuthErrorCode;
 import com.lgcns.repository.RefreshTokenRepository;
@@ -36,6 +37,10 @@ public class JwtTokenService {
         return token;
     }
 
+    public String createRegisterToken(String oauthId, String oauthProvider) {
+        return jwtUtil.generateRegisterToken(oauthId, oauthProvider);
+    }
+
     public RefreshTokenDto reissueRefreshToken(RefreshTokenDto oldRefreshTokenDto) {
         RefreshToken refreshToken =
                 refreshTokenRepository
@@ -58,5 +63,9 @@ public class JwtTokenService {
 
     public RefreshTokenDto validateRefreshToken(String refreshToken) {
         return jwtUtil.parseRefreshToken(refreshToken);
+    }
+
+    public RegisterTokenDto validateRegisterToken(String registerToken) {
+        return jwtUtil.parseRegisterToken(registerToken);
     }
 }

--- a/popi-auth-service/src/main/java/com/lgcns/util/JwtUtil.java
+++ b/popi-auth-service/src/main/java/com/lgcns/util/JwtUtil.java
@@ -5,6 +5,7 @@ import static com.lgcns.constants.SecurityConstants.TOKEN_ROLE_NAME;
 import com.lgcns.domain.MemberRole;
 import com.lgcns.dto.AccessTokenDto;
 import com.lgcns.dto.RefreshTokenDto;
+import com.lgcns.dto.RegisterTokenDto;
 import com.lgcns.infra.jwt.JwtProperties;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
@@ -68,6 +69,22 @@ public class JwtUtil {
                     Long.parseLong(claims.getBody().getSubject()),
                     refreshTokenValue,
                     jwtProperties.refreshTokenExpirationTime());
+        } catch (ExpiredJwtException e) {
+            return null;
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    public RegisterTokenDto parseRegisterToken(String registerTokenValue)
+            throws ExpiredJwtException {
+        try {
+            Jws<Claims> claims = getClaims(registerTokenValue, getRegisterTokenKey());
+
+            return RegisterTokenDto.of(
+                    claims.getBody().getSubject(),
+                    claims.getBody().get("provider", String.class),
+                    registerTokenValue);
         } catch (ExpiredJwtException e) {
             return null;
         } catch (Exception e) {

--- a/popi-auth-service/src/main/java/com/lgcns/util/JwtUtil.java
+++ b/popi-auth-service/src/main/java/com/lgcns/util/JwtUtil.java
@@ -53,6 +53,13 @@ public class JwtUtil {
         return buildRefreshToken(memberId, issuedAt, expiredAt);
     }
 
+    public String generateRegisterToken(String oauthId, String oauthProvider) {
+        Date issuedAt = new Date();
+        Date expiredAt =
+                new Date(issuedAt.getTime() + jwtProperties.registerTokenExpirationMilliTime());
+        return buildRegisterToken(oauthId, oauthProvider, issuedAt, expiredAt);
+    }
+
     public RefreshTokenDto parseRefreshToken(String refreshTokenValue) throws ExpiredJwtException {
         try {
             Jws<Claims> claims = getClaims(refreshTokenValue, getRefreshTokenKey());
@@ -80,6 +87,10 @@ public class JwtUtil {
         return Keys.hmacShaKeyFor(jwtProperties.refreshTokenSecret().getBytes());
     }
 
+    private Key getRegisterTokenKey() {
+        return Keys.hmacShaKeyFor(jwtProperties.registerTokenSecret().getBytes());
+    }
+
     private String buildAccessToken(
             Long memberId, MemberRole memberRole, Date issuedAt, Date expiredAt) {
         return Jwts.builder()
@@ -99,6 +110,18 @@ public class JwtUtil {
                 .setIssuedAt(issuedAt)
                 .setExpiration(expiredAt)
                 .signWith(getRefreshTokenKey())
+                .compact();
+    }
+
+    private String buildRegisterToken(
+            String oauthId, String oauthProvider, Date issuedAt, Date expiredAt) {
+        return Jwts.builder()
+                .setIssuer(jwtProperties.issuer())
+                .setSubject(oauthId)
+                .claim("provider", oauthProvider)
+                .setIssuedAt(issuedAt)
+                .setExpiration(expiredAt)
+                .signWith(getRegisterTokenKey())
                 .compact();
     }
 

--- a/popi-auth-service/src/main/resources/application-local.yml
+++ b/popi-auth-service/src/main/resources/application-local.yml
@@ -45,6 +45,8 @@ jwt:
   refresh-token-secret: ${JWT_REFRESH_TOKEN_SECRET}
   access-token-expiration-time: ${JWT_ACCESS_TOKEN_EXPIRATION_TIME:3600}
   refresh-token-expiration-time: ${JWT_REFRESH_TOKEN_EXPIRATION_TIME:172800}
+  register-token-secret: ${JWT_REGISTER_TOKEN_SECRET}
+  register-token-expiration-time: ${JWT_REGISTER_TOKEN_EXPIRATION_TIME:300}
   issuer: ${JWT_ISSUER}
 
 eureka:

--- a/popi-auth-service/src/test/java/com/lgcns/service/AuthServiceTest.java
+++ b/popi-auth-service/src/test/java/com/lgcns/service/AuthServiceTest.java
@@ -3,10 +3,7 @@ package com.lgcns.service;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 
-import com.lgcns.domain.Member;
-import com.lgcns.domain.MemberStatus;
-import com.lgcns.domain.OauthInfo;
-import com.lgcns.domain.RefreshToken;
+import com.lgcns.domain.*;
 import com.lgcns.error.exception.CustomException;
 import com.lgcns.exception.MemberErrorCode;
 import com.lgcns.repository.MemberRepository;
@@ -30,8 +27,10 @@ public class AuthServiceTest {
     private Member registerAuthenticatedMember() {
         Member member =
                 Member.createMember(
-                        "testNickName",
-                        OauthInfo.createOauthInfo("testOauthId", "testOauthProvider"));
+                        OauthInfo.createOauthInfo("testOauthId", "testOauthProvider"),
+                        "testNickname",
+                        MemberGender.MALE,
+                        MemberAge.TWENTIES);
         memberRepository.save(member);
 
         UserDetails userDetails =

--- a/popi-auth-service/src/test/resources/application.yml
+++ b/popi-auth-service/src/test/resources/application.yml
@@ -15,11 +15,15 @@ oidc:
   google:
     jwk-set-uri: https://www.googleapis.com/oauth2/v3/certs
     issuer: https://accounts.google.com
-    audience: ${GOOGLE_CLIENT_ID:}
+    audiences:
+      - ${GOOGLE_WEB_CLIENT_ID:}
+      - ${GOOGLE_ANDROID_CLIENT_ID:}
 
 jwt:
   access-token-secret: ${JWT_ACCESS_TOKEN_SECRET}
   refresh-token-secret: ${JWT_REFRESH_TOKEN_SECRET}
   access-token-expiration-time: ${JWT_ACCESS_TOKEN_EXPIRATION_TIME:3600}
   refresh-token-expiration-time: ${JWT_REFRESH_TOKEN_EXPIRATION_TIME:172800}
+  register-token-secret: ${JWT_REGISTER_TOKEN_SECRET}
+  register-token-expiration-time: ${JWT_REGISTER_TOKEN_EXPIRATION_TIME:300}
   issuer: ${JWT_ISSUER}


### PR DESCRIPTION
## 🌱 관련 이슈

- [LCR-197]

---
## 📌 작업 내용 및 특이사항

- 소셜 로그인 시 기존 유저와 신규 유저를 분기하여 처리하도록 로직을 추가하였습니다.
  - 기존 유저의 경우: Access Token 및 Refresh Token 발급 후 로그인 처리
  - 신규 유저의 경우: Register Token 발급 후 추가 정보 입력을 유도
- registerToken을 활용한 회원가입 기능을 구현하였습니다.
  - 발급된 registerToken을 이용해 닉네임, 연령대, 성별의 정보를 받아 회원가입을 완료합니다.
- 회원가입 완료 시 accessToken, refreshToken을 발급합니다.
- 소셜 로그인 응답에 `isRegistered` 필드를 포함하여, 클라이언트가 회원가입 여부를 판단할 수 있도록 하였습니다.
  - `true`: 기존 유저 → 토큰 발급됨
  - `false`: 신규 유저 → 추가 정보 입력 필요
- 이미 가입된 사용자가 registerToken으로 다시 회원가입을 시도하는 경우 예외 처리 (`ALREADY_REGISTERED`)를 추가하였습니다.
- 만료된 registerToken에 대한 예외 처리 (`EXPIRED_REGISTER_TOKEN`)를 구현하였습니다.

---
## 📚 참고사항

- registerToken은 JWT 기반으로 발급되며, 내부에 oauthId, oauthProvider 정보를 포함합니다.
- 온보딩 중 이탈한 경우 DB에 회원 정보가 저장되지 않으므로 별도 정리 로직은 필요하지 않습니다.

[LCR-197]: https://lgcns-retail.atlassian.net/browse/LCR-197?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ