### PR TITLE
feat: 상품 전체 리스트 조회 기능 구현

### DIFF
--- a/popi-common/src/main/java/com/lgcns/response/SliceResponse.java
+++ b/popi-common/src/main/java/com/lgcns/response/SliceResponse.java
@@ -1,0 +1,5 @@
+package com.lgcns.response;
+
+import java.util.List;
+
+public record SliceResponse<T>(List<T> content, boolean isLast) {}

--- a/popi-popup-service/build.gradle
+++ b/popi-popup-service/build.gradle
@@ -15,4 +15,7 @@ dependencies {
 
     // Spring Cloud Open Feign
     implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
+
+    // WireMock
+    testImplementation 'org.springframework.cloud:spring-cloud-contract-wiremock:4.2.1'
 }

--- a/popi-popup-service/src/main/java/com/lgcns/client/ManagerServiceClient.java
+++ b/popi-popup-service/src/main/java/com/lgcns/client/ManagerServiceClient.java
@@ -1,0 +1,18 @@
+package com.lgcns.client;
+
+import com.lgcns.dto.item.response.ItemInfoResponse;
+import com.lgcns.response.SliceResponse;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@FeignClient(name = "popi-manager-service", url = "${manager-service-url:}")
+public interface ManagerServiceClient {
+
+    @GetMapping("/internal/popups/{popupId}/items")
+    SliceResponse<ItemInfoResponse> findAllItems(
+            @PathVariable(name = "popupId") Long popupId,
+            @RequestParam(name = "lastItemId", required = false) Long lastItemId,
+            @RequestParam(name = "size", defaultValue = "4") int size);
+}

--- a/popi-popup-service/src/main/java/com/lgcns/client/ManagerServiceClient.java
+++ b/popi-popup-service/src/main/java/com/lgcns/client/ManagerServiceClient.java
@@ -14,5 +14,5 @@ public interface ManagerServiceClient {
     SliceResponse<ItemInfoResponse> findAllItems(
             @PathVariable(name = "popupId") Long popupId,
             @RequestParam(name = "lastItemId", required = false) Long lastItemId,
-            @RequestParam(name = "size", defaultValue = "4") int size);
+            @RequestParam(name = "size", defaultValue = "8") int size);
 }

--- a/popi-popup-service/src/main/java/com/lgcns/config/FeignConfig.java
+++ b/popi-popup-service/src/main/java/com/lgcns/config/FeignConfig.java
@@ -1,0 +1,8 @@
+package com.lgcns.config;
+
+import org.springframework.cloud.openfeign.EnableFeignClients;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableFeignClients(basePackages = "com.lgcns.client")
+public class FeignConfig {}

--- a/popi-popup-service/src/main/java/com/lgcns/controller/ItemController.java
+++ b/popi-popup-service/src/main/java/com/lgcns/controller/ItemController.java
@@ -21,7 +21,7 @@ public class ItemController {
     public SliceResponse<ItemInfoResponse> userItemFindAll(
             @PathVariable(name = "popupId") Long popupId,
             @RequestParam(name = "lastItemId", required = false) Long lastItemId,
-            @RequestParam(name = "size", defaultValue = "4") int size) {
+            @RequestParam(name = "size", defaultValue = "8") int size) {
         return itemService.findAllItems(popupId, lastItemId, size);
     }
 }

--- a/popi-popup-service/src/main/java/com/lgcns/controller/ItemController.java
+++ b/popi-popup-service/src/main/java/com/lgcns/controller/ItemController.java
@@ -1,0 +1,27 @@
+package com.lgcns.controller;
+
+import com.lgcns.dto.item.response.ItemInfoResponse;
+import com.lgcns.response.SliceResponse;
+import com.lgcns.service.item.ItemService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/popups/{popupId}/items")
+@Tag(name = "2. 상품 API", description = "상품 관련 API 입니다.")
+public class ItemController {
+
+    private final ItemService itemService;
+
+    @GetMapping
+    @Operation(summary = "상품 목록 조회", description = "현재 팝업의 모든 상품을 무한 스크롤을 위하여 페이징 처리한 뒤 반환합니다.")
+    public SliceResponse<ItemInfoResponse> userItemFindAll(
+            @PathVariable(name = "popupId") Long popupId,
+            @RequestParam(name = "lastItemId", required = false) Long lastItemId,
+            @RequestParam(name = "size", defaultValue = "4") int size) {
+        return itemService.findAllItems(popupId, lastItemId, size);
+    }
+}

--- a/popi-popup-service/src/main/java/com/lgcns/dto/item/response/ItemInfoResponse.java
+++ b/popi-popup-service/src/main/java/com/lgcns/dto/item/response/ItemInfoResponse.java
@@ -1,0 +1,13 @@
+package com.lgcns.dto.item.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record ItemInfoResponse(
+        @Schema(description = "상품 ID", example = "1") Long itemId,
+        @Schema(description = "상품명", example = "지수 포토카드") String name,
+        @Schema(description = "상품 이미지 URL", example = "https://bucket/asdf") String imageUrl,
+        @Schema(description = "상품 가격", example = "50000") int price) {
+    public static ItemInfoResponse of(Long itemId, String name, String imageUrl, int price) {
+        return new ItemInfoResponse(itemId, name, imageUrl, price);
+    }
+}

--- a/popi-popup-service/src/main/java/com/lgcns/service/item/ItemService.java
+++ b/popi-popup-service/src/main/java/com/lgcns/service/item/ItemService.java
@@ -1,0 +1,8 @@
+package com.lgcns.service.item;
+
+import com.lgcns.dto.item.response.ItemInfoResponse;
+import com.lgcns.response.SliceResponse;
+
+public interface ItemService {
+    SliceResponse<ItemInfoResponse> findAllItems(Long popupId, Long lastItemId, int size);
+}

--- a/popi-popup-service/src/main/java/com/lgcns/service/item/ItemServiceImpl.java
+++ b/popi-popup-service/src/main/java/com/lgcns/service/item/ItemServiceImpl.java
@@ -1,0 +1,19 @@
+package com.lgcns.service.item;
+
+import com.lgcns.client.ManagerServiceClient;
+import com.lgcns.dto.item.response.ItemInfoResponse;
+import com.lgcns.response.SliceResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ItemServiceImpl implements ItemService {
+
+    private final ManagerServiceClient managerServiceClient;
+
+    @Override
+    public SliceResponse<ItemInfoResponse> findAllItems(Long popupId, Long lastItemId, int size) {
+        return managerServiceClient.findAllItems(popupId, lastItemId, size);
+    }
+}

--- a/popi-popup-service/src/main/resources/application-local.yml
+++ b/popi-popup-service/src/main/resources/application-local.yml
@@ -28,3 +28,5 @@ spring-doc:
   enable-kotlin: false
   default-consumes-media-type: application/json
   default-produces-media-type: application/json
+
+manager-service-url: http://localhost:8080

--- a/popi-popup-service/src/test/java/com/lgcns/WireMockIntegrationTest.java
+++ b/popi-popup-service/src/test/java/com/lgcns/WireMockIntegrationTest.java
@@ -1,0 +1,29 @@
+package com.lgcns;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.contract.wiremock.AutoConfigureWireMock;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@AutoConfigureWireMock(port = 0)
+@TestPropertySource(properties = {"manager-service-url=http://localhost:${wiremock.server.port}"})
+public abstract class WireMockIntegrationTest {
+
+    @Autowired protected WireMockServer wireMockServer;
+
+    @BeforeEach
+    void restartWireMock() {
+        wireMockServer.resetAll();
+    }
+
+    @AfterEach
+    void resetWireMock() {
+        wireMockServer.resetAll();
+    }
+}

--- a/popi-popup-service/src/test/java/com/lgcns/service/ItemServiceTest.java
+++ b/popi-popup-service/src/test/java/com/lgcns/service/ItemServiceTest.java
@@ -1,0 +1,190 @@
+package com.lgcns.service;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.tomakehurst.wiremock.client.MappingBuilder;
+import com.lgcns.WireMockIntegrationTest;
+import com.lgcns.dto.item.response.ItemInfoResponse;
+import com.lgcns.response.SliceResponse;
+import com.lgcns.service.item.ItemService;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+
+public class ItemServiceTest extends WireMockIntegrationTest {
+
+    @Autowired private ItemService itemService;
+    @Autowired private ObjectMapper objectMapper;
+
+    private final Long popupId = 1L;
+
+    @BeforeEach
+    void setUp() throws JsonProcessingException {
+        String responseBody1 =
+                objectMapper.writeValueAsString(
+                        Map.of(
+                                "content",
+                                List.of(
+                                        Map.of(
+                                                "itemId",
+                                                24,
+                                                "name",
+                                                "크룽크 빅쿠션",
+                                                "imageUrl",
+                                                "https://ygselect.com/web/product/big/shop1_c46529e55a48ad83a68b0f78540465e8.jpg",
+                                                "price",
+                                                25000),
+                                        Map.of(
+                                                "itemId",
+                                                23,
+                                                "name",
+                                                "크룽크 미니쿠션",
+                                                "imageUrl",
+                                                "https://ygselect.com/web/product/big/shop1_6e08c64b2daaf6f2142cbd32c9c7a38a.jpg",
+                                                "price",
+                                                18000),
+                                        Map.of(
+                                                "itemId",
+                                                22,
+                                                "name",
+                                                "크룽크 키링",
+                                                "imageUrl",
+                                                "https://ygselect.com/web/product/big/shop1_d2725a478a33ccaa10b1b7f8697f5c9d.png",
+                                                "price",
+                                                14000),
+                                        Map.of(
+                                                "itemId",
+                                                21,
+                                                "name",
+                                                "크룽크 손목인형",
+                                                "imageUrl",
+                                                "https://ygselect.com/web/product/big/202403/P0000HDL.jpg",
+                                                "price",
+                                                7000)),
+                                "isLast",
+                                false));
+
+        String responseBody2 =
+                objectMapper.writeValueAsString(
+                        Map.of(
+                                "content",
+                                List.of(
+                                        Map.of(
+                                                "itemId",
+                                                4,
+                                                "name",
+                                                "DAZED 리사",
+                                                "imageUrl",
+                                                "https://image.aladin.co.kr/product/17920/59/cover500/k142534034_1.jpg",
+                                                "price",
+                                                8000),
+                                        Map.of(
+                                                "itemId",
+                                                3,
+                                                "name",
+                                                "DAZED 제니",
+                                                "imageUrl",
+                                                "https://image.aladin.co.kr/product/28453/14/cover500/k572835617_1.jpg",
+                                                "price",
+                                                9500),
+                                        Map.of(
+                                                "itemId",
+                                                2,
+                                                "name",
+                                                "DAZED 로제",
+                                                "imageUrl",
+                                                "https://ygselect.com/web/product/big/202404/257d66b0a1eca57af67b6c792e68ed75.jpg",
+                                                "price",
+                                                15000),
+                                        Map.of(
+                                                "itemId",
+                                                1,
+                                                "name",
+                                                "DAZED 지수",
+                                                "imageUrl",
+                                                "https://ygselect.com/web/product/big/202402/P0000NMY.jpg",
+                                                "price",
+                                                15000)),
+                                "isLast",
+                                true));
+        stubFindAllItems(popupId, null, 4, 200, responseBody1);
+        stubFindAllItems(popupId, 5L, 4, 200, responseBody2);
+    }
+
+    @Nested
+    class 상품_목록_조회 {
+        @Test
+        void 상품_목록_조회에_성공한다() {
+            // given
+            int size = 4;
+
+            // when
+            SliceResponse<ItemInfoResponse> result = itemService.findAllItems(popupId, null, size);
+
+            // then
+            Assertions.assertAll(
+                    () -> assertThat(result).isNotNull(),
+                    () -> assertThat(result.content()).hasSize(4),
+
+                    // 각 항목의 필드 검증
+                    () -> assertThat(result.content().get(0).itemId()).isEqualTo(24L),
+                    () -> assertThat(result.content().get(1).itemId()).isEqualTo(23L),
+                    () -> assertThat(result.content().get(2).itemId()).isEqualTo(22L),
+                    () -> assertThat(result.content().get(3).itemId()).isEqualTo(21L),
+                    () -> assertThat(result.isLast()).isFalse() // isLast=false 검증
+                    );
+        }
+
+        @Test
+        void 마지막_상품까지_조회하면_is_last가_true를_반환한다() {
+            // given
+            Long lastItemId = 5L;
+            int size = 4;
+
+            // when
+            SliceResponse<ItemInfoResponse> result =
+                    itemService.findAllItems(popupId, lastItemId, size);
+
+            // then
+            Assertions.assertAll(
+                    () -> assertThat(result).isNotNull(),
+                    () -> assertThat(result.content()).hasSize(4),
+
+                    // 각 항목의 필드 검증
+                    () -> assertThat(result.content().get(0).itemId()).isEqualTo(4L),
+                    () -> assertThat(result.content().get(1).itemId()).isEqualTo(3L),
+                    () -> assertThat(result.content().get(2).itemId()).isEqualTo(2L),
+                    () -> assertThat(result.content().get(3).itemId()).isEqualTo(1L),
+                    () -> assertThat(result.isLast()).isTrue() // isLast=true 검증
+                    );
+        }
+    }
+
+    private void stubFindAllItems(
+            Long popupId, Long lastItemId, int size, int status, String body) {
+        MappingBuilder mappingBuilder =
+                get(urlPathEqualTo("/internal/popups/" + popupId + "/items"))
+                        .withQueryParam("size", equalTo(String.valueOf(size)));
+
+        if (lastItemId != null) {
+            mappingBuilder =
+                    mappingBuilder.withQueryParam(
+                            "lastItemId", equalTo(String.valueOf(lastItemId)));
+        }
+
+        wireMockServer.stubFor(
+                mappingBuilder.willReturn(
+                        aResponse()
+                                .withStatus(status)
+                                .withHeader("Content-Type", MediaType.APPLICATION_JSON_VALUE)
+                                .withBody(body)));
+    }
+}


### PR DESCRIPTION
## 🌱 관련 이슈

- [LCR-190]

---
## 📌 작업 내용 및 특이사항

- 상품 전체 리스트 조회 기능을 구현하였습니다.
- OpenFeign 클라이언트를 통해 Manager Service로부터 받아온 SliceResponse를 그대로 응답으로 반환합니다.
- WireMock을 사용하여 OpenFeign 클라이언트를 Mocking 하였습니다.
- ObjectMapper를 통해 WireMock stub에 사용될 테스트 데이터를 생성하였습니다.
- SliceResponse를 받아와서 클라이언트에게 전달하는 Item Service에서는 Slice 관련 의존성이 필요하지 않다고 판단해서 포함하지 않았고, 추가적으로 SliceResponse에 from 메서드도 생성하지 않았습니다.

---
## 📚 참고사항

-


[LCR-190]: https://lgcns-retail.atlassian.net/browse/LCR-190?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ