### PR TITLE
chore: 회원 서비스 flyway 설정

### DIFF
--- a/popi-member-service/build.gradle
+++ b/popi-member-service/build.gradle
@@ -16,6 +16,10 @@ dependencies {
     // MySQL
     runtimeOnly 'com.mysql:mysql-connector-j'
 
+    // Flyway
+    implementation 'org.flywaydb:flyway-core'
+    implementation 'org.flywaydb:flyway-mysql'
+
     // JPA
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 

--- a/popi-member-service/src/main/resources/application-local.yml
+++ b/popi-member-service/src/main/resources/application-local.yml
@@ -21,6 +21,10 @@ spring:
         format_sql: true
         default_batch_fetch_size: 100
     open-in-view: false
+  flyway:
+    enabled: true
+    baseline-on-migrate: true
+    locations: classpath:db/migration
 
 eureka:
   instance:

--- a/popi-member-service/src/main/resources/db/migration/V1__init.sql
+++ b/popi-member-service/src/main/resources/db/migration/V1__init.sql
@@ -1,0 +1,12 @@
+CREATE TABLE member (
+                         member_id BIGINT AUTO_INCREMENT PRIMARY KEY,
+                         nickname VARCHAR(255) NOT NULL,
+                         oauth_id VARCHAR(255) NOT NULL,
+                         oauth_provider VARCHAR(255) NOT NULL,
+                         age ENUM('TEENAGER', 'TWENTIES', 'THIRTIES', 'FORTIES_AND_ABOVE') NOT NULL,
+                         gender ENUM('MALE', 'FEMALE') NOT NULL,
+                         status ENUM('NORMAL', 'DELETED', 'FORBIDDEN') NOT NULL,
+                         role ENUM('ADMIN', 'USER') NOT NULL,
+                         created_at DATETIME NOT NULL,
+                         updated_at DATETIME
+);

--- a/popi-member-service/src/test/resources/application-test.yml
+++ b/popi-member-service/src/test/resources/application-test.yml
@@ -4,6 +4,8 @@ spring:
       on-profile: "test"
   datasource:
     url: jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=false;MODE=MYSQL
+  flyway:
+    enabled: false
 
 auth:
   service:


### PR DESCRIPTION
## 🌱 관련 이슈

- [LCR-175]

---
## 📌 작업 내용 및 특이사항

- 기존에는 ddl-auto: create 설정을 사용해 애플리케이션 실행 시마다 스키마를 재생성하고 있었습니다.
- 이로 인해 개발/운영 환경에 부적합할 뿐 아니라, 마이크로서비스 재기동 시점마다 소셜 로그인 전에 회원가입을 다시 진행해야 하는 불편함이 있었습니다.
- 개발/운영 환경에 적합한 방식으로 전환하기 위해 Flyway 기반의 마이그레이션 방식으로 변경하였습니다.
- 현재까지 작성된 테이블 스키마를 기준으로 초기 마이그레이션 SQL(V1__init.sql)을 추가하였습니다.


[LCR-175]: https://lgcns-retail.atlassian.net/browse/LCR-175?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ