### PR TITLE
feat: 상품 검색 기능 구현

### DIFF
--- a/popi-popup-service/src/main/java/com/lgcns/client/ManagerServiceClient.java
+++ b/popi-popup-service/src/main/java/com/lgcns/client/ManagerServiceClient.java
@@ -11,7 +11,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 
 @FeignClient(
         name = "${manager.service.name}",
-        url = "${manager.service.url}",
+        url = "${manager.service.url:}",
         configuration = FeignConfig.class)
 public interface ManagerServiceClient {
 

--- a/popi-popup-service/src/main/java/com/lgcns/client/ManagerServiceClient.java
+++ b/popi-popup-service/src/main/java/com/lgcns/client/ManagerServiceClient.java
@@ -21,8 +21,9 @@ public interface ManagerServiceClient {
             @RequestParam(name = "size", defaultValue = "8") int size);
 
     @GetMapping("/internal/popups/{popupId}/items")
-    SliceResponse<ItemInfoResponse> findAllItems(
+    SliceResponse<ItemInfoResponse> findItemsByName(
             @PathVariable(name = "popupId") Long popupId,
+            @RequestParam(name = "searchName", required = false) String searchName,
             @RequestParam(name = "lastItemId", required = false) Long lastItemId,
             @RequestParam(name = "size", defaultValue = "8") int size);
 }

--- a/popi-popup-service/src/main/java/com/lgcns/externalApi/ItemController.java
+++ b/popi-popup-service/src/main/java/com/lgcns/externalApi/ItemController.java
@@ -4,6 +4,7 @@ import com.lgcns.dto.item.response.ItemInfoResponse;
 import com.lgcns.response.SliceResponse;
 import com.lgcns.service.item.ItemService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
@@ -17,11 +18,23 @@ public class ItemController {
     private final ItemService itemService;
 
     @GetMapping
-    @Operation(summary = "상품 목록 조회", description = "현재 팝업의 모든 상품을 무한 스크롤을 위하여 페이징 처리한 뒤 반환합니다.")
-    public SliceResponse<ItemInfoResponse> userItemFindAll(
-            @PathVariable(name = "popupId") Long popupId,
-            @RequestParam(name = "lastItemId", required = false) Long lastItemId,
-            @RequestParam(name = "size", defaultValue = "8") int size) {
-        return itemService.findAllItems(popupId, lastItemId, size);
+    @Operation(
+            summary = "상품 목록 조회",
+            description =
+                    "searchName을 포함하지 않으면 현재 팝업의 모든 상품을 무한 스크롤을 위하여 페이징 처리한 뒤 반환합니다.</br>"
+                            + "searchName을 포함하여 호출하면 상품명에 searchName이 포함된 모든 상품을 페이징 처리한 뒤 반환합니다.")
+    public SliceResponse<ItemInfoResponse> userItemFindByName(
+            @Parameter(description = "팝업 ID", example = "1") @PathVariable(name = "popupId")
+                    Long popupId,
+            @Parameter(description = "검색할 상품 이름 (비워두면 모든 상품을 반환합니다.)", example = "포토카드")
+                    @RequestParam(name = "searchName", required = false)
+                    String searchName,
+            @Parameter(description = "이전 페이지의 마지막 ID (첫 요청 시 비워두세요.)", example = "2")
+                    @RequestParam(name = "lastItemId", required = false)
+                    Long lastItemId,
+            @Parameter(description = "페이지 크기 (기본 8)", example = "8")
+                    @RequestParam(name = "size", defaultValue = "8")
+                    int size) {
+        return itemService.findItemsByName(popupId, searchName, lastItemId, size);
     }
 }

--- a/popi-popup-service/src/main/java/com/lgcns/externalApi/ItemController.java
+++ b/popi-popup-service/src/main/java/com/lgcns/externalApi/ItemController.java
@@ -27,14 +27,14 @@ public class ItemController {
             @Parameter(description = "팝업 ID", example = "1") @PathVariable(name = "popupId")
                     Long popupId,
             @Parameter(description = "검색할 상품 이름 (비워두면 모든 상품을 반환합니다.)", example = "포토카드")
-                    @RequestParam(name = "searchName", required = false)
-                    String searchName,
+                    @RequestParam(name = "keyWord", required = false)
+                    String keyWord,
             @Parameter(description = "이전 페이지의 마지막 ID (첫 요청 시 비워두세요.)", example = "2")
                     @RequestParam(name = "lastItemId", required = false)
                     Long lastItemId,
             @Parameter(description = "페이지 크기 (기본 8)", example = "8")
                     @RequestParam(name = "size", defaultValue = "8")
                     int size) {
-        return itemService.findItemsByName(popupId, searchName, lastItemId, size);
+        return itemService.findItemsByName(popupId, keyWord, lastItemId, size);
     }
 }

--- a/popi-popup-service/src/main/java/com/lgcns/service/item/ItemService.java
+++ b/popi-popup-service/src/main/java/com/lgcns/service/item/ItemService.java
@@ -4,5 +4,6 @@ import com.lgcns.dto.item.response.ItemInfoResponse;
 import com.lgcns.response.SliceResponse;
 
 public interface ItemService {
-    SliceResponse<ItemInfoResponse> findAllItems(Long popupId, Long lastItemId, int size);
+    SliceResponse<ItemInfoResponse> findItemsByName(
+            Long popupId, String searchName, Long lastItemId, int size);
 }

--- a/popi-popup-service/src/main/java/com/lgcns/service/item/ItemServiceImpl.java
+++ b/popi-popup-service/src/main/java/com/lgcns/service/item/ItemServiceImpl.java
@@ -13,7 +13,8 @@ public class ItemServiceImpl implements ItemService {
     private final ManagerServiceClient managerServiceClient;
 
     @Override
-    public SliceResponse<ItemInfoResponse> findAllItems(Long popupId, Long lastItemId, int size) {
-        return managerServiceClient.findAllItems(popupId, lastItemId, size);
+    public SliceResponse<ItemInfoResponse> findItemsByName(
+            Long popupId, String searchName, Long lastItemId, int size) {
+        return managerServiceClient.findItemsByName(popupId, searchName, lastItemId, size);
     }
 }

--- a/popi-popup-service/src/main/resources/application-local.yml
+++ b/popi-popup-service/src/main/resources/application-local.yml
@@ -31,5 +31,5 @@ spring-doc:
 
 manager:
   service:
-    name: popi-manager-service
+    name: managers
     url: http://localhost:8080

--- a/popi-popup-service/src/test/java/com/lgcns/WireMockIntegrationTest.java
+++ b/popi-popup-service/src/test/java/com/lgcns/WireMockIntegrationTest.java
@@ -16,12 +16,13 @@ public abstract class WireMockIntegrationTest {
     @Autowired protected WireMockServer wireMockServer;
 
     @BeforeEach
-    void restartWireMock() {
-        wireMockServer.resetAll();
+    void setUp() {
+        wireMockServer.stop();
+        wireMockServer.start();
     }
 
     @AfterEach
-    void resetWireMock() {
+    void afterEach() {
         wireMockServer.resetAll();
     }
 }

--- a/popi-popup-service/src/test/java/com/lgcns/service/ItemServiceTest.java
+++ b/popi-popup-service/src/test/java/com/lgcns/service/ItemServiceTest.java
@@ -13,7 +13,6 @@ import com.lgcns.service.item.ItemService;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -26,113 +25,58 @@ public class ItemServiceTest extends WireMockIntegrationTest {
 
     private final Long popupId = 1L;
 
-    @BeforeEach
-    void setUp() throws JsonProcessingException {
-        wireMockServer.resetAll();
-
-        String responseBody1 =
-                objectMapper.writeValueAsString(
-                        Map.of(
-                                "content",
-                                List.of(
-                                        Map.of(
-                                                "itemId",
-                                                24,
-                                                "name",
-                                                "크룽크 빅쿠션",
-                                                "imageUrl",
-                                                "https://ygselect.com/web/product/big/shop1_c46529e55a48ad83a68b0f78540465e8.jpg",
-                                                "price",
-                                                25000),
-                                        Map.of(
-                                                "itemId",
-                                                23,
-                                                "name",
-                                                "크룽크 미니쿠션",
-                                                "imageUrl",
-                                                "https://ygselect.com/web/product/big/shop1_6e08c64b2daaf6f2142cbd32c9c7a38a.jpg",
-                                                "price",
-                                                18000),
-                                        Map.of(
-                                                "itemId",
-                                                22,
-                                                "name",
-                                                "크룽크 키링",
-                                                "imageUrl",
-                                                "https://ygselect.com/web/product/big/shop1_d2725a478a33ccaa10b1b7f8697f5c9d.png",
-                                                "price",
-                                                14000),
-                                        Map.of(
-                                                "itemId",
-                                                21,
-                                                "name",
-                                                "크룽크 손목인형",
-                                                "imageUrl",
-                                                "https://ygselect.com/web/product/big/202403/P0000HDL.jpg",
-                                                "price",
-                                                7000)),
-                                "isLast",
-                                false));
-
-        String responseBody2 =
-                objectMapper.writeValueAsString(
-                        Map.of(
-                                "content",
-                                List.of(
-                                        Map.of(
-                                                "itemId",
-                                                4,
-                                                "name",
-                                                "DAZED 리사",
-                                                "imageUrl",
-                                                "https://image.aladin.co.kr/product/17920/59/cover500/k142534034_1.jpg",
-                                                "price",
-                                                8000),
-                                        Map.of(
-                                                "itemId",
-                                                3,
-                                                "name",
-                                                "DAZED 제니",
-                                                "imageUrl",
-                                                "https://image.aladin.co.kr/product/28453/14/cover500/k572835617_1.jpg",
-                                                "price",
-                                                9500),
-                                        Map.of(
-                                                "itemId",
-                                                2,
-                                                "name",
-                                                "DAZED 로제",
-                                                "imageUrl",
-                                                "https://ygselect.com/web/product/big/202404/257d66b0a1eca57af67b6c792e68ed75.jpg",
-                                                "price",
-                                                15000),
-                                        Map.of(
-                                                "itemId",
-                                                1,
-                                                "name",
-                                                "DAZED 지수",
-                                                "imageUrl",
-                                                "https://ygselect.com/web/product/big/202402/P0000NMY.jpg",
-                                                "price",
-                                                15000)),
-                                "isLast",
-                                true));
-
-        String emptyResponseBody =
-                objectMapper.writeValueAsString(Map.of("content", List.of(), "isLast", true));
-
-        stubFindItemsByName(popupId, null, null, 4, 200, responseBody1);
-        stubFindItemsByName(popupId, null, 5L, 4, 200, responseBody2);
-        stubFindItemsByName(popupId, "DAZED", null, 4, 200, responseBody2);
-        stubFindItemsByName(popupId, "EMPTY", null, 4, 200, emptyResponseBody);
-    }
-
     @Nested
-    class 상품_목록_조회 {
+    class 상품_목록을_조회할_때 {
         @Test
-        void 상품_목록_조회에_성공한다() {
+        void 데이터가_존재하면_상품_목록_조회에_성공한다() throws JsonProcessingException {
             // given
             int size = 4;
+
+            String responseBody =
+                    objectMapper.writeValueAsString(
+                            Map.of(
+                                    "content",
+                                    List.of(
+                                            Map.of(
+                                                    "itemId",
+                                                    24,
+                                                    "name",
+                                                    "크룽크 빅쿠션",
+                                                    "imageUrl",
+                                                    "https://ygselect.com/web/product/big/shop1_c46529e55a48ad83a68b0f78540465e8.jpg",
+                                                    "price",
+                                                    25000),
+                                            Map.of(
+                                                    "itemId",
+                                                    23,
+                                                    "name",
+                                                    "크룽크 미니쿠션",
+                                                    "imageUrl",
+                                                    "https://ygselect.com/web/product/big/shop1_6e08c64b2daaf6f2142cbd32c9c7a38a.jpg",
+                                                    "price",
+                                                    18000),
+                                            Map.of(
+                                                    "itemId",
+                                                    22,
+                                                    "name",
+                                                    "크룽크 키링",
+                                                    "imageUrl",
+                                                    "https://ygselect.com/web/product/big/shop1_d2725a478a33ccaa10b1b7f8697f5c9d.png",
+                                                    "price",
+                                                    14000),
+                                            Map.of(
+                                                    "itemId",
+                                                    21,
+                                                    "name",
+                                                    "크룽크 손목인형",
+                                                    "imageUrl",
+                                                    "https://ygselect.com/web/product/big/202403/P0000HDL.jpg",
+                                                    "price",
+                                                    7000)),
+                                    "isLast",
+                                    false));
+
+            stubFindItemsByName(popupId, null, null, 4, 200, responseBody);
 
             // when
             SliceResponse<ItemInfoResponse> result =
@@ -153,10 +97,56 @@ public class ItemServiceTest extends WireMockIntegrationTest {
         }
 
         @Test
-        void 마지막_상품까지_조회하면_is_last가_true를_반환한다() {
+        void 마지막_상품까지_조회하면_is_last가_true를_반환한다() throws JsonProcessingException {
             // given
             Long lastItemId = 5L;
             int size = 4;
+
+            String responseBody =
+                    objectMapper.writeValueAsString(
+                            Map.of(
+                                    "content",
+                                    List.of(
+                                            Map.of(
+                                                    "itemId",
+                                                    4,
+                                                    "name",
+                                                    "DAZED 리사",
+                                                    "imageUrl",
+                                                    "https://image.aladin.co.kr/product/17920/59/cover500/k142534034_1.jpg",
+                                                    "price",
+                                                    8000),
+                                            Map.of(
+                                                    "itemId",
+                                                    3,
+                                                    "name",
+                                                    "DAZED 제니",
+                                                    "imageUrl",
+                                                    "https://image.aladin.co.kr/product/28453/14/cover500/k572835617_1.jpg",
+                                                    "price",
+                                                    9500),
+                                            Map.of(
+                                                    "itemId",
+                                                    2,
+                                                    "name",
+                                                    "DAZED 로제",
+                                                    "imageUrl",
+                                                    "https://ygselect.com/web/product/big/202404/257d66b0a1eca57af67b6c792e68ed75.jpg",
+                                                    "price",
+                                                    15000),
+                                            Map.of(
+                                                    "itemId",
+                                                    1,
+                                                    "name",
+                                                    "DAZED 지수",
+                                                    "imageUrl",
+                                                    "https://ygselect.com/web/product/big/202402/P0000NMY.jpg",
+                                                    "price",
+                                                    15000)),
+                                    "isLast",
+                                    true));
+
+            stubFindItemsByName(popupId, null, 5L, 4, 200, responseBody);
 
             // when
             SliceResponse<ItemInfoResponse> result =
@@ -177,10 +167,56 @@ public class ItemServiceTest extends WireMockIntegrationTest {
         }
 
         @Test
-        void 상품_검색에_성공한다() {
+        void 검색어에_대해_결과가_존재하면_상품_검색에_성공한다() throws JsonProcessingException {
             // given
             String searchName = "DAZED";
             int size = 4;
+
+            String responseBody =
+                    objectMapper.writeValueAsString(
+                            Map.of(
+                                    "content",
+                                    List.of(
+                                            Map.of(
+                                                    "itemId",
+                                                    4,
+                                                    "name",
+                                                    "DAZED 리사",
+                                                    "imageUrl",
+                                                    "https://image.aladin.co.kr/product/17920/59/cover500/k142534034_1.jpg",
+                                                    "price",
+                                                    8000),
+                                            Map.of(
+                                                    "itemId",
+                                                    3,
+                                                    "name",
+                                                    "DAZED 제니",
+                                                    "imageUrl",
+                                                    "https://image.aladin.co.kr/product/28453/14/cover500/k572835617_1.jpg",
+                                                    "price",
+                                                    9500),
+                                            Map.of(
+                                                    "itemId",
+                                                    2,
+                                                    "name",
+                                                    "DAZED 로제",
+                                                    "imageUrl",
+                                                    "https://ygselect.com/web/product/big/202404/257d66b0a1eca57af67b6c792e68ed75.jpg",
+                                                    "price",
+                                                    15000),
+                                            Map.of(
+                                                    "itemId",
+                                                    1,
+                                                    "name",
+                                                    "DAZED 지수",
+                                                    "imageUrl",
+                                                    "https://ygselect.com/web/product/big/202402/P0000NMY.jpg",
+                                                    "price",
+                                                    15000)),
+                                    "isLast",
+                                    true));
+
+            stubFindItemsByName(popupId, searchName, null, 4, 200, responseBody);
 
             // when
             SliceResponse<ItemInfoResponse> result =
@@ -201,10 +237,15 @@ public class ItemServiceTest extends WireMockIntegrationTest {
         }
 
         @Test
-        void 상품_검색_결과가_없으면_빈_리스트를_반환한다() {
+        void 검색어에_대해_결과가_없으면_빈_리스트를_반환한다() throws JsonProcessingException {
             // given
             String searchName = "EMPTY";
             int size = 4;
+
+            String emptyResponseBody =
+                    objectMapper.writeValueAsString(Map.of("content", List.of(), "isLast", true));
+
+            stubFindItemsByName(popupId, searchName, null, 4, 200, emptyResponseBody);
 
             // when
             SliceResponse<ItemInfoResponse> result =

--- a/popi-popup-service/src/test/resources/application-test.yml
+++ b/popi-popup-service/src/test/resources/application-test.yml
@@ -5,5 +5,5 @@ spring:
 
 manager:
   service:
-    name: popi-manager-service
+    name: managers
     url: http://localhost:${wiremock.server.port}


### PR DESCRIPTION
## 🌱 관련 이슈

- [LCR-191]

---
## 📌 작업 내용 및 특이사항

- 상품 검색 기능을 구현하였습니다.
- 전체 상품 조회 API와 통합하여 구현하였으며, keyWord의 포함 여부에 따라 전체 상품 또는 검색 결과가 반환됩니다.
- ManagerServiceClient의 설정 파일을 common 모듈의 FeignConfig로 변경하였습니다.
- Manager Service name, url을 수정하고 application-test.yml 파일을 추가하였습니다.
- 각 테스트가 실행될 때마다 wireMock stub을 제거하도록 resetAll() 메서드를 추가하였습니다.
- 상품 검색이 성공한 경우, 검색 결과가 없는 경우에 대해 테스트 코드를 작성하였으며, 별도의 예외 처리는 추가하지 않았습니다.

---
## 📚 참고사항

-


[LCR-191]: https://lgcns-retail.atlassian.net/browse/LCR-191?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ