### PR TITLE
feat: 팝업 검색 기능 구현

### DIFF
--- a/popi-popup-service/src/main/java/com/lgcns/client/ManagerServiceClient.java
+++ b/popi-popup-service/src/main/java/com/lgcns/client/ManagerServiceClient.java
@@ -17,7 +17,8 @@ public interface ManagerServiceClient {
 
     @GetMapping("/internal/popups")
     SliceResponse<PopupInfoResponse> findAllPopups(
-            @RequestParam(name = "lastPopupId", defaultValue = "0") Long lastPopupId,
+            @RequestParam(name = "searchName", required = false) String searchName,
+            @RequestParam(name = "lastPopupId", required = false) Long lastPopupId,
             @RequestParam(name = "size", defaultValue = "8") int size);
 
     @GetMapping("/internal/popups/{popupId}/items")

--- a/popi-popup-service/src/main/java/com/lgcns/client/ManagerServiceClient.java
+++ b/popi-popup-service/src/main/java/com/lgcns/client/ManagerServiceClient.java
@@ -16,7 +16,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 public interface ManagerServiceClient {
 
     @GetMapping("/internal/popups")
-    SliceResponse<PopupInfoResponse> findAllPopups(
+    SliceResponse<PopupInfoResponse> findPopupsByName(
             @RequestParam(name = "searchName", required = false) String searchName,
             @RequestParam(name = "lastPopupId", required = false) Long lastPopupId,
             @RequestParam(name = "size", defaultValue = "8") int size);

--- a/popi-popup-service/src/main/java/com/lgcns/externalApi/PopupController.java
+++ b/popi-popup-service/src/main/java/com/lgcns/externalApi/PopupController.java
@@ -21,12 +21,15 @@ public class PopupController {
     @GetMapping("/popups")
     @Operation(summary = "팝업 목록 조회", description = "현재 운영중인 모든 팝업을 무한 스크롤을 위하여 페이징 처리한 뒤 반환합니다.")
     public SliceResponse<PopupInfoResponse> popupFindAll(
-            @Parameter(description = "이전 페이지의 마지막 ID (첫 요청 시 비워두세요.)", example = "2")
+            @Parameter(description = "검색할 팝업 이름 (비워두면 모든 팝업을 반환합니다.)", example = "black")
+                    @RequestParam(name = "keyWord", required = false)
+                    String keyWord,
+            @Parameter(description = "이전 페이지의 마지막 ID (첫 요청 시 비워두세요.)", example = "1")
                     @RequestParam(required = false)
                     Long lastPopupId,
             @Parameter(description = "페이지 크기 (기본 8)", example = "8")
                     @RequestParam(defaultValue = "8")
                     int size) {
-        return popupService.findAllPopups(lastPopupId, size);
+        return popupService.findPopupsByName(keyWord, lastPopupId, size);
     }
 }

--- a/popi-popup-service/src/main/java/com/lgcns/service/popup/PopupService.java
+++ b/popi-popup-service/src/main/java/com/lgcns/service/popup/PopupService.java
@@ -4,5 +4,6 @@ import com.lgcns.dto.popup.response.PopupInfoResponse;
 import com.lgcns.response.SliceResponse;
 
 public interface PopupService {
-    SliceResponse<PopupInfoResponse> findAllPopups(Long lastPopupId, int size);
+    SliceResponse<PopupInfoResponse> findPopupsByName(
+            String searchName, Long lastPopupId, int size);
 }

--- a/popi-popup-service/src/main/java/com/lgcns/service/popup/PopupServiceImpl.java
+++ b/popi-popup-service/src/main/java/com/lgcns/service/popup/PopupServiceImpl.java
@@ -12,7 +12,8 @@ public class PopupServiceImpl implements PopupService {
     private final ManagerServiceClient managerServiceClient;
 
     @Override
-    public SliceResponse<PopupInfoResponse> findAllPopups(Long lastPopupId, int size) {
-        return managerServiceClient.findAllPopups(lastPopupId, size);
+    public SliceResponse<PopupInfoResponse> findPopupsByName(
+            String searchName, Long lastPopupId, int size) {
+        return managerServiceClient.findPopupsByName(searchName, lastPopupId, size);
     }
 }

--- a/popi-popup-service/src/test/java/com/lgcns/service/PopupServiceTest.java
+++ b/popi-popup-service/src/test/java/com/lgcns/service/PopupServiceTest.java
@@ -212,6 +212,92 @@ public class PopupServiceTest extends WireMockIntegrationTest {
                                     .isEqualTo("뉴진스 팝업스토어"),
                     () -> assertThat(secondResult.isLast()).isTrue());
         }
+
+        @Test
+        void 검색어와_일치하는_데이터가_존재하면_결과_리스트를_반환한다() throws JsonProcessingException {
+            // given
+            String searchName = "BLACK";
+            Long lastPopupId = null;
+            int size = 8;
+
+            String responseBody =
+                    objectMapper.writeValueAsString(
+                            Map.of(
+                                    "content",
+                                    List.of(
+                                            Map.of(
+                                                    "popupId",
+                                                    3,
+                                                    "popupName",
+                                                    "BLACKPINK 팝업스토어",
+                                                    "imageUrl",
+                                                    "https://bucket/blackpink.jpg",
+                                                    "popupOpenDate",
+                                                    "2025-05-01",
+                                                    "popupCloseDate",
+                                                    "2025-06-01",
+                                                    "address",
+                                                    "서울특별시 강남구 테헤란로 12, 1층 201호")),
+                                    "isLast",
+                                    true));
+
+            stubFindPopupsByName(searchName, size, 200, responseBody);
+
+            // when
+            SliceResponse<PopupInfoResponse> result =
+                    popupService.findPopupsByName(searchName, lastPopupId, size);
+
+            // then
+            Assertions.assertAll(
+                    () -> assertThat(result).isNotNull(),
+                    () -> assertThat(result.content()).hasSize(1),
+                    () -> assertThat(result.content().get(0).popupId()).isEqualTo(3L),
+                    () ->
+                            assertThat(result.content().get(0).popupName())
+                                    .isEqualTo("BLACKPINK 팝업스토어"),
+                    () ->
+                            assertThat(result.content().get(0).imageUrl())
+                                    .isEqualTo("https://bucket/blackpink.jpg"),
+                    () ->
+                            assertThat(result.content().get(0).popupOpenDate())
+                                    .isEqualTo("2025-05-01"),
+                    () ->
+                            assertThat(result.content().get(0).popupCloseDate())
+                                    .isEqualTo("2025-06-01"),
+                    () ->
+                            assertThat(result.content().get(0).address())
+                                    .isEqualTo("서울특별시 강남구 테헤란로 12, 1층 201호"),
+                    () -> assertThat(result.isLast()).isTrue(),
+                    () ->
+                            assertThat(result.content())
+                                    .allSatisfy(
+                                            popup ->
+                                                    assertThat(popup.popupName())
+                                                            .contains(searchName)));
+        }
+
+        @Test
+        void 검색어와_일치하는_데이터가_없으면_빈_리스트를_반환한다() throws JsonProcessingException {
+            // given
+            String searchName = "NONEXISTENT";
+            Long lastPopupId = null;
+            int size = 8;
+
+            String emptyResponseBody =
+                    objectMapper.writeValueAsString(Map.of("content", List.of(), "isLast", true));
+
+            stubFindPopupsByName(searchName, size, 200, emptyResponseBody);
+
+            // when
+            SliceResponse<PopupInfoResponse> result =
+                    popupService.findPopupsByName(searchName, lastPopupId, size);
+
+            // then
+            Assertions.assertAll(
+                    () -> assertThat(result).isNotNull(),
+                    () -> assertThat(result.content()).isEmpty(),
+                    () -> assertThat(result.isLast()).isTrue());
+        }
     }
 
     private void stubFindAllPopups(Long lastPopupId, int size, int status, String body) {
@@ -231,7 +317,19 @@ public class PopupServiceTest extends WireMockIntegrationTest {
         wireMockServer.stubFor(
                 get(urlPathEqualTo("/internal/popups"))
                         .withQueryParam("size", equalTo(String.valueOf(size)))
-                        // lastPopupId 파라미터가 없는 경우
+                        .willReturn(
+                                aResponse()
+                                        .withStatus(status)
+                                        .withHeader(
+                                                "Content-Type", MediaType.APPLICATION_JSON_VALUE)
+                                        .withBody(body)));
+    }
+
+    private void stubFindPopupsByName(String searchName, int size, int status, String body) {
+        wireMockServer.stubFor(
+                get(urlPathEqualTo("/internal/popups"))
+                        .withQueryParam("searchName", equalTo(searchName))
+                        .withQueryParam("size", equalTo(String.valueOf(size)))
                         .willReturn(
                                 aResponse()
                                         .withStatus(status)

--- a/popi-popup-service/src/test/java/com/lgcns/service/PopupServiceTest.java
+++ b/popi-popup-service/src/test/java/com/lgcns/service/PopupServiceTest.java
@@ -81,7 +81,8 @@ public class PopupServiceTest extends WireMockIntegrationTest {
             stubFindAllPopups(lastPopupId, size, 200, responseBody);
 
             // when
-            SliceResponse<PopupInfoResponse> result = popupService.findAllPopups(lastPopupId, size);
+            SliceResponse<PopupInfoResponse> result =
+                    popupService.findPopupsByName(null, lastPopupId, size);
 
             // then
             assertThat(result).isNotNull();
@@ -101,7 +102,8 @@ public class PopupServiceTest extends WireMockIntegrationTest {
             stubFindAllPopupsWithoutLastId(size, 200, responseBody);
 
             // when
-            SliceResponse<PopupInfoResponse> result = popupService.findAllPopups(lastPopupId, size);
+            SliceResponse<PopupInfoResponse> result =
+                    popupService.findPopupsByName(null, lastPopupId, size);
 
             // then
             assertThat(result).isNotNull();
@@ -153,7 +155,7 @@ public class PopupServiceTest extends WireMockIntegrationTest {
 
             // when - 첫 번째 페이지 조회
             SliceResponse<PopupInfoResponse> firstResult =
-                    popupService.findAllPopups(firstLastPopupId, size);
+                    popupService.findPopupsByName(null, firstLastPopupId, size);
 
             // then - 첫 번째 페이지 검증
             Assertions.assertAll(
@@ -198,7 +200,7 @@ public class PopupServiceTest extends WireMockIntegrationTest {
 
             // when - 두 번째 페이지 조회
             SliceResponse<PopupInfoResponse> secondResult =
-                    popupService.findAllPopups(secondLastPopupId, size);
+                    popupService.findPopupsByName(null, secondLastPopupId, size);
 
             // then - 두 번째 페이지 검증
             Assertions.assertAll(


### PR DESCRIPTION
## 🌱 관련 이슈

- [LCR-186]

---
## 📌 작업 내용 및 특이사항

- 팝업 검색 기능을 구현했습니다.
- 전체 팝업 조회 API와 통합하여 구현하였으며, keyWord의 포함 여부에 따라 전체 팝업 또는 검색 결과가 반환됩니다.
- 상품 검색이 성공한 경우, 검색 결과가 없는 경우에 대해 테스트 코드를 작성하였으며, 별도의 예외 처리는 추가하지 않았습니다.
- 검색 결과가 없는 경우. 빈 리스트를 반환합니다.

---
## 📚 참고사항

-


[LCR-186]: https://lgcns-retail.atlassian.net/browse/LCR-186?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ