### PR TITLE
feat: Feign 클라이언트용 커스텀 예외 디코딩 로직 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,7 @@ def jacocoExcludePatterns = [
         "**/*Filter*",
         "**/*Error*/**",
         "**/resources/**",
+        "**/error/**",
         "**/exception/**",
         "**/config/**",
         "**/controller/**",

--- a/popi-common/build.gradle
+++ b/popi-common/build.gradle
@@ -13,4 +13,7 @@ dependencies {
 
     // Actuator
     api 'org.springframework.boot:spring-boot-starter-actuator'
+
+    // Open Feign
+    implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
 }

--- a/popi-common/src/main/java/com/lgcns/config/FeignConfig.java
+++ b/popi-common/src/main/java/com/lgcns/config/FeignConfig.java
@@ -1,0 +1,17 @@
+package com.lgcns.config;
+
+import com.lgcns.error.feign.FeignErrorDecoder;
+import feign.codec.ErrorDecoder;
+import org.springframework.cloud.openfeign.EnableFeignClients;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableFeignClients("com.lgcns")
+public class FeignConfig {
+
+    @Bean
+    public ErrorDecoder errorDecoder() {
+        return new FeignErrorDecoder();
+    }
+}

--- a/popi-common/src/main/java/com/lgcns/error/feign/FeignErrorCode.java
+++ b/popi-common/src/main/java/com/lgcns/error/feign/FeignErrorCode.java
@@ -1,0 +1,25 @@
+package com.lgcns.error.feign;
+
+import com.lgcns.error.exception.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+public record FeignErrorCode(String errorName, String message, int statusCode)
+        implements ErrorCode {
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return HttpStatus.resolve(statusCode) != null
+                ? HttpStatus.resolve(statusCode)
+                : HttpStatus.INTERNAL_SERVER_ERROR;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+
+    @Override
+    public String getErrorName() {
+        return errorName;
+    }
+}

--- a/popi-common/src/main/java/com/lgcns/error/feign/FeignErrorDecoder.java
+++ b/popi-common/src/main/java/com/lgcns/error/feign/FeignErrorDecoder.java
@@ -1,0 +1,30 @@
+package com.lgcns.error.feign;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.lgcns.error.exception.CustomException;
+import feign.Response;
+import feign.codec.ErrorDecoder;
+import java.io.InputStream;
+
+public class FeignErrorDecoder implements ErrorDecoder {
+
+    private final ErrorDecoder defaultDecoder = new Default();
+
+    @Override
+    public Exception decode(String methodKey, Response response) {
+        try (InputStream body = response.body().asInputStream()) {
+            ObjectMapper objectMapper = new ObjectMapper();
+            JsonNode errorBody = objectMapper.readTree(body);
+
+            String errorClassName =
+                    errorBody.path("data").path("errorClassName").asText("FEIGN_ERROR");
+            String message = errorBody.path("data").path("message").asText("Feign 예외 디코딩 실패");
+
+            return new CustomException(
+                    new FeignErrorCode(errorClassName, message, response.status()));
+        } catch (Exception e) {
+            return defaultDecoder.decode(methodKey, response);
+        }
+    }
+}


### PR DESCRIPTION
## 🌱 관련 이슈

- [LCR-207]

---
## 📌 작업 내용 및 특이사항

- Feign 통신 중 발생한 예외를 GlobalResponse 구조로 디코딩하는 커스텀 예외 디코더를 구현했습니다.
- 응답에서 errorClassName, message, statusCode를 추출해 FeignErrorCode로 매핑하고, CustomException을 생성해 처리합니다.
- 디코딩 실패 시 DefaultErrorDecoder로 fallback 하도록 구성했습니다.
- 기존에 마이크로서비스 간 예외가 500으로 포장되던 문제를 해결하고, 정의된 에러 메시지와 상태코드가 그대로 전달되도록 개선했습니다.

---
## 📚 참고사항

- 본 커스텀 예외 디코딩 로직은 공통 모듈(common)의 FeignConfig에서 설정됩니다.
- 각 마이크로서비스에서 Feign 클라이언트를 사용할 경우, @FeignClient 어노테이션에 다음과 같이 configuration 속성을 지정해야 공통 예외 디코더가 적용됩니다.

```java
@FeignClient(name = "members", url = "${member-service-url}", configuration = FeignConfig.class)
public interface MemberServiceClient {}
```


[LCR-207]: https://lgcns-retail.atlassian.net/browse/LCR-207?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ