### PR TITLE
chore: 예약 서비스 flyway 설정

### DIFF
--- a/popi-reservation-service/build.gradle
+++ b/popi-reservation-service/build.gradle
@@ -31,10 +31,14 @@ dependencies {
 
 	// QueryDSL
 	implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
-
 	annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
 	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
 	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 
+	// WireMock
 	testImplementation 'org.springframework.cloud:spring-cloud-contract-wiremock:4.2.1'
+
+	// Flyway
+	implementation 'org.flywaydb:flyway-core'
+	implementation 'org.flywaydb:flyway-mysql'
 }

--- a/popi-reservation-service/src/main/java/com/lgcns/domain/MemberReservation.java
+++ b/popi-reservation-service/src/main/java/com/lgcns/domain/MemberReservation.java
@@ -25,7 +25,7 @@ public class MemberReservation extends BaseTimeEntity {
 
     private Long popupId;
 
-    private String imageByte;
+    private String qrImage;
 
     private LocalDate reservationDate;
 
@@ -36,13 +36,13 @@ public class MemberReservation extends BaseTimeEntity {
             Long reservationId,
             Long memberId,
             Long popupId,
-            String imageByte,
+            String qrImage,
             LocalDate reservationDate,
             LocalTime reservationTime) {
         this.reservationId = reservationId;
         this.memberId = memberId;
         this.popupId = popupId;
-        this.imageByte = imageByte;
+        this.qrImage = qrImage;
         this.reservationDate = reservationDate;
         this.reservationTime = reservationTime;
     }
@@ -51,14 +51,14 @@ public class MemberReservation extends BaseTimeEntity {
             Long reservationId,
             Long memberId,
             Long popupId,
-            String imageByte,
+            String qrImage,
             LocalDate reservationDate,
             LocalTime reservationTime) {
         return MemberReservation.builder()
                 .reservationId(reservationId)
                 .memberId(memberId)
                 .popupId(popupId)
-                .imageByte(imageByte)
+                .qrImage(qrImage)
                 .reservationDate(reservationDate)
                 .reservationTime(reservationTime)
                 .build();

--- a/popi-reservation-service/src/main/resources/application-local.yml
+++ b/popi-reservation-service/src/main/resources/application-local.yml
@@ -27,6 +27,10 @@ spring:
       port: ${REDIS_PORT}
       password: ${REDIS_PASSWORD:}
       database: 1
+  flyway:
+    enabled: true
+    baseline-on-migrate: true
+    locations: classpath:db/migration
 
 eureka:
   instance:

--- a/popi-reservation-service/src/main/resources/db/migration/V1__init.sql
+++ b/popi-reservation-service/src/main/resources/db/migration/V1__init.sql
@@ -1,12 +1,12 @@
 CREATE TABLE member_reservation
 (
     member_reservation_id BIGINT AUTO_INCREMENT NOT NULL,
-    reservation_id        BIGINT NOT NULL,
-    member_id             BIGINT NOT NULL,
+    reservation_id        BIGINT   NOT NULL,
+    member_id             BIGINT   NOT NULL,
     popup_id              BIGINT NULL,
-    image_byte            BLOB NULL,
+    qr_image              TEXT NULL,
     reservation_date      DATE,
     reservation_time      TIME,
-    created_at DATETIME NOT NULL,
-    updated_at DATETIME
+    created_at            DATETIME NOT NULL,
+    updated_at            DATETIME
 );

--- a/popi-reservation-service/src/main/resources/db/migration/V1__init.sql
+++ b/popi-reservation-service/src/main/resources/db/migration/V1__init.sql
@@ -6,5 +6,7 @@ CREATE TABLE member_reservation
     popup_id              BIGINT NULL,
     image_byte            BLOB NULL,
     reservation_date      DATE,
-    reservation_time      TIME
+    reservation_time      TIME,
+    created_at DATETIME NOT NULL,
+    updated_at DATETIME
 );

--- a/popi-reservation-service/src/main/resources/db/migration/V1__init.sql
+++ b/popi-reservation-service/src/main/resources/db/migration/V1__init.sql
@@ -1,0 +1,10 @@
+CREATE TABLE member_reservation
+(
+    member_reservation_id BIGINT AUTO_INCREMENT NOT NULL,
+    reservation_id        BIGINT NOT NULL,
+    member_id             BIGINT NOT NULL,
+    popup_id              BIGINT NULL,
+    image_byte            BLOB NULL,
+    reservation_date      DATE,
+    reservation_time      TIME
+);

--- a/popi-reservation-service/src/test/resources/application-test.yml
+++ b/popi-reservation-service/src/test/resources/application-test.yml
@@ -10,6 +10,8 @@ spring:
       port: ${REDIS_PORT:6379}
       password: ${REDIS_PASSWORD:}
       database: 1
+  flyway:
+    enabled: false
 
 manager:
     service:


### PR DESCRIPTION
## 🌱 관련 이슈

- [LCR-218]

---
## 📌 작업 내용 및 특이사항

- 개발/운영 환경에 적합한 방식으로 전환하기 위해 Flyway 기반의 마이그레이션 방식으로 변경했습니다.
- 회원 예약 테이블 생성하는 초기 마이그레이션 SQL(V1__init.sql)을 추가했습니다.
- 비동기 업데이트 고려하여 popup_id, image_byte, reservation_date, reservation_time은 NULL을 허용했습니다.

---
## 📚 참고사항



[LCR-218]: https://lgcns-retail.atlassian.net/browse/LCR-218?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ