### PR TITLE
chore: 결제 마이크로서비스 초기 세팅

### DIFF
--- a/popi-api-gateway/src/main/resources/application-local.yml
+++ b/popi-api-gateway/src/main/resources/application-local.yml
@@ -121,6 +121,23 @@ spring:
             - RewritePath=/notifications/(?<segment>.*), /$\{segment}
             - JwtAuthenticationFilter
 
+        - id: payment-docs
+          uri: lb://PAYMENTS
+          predicates:
+            - Path=/payments/v3/api-docs
+          filters:
+            - RemoveRequestHeader=Cookie
+            - RewritePath=/payments/(?<segment>.*), /$\{segment}
+        - id: payment-service
+          uri: lb://PAYMENTS
+          predicates:
+            - Path=/payments/**
+            - Method=POST
+          filters:
+            - RemoveRequestHeader=Cookie
+            - RewritePath=/payments/(?<segment>.*), /$\{segment}
+            - JwtAuthenticationFilter
+
       globalcors:
         cors-configurations:
           "[/**]":
@@ -158,6 +175,9 @@ springdoc:
     urls[4]:
       name: 알림 서비스
       url: /notifications/v3/api-docs
+    urls[5]:
+      name: 결제 서비스
+      url: /payments/v3/api-docs
 
 jwt:
   access-token-secret: ${JWT_ACCESS_TOKEN_SECRET}

--- a/popi-payment-service/Dockerfile
+++ b/popi-payment-service/Dockerfile
@@ -1,0 +1,4 @@
+FROM openjdk:17-slim
+ARG JAR_FILE=build/libs/*.jar
+COPY ${JAR_FILE} app.jar
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/popi-payment-service/build.gradle
+++ b/popi-payment-service/build.gradle
@@ -16,6 +16,10 @@ dependencies {
     // MySQL
     runtimeOnly 'com.mysql:mysql-connector-j'
 
+    // Flyway
+    implementation 'org.flywaydb:flyway-core'
+    implementation 'org.flywaydb:flyway-mysql'
+
     // JPA
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 

--- a/popi-payment-service/build.gradle
+++ b/popi-payment-service/build.gradle
@@ -1,0 +1,27 @@
+dependencies {
+    implementation project(':popi-domain')
+    implementation project(':popi-common')
+
+    // Eureka Client
+    implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
+
+    // Spring Cloud Kubernetes Discovery Client
+    implementation 'org.springframework.cloud:spring-cloud-starter-kubernetes-client'
+
+    // Spring Cloud Kubernetes Config Client
+    implementation 'org.springframework.cloud:spring-cloud-starter-kubernetes-client-config'
+
+    // H2
+    runtimeOnly 'com.h2database:h2'
+    // MySQL
+    runtimeOnly 'com.mysql:mysql-connector-j'
+
+    // JPA
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+
+    // Swagger
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.0'
+
+    // Spring Cloud Open Feign
+    implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
+}

--- a/popi-payment-service/src/main/java/com/lgcns/PopiPaymentServiceApplication.java
+++ b/popi-payment-service/src/main/java/com/lgcns/PopiPaymentServiceApplication.java
@@ -1,0 +1,12 @@
+package com.lgcns;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class PopiPaymentServiceApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(PopiPaymentServiceApplication.class, args);
+    }
+}

--- a/popi-payment-service/src/main/java/com/lgcns/config/SwaggerConfig.java
+++ b/popi-payment-service/src/main/java/com/lgcns/config/SwaggerConfig.java
@@ -1,0 +1,45 @@
+package com.lgcns.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.servers.Server;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@RequiredArgsConstructor
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI openAPI() {
+        return new OpenAPI()
+                .info(
+                        new Info()
+                                .title("PoPI Payment Server API")
+                                .description("PoPI 결제 서비스 API 명세서입니다.")
+                                .version("v0.0.1"))
+                .addServersItem(new Server().url("/payments"))
+                .components(authSetting())
+                .addSecurityItem(securityRequirement());
+    }
+
+    private Components authSetting() {
+        return new Components()
+                .addSecuritySchemes(
+                        "accessToken",
+                        new SecurityScheme()
+                                .type(SecurityScheme.Type.HTTP)
+                                .scheme("bearer")
+                                .bearerFormat("JWT")
+                                .in(SecurityScheme.In.HEADER)
+                                .name("Authorization"));
+    }
+
+    private SecurityRequirement securityRequirement() {
+        return new SecurityRequirement().addList("accessToken");
+    }
+}

--- a/popi-payment-service/src/main/resources/application-local.yml
+++ b/popi-payment-service/src/main/resources/application-local.yml
@@ -15,12 +15,16 @@ spring:
     password: ${DB_PASSWORD}
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: validate
     properties:
       hibernate:
-        format_sql: true
+        show_sql: true
         default_batch_fetch_size: 100
     open-in-view: false
+  flyway:
+    enabled: true
+    baseline-on-migrate: true
+    locations: classpath:db/migration
 
 eureka:
   instance:

--- a/popi-payment-service/src/main/resources/application-local.yml
+++ b/popi-payment-service/src/main/resources/application-local.yml
@@ -33,3 +33,11 @@ eureka:
 logging:
   level:
     org.hibernate.SQL: debug
+
+spring-doc:
+  api-docs:
+    version: openapi_3_1
+    enabled: true
+  enable-kotlin: false
+  default-consumes-media-type: application/json
+  default-produces-media-type: application/json

--- a/popi-payment-service/src/main/resources/application-local.yml
+++ b/popi-payment-service/src/main/resources/application-local.yml
@@ -1,0 +1,35 @@
+server:
+  port: 0
+
+spring:
+  application:
+    name: payments
+  cloud:
+    kubernetes:
+      config:
+        enabled: false
+  datasource:
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    url: jdbc:mysql://${MYSQL_HOST}:${MYSQL_PORT}/${PAYMENT_DB_NAME}?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
+    username: ${DB_USERNAME}
+    password: ${DB_PASSWORD}
+  jpa:
+    hibernate:
+      ddl-auto: create
+    properties:
+      hibernate:
+        format_sql: true
+        default_batch_fetch_size: 100
+    open-in-view: false
+
+eureka:
+  instance:
+    instance-id: ${spring.cloud.client.hostname}:${spring.application.instance_id:${random.value}}
+    leaseRenewalIntervalInSeconds: 10
+  client:
+    serviceUrl:
+      defaultZone: http://localhost:8761/eureka/
+
+logging:
+  level:
+    org.hibernate.SQL: debug

--- a/popi-payment-service/src/test/java/com/lgcns/PopiPaymentServiceApplicationTests.java
+++ b/popi-payment-service/src/test/java/com/lgcns/PopiPaymentServiceApplicationTests.java
@@ -1,0 +1,11 @@
+package com.lgcns;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class PopiPaymentServiceApplicationTests {
+
+    @Test
+    void contextLoads() {}
+}

--- a/popi-payment-service/src/test/resources/application-test.yml
+++ b/popi-payment-service/src/test/resources/application-test.yml
@@ -1,0 +1,3 @@
+spring:
+  datasource:
+    url: jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=false;MODE=MYSQL

--- a/popi-payment-service/src/test/resources/application-test.yml
+++ b/popi-payment-service/src/test/resources/application-test.yml
@@ -1,3 +1,7 @@
 spring:
+  profiles:
+    active: test
   datasource:
     url: jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=false;MODE=MYSQL
+  flyway:
+    enabled: false

--- a/settings.gradle
+++ b/settings.gradle
@@ -10,4 +10,5 @@ include(
         "popi-reservation-service",
         "popi-popup-service",
         "popi-notification-service",
+        "popi-payment-service"
 )


### PR DESCRIPTION
## 🌱 관련 이슈

- [LCR-217]

---
## 📌 작업 내용 및 특이사항

- 결제 마이크로서비스 초기 세팅을 진행하였습니다.
  - `application-local.yml`과 `application-test.yml`을 작성하였고, 기본적인 DB 접속 정보만 포함하였으며 로컬 환경에서는 Eureka 기반, Kubernetes 환경에서는 Spring Cloud Kubernetes Discovery 기반으로 서비스 디스커버리를 수행하도록 설정을 분리했습니다.
  - Docker 이미지 생성을 위한 Dockerfile을 추가하였습니다.
  - 결제 서비스의 모든 API가 인증이 필요하므로 API Gateway에 /payments/** 라우팅을 추가하고, Swagger 문서 경로(/payments/v3/api-docs)는 인증 필터를 거치지 않도록 별도 라우팅으로 우선 처리하였습니다.
  - Swagger UI를 통해 결제 서비스의 API 문서를 모두 확인할 수 있도록, API Gateway에서 springdoc 설정을 통합 관리하고 라우팅을 구성했습니다.
  - Kubernetes 배포는 `popi-ops` 레포지토리의 apps/payment-service 경로에 Helm 차트 추가 완료하였습니다.


[LCR-217]: https://lgcns-retail.atlassian.net/browse/LCR-217?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ