### PR TITLE
feat: 예약 후 설문지 조회 구현

### DIFF
--- a/popi-reservation-service/src/main/java/com/lgcns/client/ManagerServiceClient.java
+++ b/popi-reservation-service/src/main/java/com/lgcns/client/ManagerServiceClient.java
@@ -2,17 +2,22 @@ package com.lgcns.client;
 
 import com.lgcns.client.dto.MonthlyReservationResponse;
 import com.lgcns.config.FeignConfig;
+import com.lgcns.dto.response.SurveyChoiceResponse;
+import java.util.List;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
 
 @FeignClient(
-        name = "popi-manager-service",
-        url = "${manager-service-url:}",
+        name = "${manager.service.name}",
+        url = "${manager.service.url:}",
         configuration = FeignConfig.class)
 public interface ManagerServiceClient {
     @GetMapping("/internal/reservations/popups/{popupId}")
     MonthlyReservationResponse findMonthlyReservation(
             @PathVariable Long popupId, @RequestParam String date);
+
+    @GetMapping("/internal/reservations/popups/{popupId}/survey")
+    List<SurveyChoiceResponse> findSurveyChoicesByPopupId(@PathVariable Long popupId);
 }

--- a/popi-reservation-service/src/main/java/com/lgcns/dto/response/SurveyChoiceResponse.java
+++ b/popi-reservation-service/src/main/java/com/lgcns/dto/response/SurveyChoiceResponse.java
@@ -1,0 +1,13 @@
+package com.lgcns.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+
+public record SurveyChoiceResponse(
+        @Schema(description = "DB에 등록된 설문지 번호", example = "2") Long surveyId,
+        @Schema(description = "선지 번호 및 내용", implementation = SurveyOption.class)
+                List<SurveyOption> options) {
+    public static SurveyChoiceResponse of(Long surveyId, List<SurveyOption> options) {
+        return new SurveyChoiceResponse(surveyId, options);
+    }
+}

--- a/popi-reservation-service/src/main/java/com/lgcns/dto/response/SurveyOption.java
+++ b/popi-reservation-service/src/main/java/com/lgcns/dto/response/SurveyOption.java
@@ -1,0 +1,11 @@
+package com.lgcns.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record SurveyOption(
+        @Schema(description = "선지 번호", example = "1") Long choiceId,
+        @Schema(description = "선지 내용", example = "포스터") String content) {
+    public static SurveyOption of(Long choiceId, String content) {
+        return new SurveyOption(choiceId, content);
+    }
+}

--- a/popi-reservation-service/src/main/java/com/lgcns/externalApi/MemberReservationController.java
+++ b/popi-reservation-service/src/main/java/com/lgcns/externalApi/MemberReservationController.java
@@ -1,10 +1,10 @@
 package com.lgcns.externalApi;
 
 import com.lgcns.dto.response.AvailableDateResponse;
+import com.lgcns.dto.response.SurveyChoiceResponse;
 import com.lgcns.service.MemberReservationService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import com.lgcns.dto.response.SurveyChoiceResponse;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;

--- a/popi-reservation-service/src/main/java/com/lgcns/externalApi/MemberReservationController.java
+++ b/popi-reservation-service/src/main/java/com/lgcns/externalApi/MemberReservationController.java
@@ -4,6 +4,8 @@ import com.lgcns.dto.response.AvailableDateResponse;
 import com.lgcns.service.MemberReservationService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import com.lgcns.dto.response.SurveyChoiceResponse;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
@@ -21,5 +23,12 @@ public class MemberReservationController {
             @PathVariable Long popupId,
             @RequestParam String date) {
         return memberReservationService.findAvailableDate(memberId, popupId, date);
+    }
+
+    @GetMapping("/popups/{popupId}/survey")
+    @Operation(summary = "설문지 조회", description = "해당 팝업에 대한 설문지 선지들을 조회합니다.")
+    public List<SurveyChoiceResponse> choiceListByPopupIdFind(
+            @RequestHeader("member-id") String memberId, @PathVariable Long popupId) {
+        return memberReservationService.findSurveyChoicesByPopupId(memberId, popupId);
     }
 }

--- a/popi-reservation-service/src/main/java/com/lgcns/service/MemberReservationService.java
+++ b/popi-reservation-service/src/main/java/com/lgcns/service/MemberReservationService.java
@@ -1,7 +1,11 @@
 package com.lgcns.service;
 
 import com.lgcns.dto.response.AvailableDateResponse;
+import com.lgcns.dto.response.SurveyChoiceResponse;
+import java.util.List;
 
 public interface MemberReservationService {
     AvailableDateResponse findAvailableDate(String memberId, Long popupId, String date);
+
+    List<SurveyChoiceResponse> findSurveyChoicesByPopupId(String memberId, Long popupId);
 }

--- a/popi-reservation-service/src/main/java/com/lgcns/service/MemberReservationServiceImpl.java
+++ b/popi-reservation-service/src/main/java/com/lgcns/service/MemberReservationServiceImpl.java
@@ -50,6 +50,11 @@ public class MemberReservationServiceImpl implements MemberReservationService {
                 reservableDateList);
     }
 
+    @Override
+    public List<SurveyChoiceResponse> findSurveyChoicesByPopupId(String memberId, Long popupId) {
+        return managerServiceClient.findSurveyChoicesByPopupId(popupId);
+    }
+
     private void validateYearMonthFormat(String date) {
         try {
             YearMonth.parse(date);

--- a/popi-reservation-service/src/main/resources/application-local.yml
+++ b/popi-reservation-service/src/main/resources/application-local.yml
@@ -48,4 +48,7 @@ spring-doc:
   default-consumes-media-type: application/json
   default-produces-media-type: application/json
 
-manager-service-url: localhost:8080
+manager:
+  service:
+    name: managers
+    url: http://localhost:8080

--- a/popi-reservation-service/src/test/java/com/lgcns/WireMockIntegrationTest.java
+++ b/popi-reservation-service/src/test/java/com/lgcns/WireMockIntegrationTest.java
@@ -17,7 +17,8 @@ public abstract class WireMockIntegrationTest {
 
     @BeforeEach
     void restartWireMock() {
-        wireMockServer.resetAll();
+        wireMockServer.stop();
+        wireMockServer.start();
     }
 
     @AfterEach

--- a/popi-reservation-service/src/test/java/com/lgcns/WireMockIntegrationTest.java
+++ b/popi-reservation-service/src/test/java/com/lgcns/WireMockIntegrationTest.java
@@ -12,7 +12,7 @@ import org.springframework.test.context.TestPropertySource;
 @SpringBootTest
 @ActiveProfiles("test")
 @AutoConfigureWireMock(port = 0)
-@TestPropertySource(properties = {"manager-service-url=http://localhost:${wiremock.server.port}"})
+@TestPropertySource(properties = {"name=${manager.service.name}", "url=${manager.service.url}"})
 public abstract class WireMockIntegrationTest {
 
     @Autowired protected WireMockServer wireMockServer;

--- a/popi-reservation-service/src/test/java/com/lgcns/WireMockIntegrationTest.java
+++ b/popi-reservation-service/src/test/java/com/lgcns/WireMockIntegrationTest.java
@@ -7,12 +7,10 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.cloud.contract.wiremock.AutoConfigureWireMock;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.TestPropertySource;
 
 @SpringBootTest
 @ActiveProfiles("test")
 @AutoConfigureWireMock(port = 0)
-@TestPropertySource(properties = {"name=${manager.service.name}", "url=${manager.service.url}"})
 public abstract class WireMockIntegrationTest {
 
     @Autowired protected WireMockServer wireMockServer;

--- a/popi-reservation-service/src/test/java/com/lgcns/service/MemberReservationServiceTest.java
+++ b/popi-reservation-service/src/test/java/com/lgcns/service/MemberReservationServiceTest.java
@@ -11,6 +11,7 @@ import com.lgcns.domain.MemberReservation;
 import com.lgcns.dto.response.AvailableDateResponse;
 import com.lgcns.dto.response.ReservableDate;
 import com.lgcns.dto.response.ReservableTime;
+import com.lgcns.dto.response.SurveyChoiceResponse;
 import com.lgcns.error.exception.CustomException;
 import com.lgcns.exception.MemberReservationErrorCode;
 import com.lgcns.repository.MemberReservationRepository;
@@ -297,11 +298,95 @@ class MemberReservationServiceTest extends WireMockIntegrationTest {
         }
     }
 
+    @Nested
+    class 설문지_조회할_때 {
+
+        @Test
+        void 팝업이_존재하면_조회에_성공한다() throws JsonProcessingException {
+            // given
+            String expectedResponse =
+                    objectMapper.writeValueAsString(
+                            List.of(
+                                    Map.of(
+                                            "surveyId",
+                                            1,
+                                            "options",
+                                            List.of(
+                                                    Map.of("choiceId", 1, "content", "보기1"),
+                                                    Map.of("choiceId", 2, "content", "보기2"),
+                                                    Map.of("choiceId", 3, "content", "보기3"),
+                                                    Map.of("choiceId", 4, "content", "보기4"),
+                                                    Map.of("choiceId", 5, "content", "보기5"))),
+                                    Map.of(
+                                            "surveyId",
+                                            2,
+                                            "options",
+                                            List.of(
+                                                    Map.of("choiceId", 6, "content", "보기1"),
+                                                    Map.of("choiceId", 7, "content", "보기2"),
+                                                    Map.of("choiceId", 8, "content", "보기3"),
+                                                    Map.of("choiceId", 9, "content", "보기4"),
+                                                    Map.of("choiceId", 10, "content", "보기5"))),
+                                    Map.of(
+                                            "surveyId",
+                                            3,
+                                            "options",
+                                            List.of(
+                                                    Map.of("choiceId", 11, "content", "보기1"),
+                                                    Map.of("choiceId", 12, "content", "보기2"),
+                                                    Map.of("choiceId", 13, "content", "보기3"),
+                                                    Map.of("choiceId", 14, "content", "보기4"),
+                                                    Map.of("choiceId", 15, "content", "보기5"))),
+                                    Map.of(
+                                            "surveyId",
+                                            4,
+                                            "options",
+                                            List.of(
+                                                    Map.of("choiceId", 16, "content", "보기1"),
+                                                    Map.of("choiceId", 17, "content", "보기2"),
+                                                    Map.of("choiceId", 18, "content", "보기3"),
+                                                    Map.of("choiceId", 19, "content", "보기4"),
+                                                    Map.of("choiceId", 20, "content", "보기5")))));
+
+            stubFindSurveyChoicesByPopupId(popupId, 200, expectedResponse);
+
+            // when
+            List<SurveyChoiceResponse> choices =
+                    memberReservationService.findSurveyChoicesByPopupId(memberId, popupId);
+
+            // then
+            assertThat(choices).isNotEmpty();
+            assertThat(choices.size()).isEqualTo(4);
+
+            for (SurveyChoiceResponse choice : choices) {
+                assertThat(choice.surveyId()).isNotNull();
+                assertThat(choice.options()).isNotEmpty();
+                assertThat(choice.options().size()).isEqualTo(5);
+            }
+        }
+    }
+
     private void stubFindAvailableDate(Long popupId, String date, int status, String body) {
         try {
             wireMockServer.stubFor(
                     get(urlPathEqualTo("/internal/reservations/popups/" + popupId))
                             .withQueryParam("date", equalTo(date))
+                            .willReturn(
+                                    aResponse()
+                                            .withStatus(status)
+                                            .withHeader(
+                                                    "Content-Type",
+                                                    MediaType.APPLICATION_JSON_VALUE)
+                                            .withBody(body)));
+        } catch (Exception e) {
+            throw new RuntimeException("직렬화 실패", e);
+        }
+    }
+
+    private void stubFindSurveyChoicesByPopupId(Long popupId, int status, String body) {
+        try {
+            wireMockServer.stubFor(
+                    get(urlPathEqualTo("/internal/reservations/popups/" + popupId + "/survey"))
                             .willReturn(
                                     aResponse()
                                             .withStatus(status)

--- a/popi-reservation-service/src/test/resources/application-test.yml
+++ b/popi-reservation-service/src/test/resources/application-test.yml
@@ -10,3 +10,8 @@ spring:
       port: ${REDIS_PORT:6379}
       password: ${REDIS_PASSWORD:}
       database: 1
+
+manager:
+    service:
+        name: managers
+        url: http://localhost:${wiremock.server.port}


### PR DESCRIPTION
## 🌱 관련 이슈

- [LCR-168]

---
## 📌 작업 내용 및 특이사항

- 예약 완료 후 사용자에게 설문지를 제공하기 위한 API를 구현했습니다.
- 기존 manager-service-url을 manager.service.url로 수정하여 설정 키를 일관성 있게 정리했습니다.
- application-test.yml에 manager.service.name 및 manager.service.url을 추가하여 WireMock 기반 테스트 환경을 구성했습니다.
- 서비스 흐름상 예외 케이스는 발생하지 않는다고 판단하여, 성공 케이스에 대한 테스트 코드만 작성했습니다.

---
## 📚 참고사항

- FeignClient에서 manager.service.name을 사용하므로, 테스트 환경에서도 해당 프로퍼티를 명시적으로 설정했습니다.
- 기존 테스트 코드 리팩토링은 추후 진행하겠습니다.


[LCR-168]: https://lgcns-retail.atlassian.net/browse/LCR-168?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ