### PR TITLE
chore: 상품 마이크로서비스 분리 및 초기 세팅

### DIFF
--- a/popi-api-gateway/src/main/resources/application-local.yml
+++ b/popi-api-gateway/src/main/resources/application-local.yml
@@ -138,6 +138,13 @@ spring:
             - RewritePath=/payments/(?<segment>.*), /$\{segment}
             - JwtAuthenticationFilter
 
+        - id: item-docs
+          uri: lb://ITEMS
+          predicates:
+            - Path=/items/v3/api-docs
+          filters:
+            - RemoveRequestHeader=Cookie
+            - RewritePath=/items/(?<segment>.*), /$\{segment}
         - id: item-service
           uri: lb://ITEMS
           predicates:
@@ -146,6 +153,15 @@ spring:
           filters:
             - RemoveRequestHeader=Cookie
             - RewritePath=/items/(?<segment>.*), /$\{segment}
+        - id: item-recommend-items
+          uri: lb://ITEMS
+          predicates:
+            - Path=/items/*/recommendation
+            - Method=GET
+          filters:
+            - RemoveRequestHeader=Cookie
+            - RewritePath=/items/(?<segment>.*), /$\{segment}
+            - JwtAuthenticationFilter
 
       globalcors:
         cors-configurations:

--- a/popi-api-gateway/src/main/resources/application-local.yml
+++ b/popi-api-gateway/src/main/resources/application-local.yml
@@ -138,6 +138,15 @@ spring:
             - RewritePath=/payments/(?<segment>.*), /$\{segment}
             - JwtAuthenticationFilter
 
+        - id: popup-service
+          uri: lb://POPUPS
+          predicates:
+            - Path=/popups/**
+            - Method=GET,POST,DELETE
+          filters:
+            - RemoveRequestHeader=Cookie
+            - RewritePath=/popups/(?<segment>.*), /$\{segment}
+
       globalcors:
         cors-configurations:
           "[/**]":
@@ -178,6 +187,9 @@ springdoc:
     urls[5]:
       name: 결제 서비스
       url: /payments/v3/api-docs
+    urls[6]:
+      name: 상품 서비스
+      url: /items/v3/api-docs
 
 jwt:
   access-token-secret: ${JWT_ACCESS_TOKEN_SECRET}

--- a/popi-api-gateway/src/main/resources/application-local.yml
+++ b/popi-api-gateway/src/main/resources/application-local.yml
@@ -138,14 +138,14 @@ spring:
             - RewritePath=/payments/(?<segment>.*), /$\{segment}
             - JwtAuthenticationFilter
 
-        - id: popup-service
-          uri: lb://POPUPS
+        - id: item-service
+          uri: lb://ITEMS
           predicates:
-            - Path=/popups/**
-            - Method=GET,POST,DELETE
+            - Path=/items/**
+            - Method=GET,POST
           filters:
             - RemoveRequestHeader=Cookie
-            - RewritePath=/popups/(?<segment>.*), /$\{segment}
+            - RewritePath=/items/(?<segment>.*), /$\{segment}
 
       globalcors:
         cors-configurations:

--- a/popi-api-gateway/src/main/resources/application-local.yml
+++ b/popi-api-gateway/src/main/resources/application-local.yml
@@ -149,14 +149,14 @@ spring:
           uri: lb://ITEMS
           predicates:
             - Path=/items/**
-            - Method=GET,POST
+            - Method=GET
           filters:
             - RemoveRequestHeader=Cookie
             - RewritePath=/items/(?<segment>.*), /$\{segment}
-        - id: item-recommend-items
+        - id: item-recommendations
           uri: lb://ITEMS
           predicates:
-            - Path=/items/*/recommendation
+            - Path=/items/*/recommendations
             - Method=GET
           filters:
             - RemoveRequestHeader=Cookie

--- a/popi-item-service/Dockerfile
+++ b/popi-item-service/Dockerfile
@@ -1,0 +1,4 @@
+FROM openjdk:17-slim
+ARG JAR_FILE=build/libs/*.jar
+COPY ${JAR_FILE} app.jar
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/popi-item-service/build.gradle
+++ b/popi-item-service/build.gradle
@@ -1,0 +1,21 @@
+dependencies {
+    implementation project(':popi-common')
+
+    // Eureka Client
+    implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
+
+    // Spring Cloud Kubernetes Discovery Client
+    implementation 'org.springframework.cloud:spring-cloud-starter-kubernetes-client'
+
+    // Spring Cloud Kubernetes Config Client
+    implementation 'org.springframework.cloud:spring-cloud-starter-kubernetes-client-config'
+
+    // Swagger
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.0'
+
+    // Spring Cloud Open Feign
+    implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
+
+    // WireMock
+    testImplementation 'org.springframework.cloud:spring-cloud-contract-wiremock:4.2.1'
+}

--- a/popi-item-service/build.gradle
+++ b/popi-item-service/build.gradle
@@ -1,4 +1,5 @@
 dependencies {
+    implementation project(':popi-domain')
     implementation project(':popi-common')
 
     // Eureka Client
@@ -22,4 +23,12 @@ dependencies {
     // Flyway
     implementation 'org.flywaydb:flyway-core'
     implementation 'org.flywaydb:flyway-mysql'
+
+    // H2
+    runtimeOnly 'com.h2database:h2'
+    // MySQL
+    runtimeOnly 'com.mysql:mysql-connector-j'
+
+    // JPA
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 }

--- a/popi-item-service/build.gradle
+++ b/popi-item-service/build.gradle
@@ -18,4 +18,8 @@ dependencies {
 
     // WireMock
     testImplementation 'org.springframework.cloud:spring-cloud-contract-wiremock:4.2.1'
+
+    // Flyway
+    implementation 'org.flywaydb:flyway-core'
+    implementation 'org.flywaydb:flyway-mysql'
 }

--- a/popi-item-service/src/main/java/com/lgcns/PopiItemServiceApplication.java
+++ b/popi-item-service/src/main/java/com/lgcns/PopiItemServiceApplication.java
@@ -1,0 +1,12 @@
+package com.lgcns;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class PopiItemServiceApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(PopiItemServiceApplication.class, args);
+    }
+}

--- a/popi-item-service/src/main/java/com/lgcns/client/ManagerServiceClient.java
+++ b/popi-item-service/src/main/java/com/lgcns/client/ManagerServiceClient.java
@@ -1,10 +1,11 @@
 package com.lgcns.client;
 
 import com.lgcns.config.FeignConfig;
-import com.lgcns.dto.popup.response.PopupInfoResponse;
+import com.lgcns.dto.response.ItemInfoResponse;
 import com.lgcns.response.SliceResponse;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
 
 @FeignClient(
@@ -13,8 +14,10 @@ import org.springframework.web.bind.annotation.RequestParam;
         configuration = FeignConfig.class)
 public interface ManagerServiceClient {
 
-    @GetMapping("/internal/popups")
-    SliceResponse<PopupInfoResponse> findAllPopups(
-            @RequestParam(name = "lastPopupId", defaultValue = "0") Long lastPopupId,
+    @GetMapping("/internal/popups/{popupId}/items")
+    SliceResponse<ItemInfoResponse> findItemsByName(
+            @PathVariable(name = "popupId") Long popupId,
+            @RequestParam(name = "searchName", required = false) String searchName,
+            @RequestParam(name = "lastItemId", required = false) Long lastItemId,
             @RequestParam(name = "size", defaultValue = "8") int size);
 }

--- a/popi-item-service/src/main/java/com/lgcns/config/SwaggerConfig.java
+++ b/popi-item-service/src/main/java/com/lgcns/config/SwaggerConfig.java
@@ -1,7 +1,10 @@
 package com.lgcns.config;
 
+import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
 import io.swagger.v3.oas.models.servers.Server;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
@@ -19,6 +22,24 @@ public class SwaggerConfig {
                                 .title("PoPI Item Service API")
                                 .description("PoPI 상품 서비스 API 명세서입니다.")
                                 .version("v0.0.1"))
-                .addServersItem(new Server().url("/items"));
+                .addServersItem(new Server().url("/items"))
+                .components(authSetting())
+                .addSecurityItem(securityRequirement());
+    }
+
+    private Components authSetting() {
+        return new Components()
+                .addSecuritySchemes(
+                        "accessToken",
+                        new SecurityScheme()
+                                .type(SecurityScheme.Type.HTTP)
+                                .scheme("bearer")
+                                .bearerFormat("JWT")
+                                .in(SecurityScheme.In.HEADER)
+                                .name("Authorization"));
+    }
+
+    private SecurityRequirement securityRequirement() {
+        return new SecurityRequirement().addList("accessToken");
     }
 }

--- a/popi-item-service/src/main/java/com/lgcns/config/SwaggerConfig.java
+++ b/popi-item-service/src/main/java/com/lgcns/config/SwaggerConfig.java
@@ -1,0 +1,24 @@
+package com.lgcns.config;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.servers.Server;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@RequiredArgsConstructor
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI openAPI() {
+        return new OpenAPI()
+                .info(
+                        new Info()
+                                .title("PoPI Item Service API")
+                                .description("PoPI 상품 서비스 API 명세서입니다.")
+                                .version("v0.0.1"))
+                .addServersItem(new Server().url("/items"));
+    }
+}

--- a/popi-item-service/src/main/java/com/lgcns/domain/ItemRecommendation.java
+++ b/popi-item-service/src/main/java/com/lgcns/domain/ItemRecommendation.java
@@ -1,0 +1,63 @@
+package com.lgcns.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ItemRecommendation {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "item_recommendation_id")
+    private Long id;
+
+    private Long memberId;
+
+    private Long popupId;
+
+    private Long itemId;
+
+    private String itemName;
+
+    private int itemPrice;
+
+    private String itemImageUrl;
+
+    @Builder(access = AccessLevel.PRIVATE)
+    private ItemRecommendation(
+            Long memberId,
+            Long popupId,
+            Long itemId,
+            String itemName,
+            int itemPrice,
+            String itemImageUrl) {
+        this.memberId = memberId;
+        this.popupId = popupId;
+        this.itemId = itemId;
+        this.itemName = itemName;
+        this.itemPrice = itemPrice;
+        this.itemImageUrl = itemImageUrl;
+    }
+
+    public static ItemRecommendation createItemRecommendation(
+            Long memberId,
+            Long popupId,
+            Long itemId,
+            String itemName,
+            int itemPrice,
+            String itemImageUrl) {
+        return ItemRecommendation.builder()
+                .memberId(memberId)
+                .popupId(popupId)
+                .itemId(itemId)
+                .itemName(itemName)
+                .itemPrice(itemPrice)
+                .itemImageUrl(itemImageUrl)
+                .build();
+    }
+}

--- a/popi-item-service/src/main/java/com/lgcns/domain/ItemRecommendation.java
+++ b/popi-item-service/src/main/java/com/lgcns/domain/ItemRecommendation.java
@@ -18,7 +18,7 @@ public class ItemRecommendation {
 
     private Long memberId;
 
-    private Long popupId;
+    private Long reservationId;
 
     private Long itemId;
 
@@ -31,13 +31,13 @@ public class ItemRecommendation {
     @Builder(access = AccessLevel.PRIVATE)
     private ItemRecommendation(
             Long memberId,
-            Long popupId,
+            Long reservationId,
             Long itemId,
             String itemName,
             int itemPrice,
             String itemImageUrl) {
         this.memberId = memberId;
-        this.popupId = popupId;
+        this.reservationId = reservationId;
         this.itemId = itemId;
         this.itemName = itemName;
         this.itemPrice = itemPrice;
@@ -46,14 +46,14 @@ public class ItemRecommendation {
 
     public static ItemRecommendation createItemRecommendation(
             Long memberId,
-            Long popupId,
+            Long reservationId,
             Long itemId,
             String itemName,
             int itemPrice,
             String itemImageUrl) {
         return ItemRecommendation.builder()
                 .memberId(memberId)
-                .popupId(popupId)
+                .reservationId(reservationId)
                 .itemId(itemId)
                 .itemName(itemName)
                 .itemPrice(itemPrice)

--- a/popi-item-service/src/main/java/com/lgcns/dto/response/ItemInfoResponse.java
+++ b/popi-item-service/src/main/java/com/lgcns/dto/response/ItemInfoResponse.java
@@ -1,4 +1,4 @@
-package com.lgcns.dto.item.response;
+package com.lgcns.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 

--- a/popi-item-service/src/main/java/com/lgcns/externalApi/ItemController.java
+++ b/popi-item-service/src/main/java/com/lgcns/externalApi/ItemController.java
@@ -11,7 +11,7 @@ import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/items/{popupId}")
+@RequestMapping("/popupId}")
 @Tag(name = "2. 상품 API", description = "상품 관련 API 입니다.")
 public class ItemController {
 

--- a/popi-item-service/src/main/java/com/lgcns/externalApi/ItemController.java
+++ b/popi-item-service/src/main/java/com/lgcns/externalApi/ItemController.java
@@ -1,8 +1,8 @@
 package com.lgcns.externalApi;
 
-import com.lgcns.dto.item.response.ItemInfoResponse;
+import com.lgcns.dto.response.ItemInfoResponse;
 import com.lgcns.response.SliceResponse;
-import com.lgcns.service.item.ItemService;
+import com.lgcns.service.ItemService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;

--- a/popi-item-service/src/main/java/com/lgcns/externalApi/ItemController.java
+++ b/popi-item-service/src/main/java/com/lgcns/externalApi/ItemController.java
@@ -11,7 +11,7 @@ import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/popups/{popupId}/items")
+@RequestMapping("/items/{popupId}")
 @Tag(name = "2. 상품 API", description = "상품 관련 API 입니다.")
 public class ItemController {
 

--- a/popi-item-service/src/main/java/com/lgcns/externalApi/ItemController.java
+++ b/popi-item-service/src/main/java/com/lgcns/externalApi/ItemController.java
@@ -11,7 +11,7 @@ import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/popupId}")
+@RequestMapping("/{popupId}")
 @Tag(name = "2. 상품 API", description = "상품 관련 API 입니다.")
 public class ItemController {
 

--- a/popi-item-service/src/main/java/com/lgcns/repository/ItemRecommendationRepository.java
+++ b/popi-item-service/src/main/java/com/lgcns/repository/ItemRecommendationRepository.java
@@ -1,0 +1,6 @@
+package com.lgcns.repository;
+
+import com.lgcns.domain.ItemRecommendation;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ItemRecommendationRepository extends JpaRepository<ItemRecommendation, Long> {}

--- a/popi-item-service/src/main/java/com/lgcns/service/ItemService.java
+++ b/popi-item-service/src/main/java/com/lgcns/service/ItemService.java
@@ -1,6 +1,6 @@
-package com.lgcns.service.item;
+package com.lgcns.service;
 
-import com.lgcns.dto.item.response.ItemInfoResponse;
+import com.lgcns.dto.response.ItemInfoResponse;
 import com.lgcns.response.SliceResponse;
 
 public interface ItemService {

--- a/popi-item-service/src/main/java/com/lgcns/service/ItemServiceImpl.java
+++ b/popi-item-service/src/main/java/com/lgcns/service/ItemServiceImpl.java
@@ -1,7 +1,7 @@
-package com.lgcns.service.item;
+package com.lgcns.service;
 
 import com.lgcns.client.ManagerServiceClient;
-import com.lgcns.dto.item.response.ItemInfoResponse;
+import com.lgcns.dto.response.ItemInfoResponse;
 import com.lgcns.response.SliceResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;

--- a/popi-item-service/src/main/resources/application-local.yml
+++ b/popi-item-service/src/main/resources/application-local.yml
@@ -8,6 +8,19 @@ spring:
     kubernetes:
       config:
         enabled: false
+  datasource:
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    url: jdbc:mysql://${MYSQL_HOST}:${MYSQL_PORT}/${ITEM_DB_NAME}?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
+    username: ${DB_USERNAME}
+    password: ${DB_PASSWORD}
+  jpa:
+    hibernate:
+      ddl-auto: create
+    properties:
+      hibernate:
+        format_sql: true
+        default_batch_fetch_size: 100
+    open-in-view: false
   flyway:
     enabled: true
     baseline-on-migrate: true

--- a/popi-item-service/src/main/resources/application-local.yml
+++ b/popi-item-service/src/main/resources/application-local.yml
@@ -8,6 +8,10 @@ spring:
     kubernetes:
       config:
         enabled: false
+  flyway:
+    enabled: true
+    baseline-on-migrate: true
+    locations: classpath:db/migration
 
 eureka:
   instance:

--- a/popi-item-service/src/main/resources/application-local.yml
+++ b/popi-item-service/src/main/resources/application-local.yml
@@ -1,0 +1,35 @@
+server:
+  port: 0
+
+spring:
+  application:
+    name: items
+  cloud:
+    kubernetes:
+      config:
+        enabled: false
+
+eureka:
+  instance:
+    instance-id: ${spring.cloud.client.hostname}:${spring.application.instance_id:${random.value}}
+    leaseRenewalIntervalInSeconds: 10
+  client:
+    serviceUrl:
+      defaultZone: http://localhost:8761/eureka/
+
+logging:
+  level:
+    org.hibernate.SQL: debug
+
+spring-doc:
+  api-docs:
+    version: openapi_3_1
+    enabled: true
+  enable-kotlin: false
+  default-consumes-media-type: application/json
+  default-produces-media-type: application/json
+
+manager:
+  service:
+    name: managers
+    url: http://localhost:8080

--- a/popi-item-service/src/main/resources/db/migration/V1_init.sql
+++ b/popi-item-service/src/main/resources/db/migration/V1_init.sql
@@ -1,0 +1,9 @@
+CREATE TABLE item_recommendation (
+    item_recommendation_id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    member_id BIGINT NOT NULL,
+    popup_id BIGINT NOT NULL,
+    item_id BIGINT NOT NULL,
+    item_name VARCHAR(255) NOT NULL,
+    item_price INT NOT NULL,
+    item_image_url VARCHAR(1000) NOT NULL
+);

--- a/popi-item-service/src/main/resources/db/migration/V1_init.sql
+++ b/popi-item-service/src/main/resources/db/migration/V1_init.sql
@@ -1,7 +1,7 @@
 CREATE TABLE item_recommendation (
     item_recommendation_id BIGINT AUTO_INCREMENT PRIMARY KEY,
     member_id BIGINT NOT NULL,
-    popup_id BIGINT NOT NULL,
+    reservation_id BIGINT NOT NULL,
     item_id BIGINT NOT NULL,
     item_name VARCHAR(255) NOT NULL,
     item_price INT NOT NULL,

--- a/popi-item-service/src/test/java/com/lgcns/PopiItemServiceApplicationTests.java
+++ b/popi-item-service/src/test/java/com/lgcns/PopiItemServiceApplicationTests.java
@@ -2,8 +2,10 @@ package com.lgcns;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
+@ActiveProfiles("test")
 class PopiItemServiceApplicationTests {
 
     @Test

--- a/popi-item-service/src/test/java/com/lgcns/PopiItemServiceApplicationTests.java
+++ b/popi-item-service/src/test/java/com/lgcns/PopiItemServiceApplicationTests.java
@@ -1,0 +1,11 @@
+package com.lgcns;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class PopiItemServiceApplicationTests {
+
+    @Test
+    void contextLoads() {}
+}

--- a/popi-item-service/src/test/java/com/lgcns/WireMockIntegrationTest.java
+++ b/popi-item-service/src/test/java/com/lgcns/WireMockIntegrationTest.java
@@ -1,0 +1,28 @@
+package com.lgcns;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.contract.wiremock.AutoConfigureWireMock;
+import org.springframework.test.context.ActiveProfiles;
+
+@SpringBootTest
+@AutoConfigureWireMock(port = 0)
+@ActiveProfiles("test")
+public abstract class WireMockIntegrationTest {
+
+    @Autowired protected WireMockServer wireMockServer;
+
+    @BeforeEach
+    void setUp() {
+        wireMockServer.stop();
+        wireMockServer.start();
+    }
+
+    @AfterEach
+    void afterEach() {
+        wireMockServer.resetAll();
+    }
+}

--- a/popi-item-service/src/test/java/com/lgcns/service/ItemServiceTest.java
+++ b/popi-item-service/src/test/java/com/lgcns/service/ItemServiceTest.java
@@ -1,15 +1,15 @@
 package com.lgcns.service;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.tomakehurst.wiremock.client.MappingBuilder;
 import com.lgcns.WireMockIntegrationTest;
-import com.lgcns.dto.item.response.ItemInfoResponse;
+import com.lgcns.dto.response.ItemInfoResponse;
 import com.lgcns.response.SliceResponse;
-import com.lgcns.service.item.ItemService;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Assertions;

--- a/popi-item-service/src/test/java/com/lgcns/service/ItemServiceTest.java
+++ b/popi-item-service/src/test/java/com/lgcns/service/ItemServiceTest.java
@@ -32,7 +32,7 @@ public class ItemServiceTest extends WireMockIntegrationTest {
             // given
             int size = 4;
 
-            String responseBody =
+            String expectedResponse =
                     objectMapper.writeValueAsString(
                             Map.of(
                                     "content",
@@ -76,7 +76,7 @@ public class ItemServiceTest extends WireMockIntegrationTest {
                                     "isLast",
                                     false));
 
-            stubFindItemsByName(popupId, null, null, 4, 200, responseBody);
+            stubFindItemsByName(popupId, null, null, 4, 200, expectedResponse);
 
             // when
             SliceResponse<ItemInfoResponse> result =
@@ -102,7 +102,7 @@ public class ItemServiceTest extends WireMockIntegrationTest {
             Long lastItemId = 5L;
             int size = 4;
 
-            String responseBody =
+            String expectedResponse =
                     objectMapper.writeValueAsString(
                             Map.of(
                                     "content",
@@ -146,7 +146,7 @@ public class ItemServiceTest extends WireMockIntegrationTest {
                                     "isLast",
                                     true));
 
-            stubFindItemsByName(popupId, null, 5L, 4, 200, responseBody);
+            stubFindItemsByName(popupId, null, 5L, 4, 200, expectedResponse);
 
             // when
             SliceResponse<ItemInfoResponse> result =
@@ -172,7 +172,7 @@ public class ItemServiceTest extends WireMockIntegrationTest {
             String searchName = "DAZED";
             int size = 4;
 
-            String responseBody =
+            String expectedResponse =
                     objectMapper.writeValueAsString(
                             Map.of(
                                     "content",
@@ -216,7 +216,7 @@ public class ItemServiceTest extends WireMockIntegrationTest {
                                     "isLast",
                                     true));
 
-            stubFindItemsByName(popupId, searchName, null, 4, 200, responseBody);
+            stubFindItemsByName(popupId, searchName, null, 4, 200, expectedResponse);
 
             // when
             SliceResponse<ItemInfoResponse> result =
@@ -242,10 +242,10 @@ public class ItemServiceTest extends WireMockIntegrationTest {
             String searchName = "EMPTY";
             int size = 4;
 
-            String emptyResponseBody =
+            String expectedResponse =
                     objectMapper.writeValueAsString(Map.of("content", List.of(), "isLast", true));
 
-            stubFindItemsByName(popupId, searchName, null, 4, 200, emptyResponseBody);
+            stubFindItemsByName(popupId, searchName, null, 4, 200, expectedResponse);
 
             // when
             SliceResponse<ItemInfoResponse> result =

--- a/popi-item-service/src/test/resources/application-test.yml
+++ b/popi-item-service/src/test/resources/application-test.yml
@@ -1,0 +1,9 @@
+spring:
+  config:
+    activate:
+      on-profile: "test"
+
+manager:
+  service:
+    name: managers
+    url: http://localhost:${wiremock.server.port}

--- a/popi-item-service/src/test/resources/application-test.yml
+++ b/popi-item-service/src/test/resources/application-test.yml
@@ -2,6 +2,8 @@ spring:
   config:
     activate:
       on-profile: "test"
+  flyway:
+    enabled: false
 
 manager:
   service:

--- a/popi-item-service/src/test/resources/application-test.yml
+++ b/popi-item-service/src/test/resources/application-test.yml
@@ -2,6 +2,8 @@ spring:
   config:
     activate:
       on-profile: "test"
+  datasource:
+    url: jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=false;MODE=MYSQL
   flyway:
     enabled: false
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -10,5 +10,6 @@ include(
         "popi-reservation-service",
         "popi-popup-service",
         "popi-notification-service",
-        "popi-payment-service"
+        "popi-payment-service",
+        "popi-item-service"
 )


### PR DESCRIPTION
## 🌱 관련 이슈

- [LCR-220]

---
## 📌 작업 내용 및 특이사항

- 상품 마이크로서비스를 팝업 서비스와 분리하고 초기 세팅을 진행했습니다.
  - 기존 팝업 마이크로서비스에서 상품 관련 로직과 테스트 코드를 분리했습니다.
  - 상품 서비스의 API 엔드포인트를 /items로 수정했습니다.
  - `application-local.yml`과 `application-test.yml`을 작성하였고, 로컬 환경에서는 Eureka 기반, Kubernetes 환경에서는 Spring Cloud Kubernetes Discovery 기반으로 서비스 디스커버리를 수행하도록 설정을 분리했습니다.
  - Docker 이미지 생성을 위한 Dockerfile을 추가하였습니다.
  - Swagger UI를 통해 상품 서비스의 API 문서를 모두 확인할 수 있도록, API Gateway에서 springdoc 설정을 통합 관리하고 라우팅을 구성했습니다.
  - Kubernetes 배포는 `popi-ops` 레포지토리의 apps/item-service 경로에 Helm 차트 추가 완료하였습니다.
  - 설문지 기반 상품 추천 데이터를 저장하기 위해 ItemRecommendation 엔티티 및 flyway init 파일을 추가했습니다.
  - 상품 추천 API 엔드포인트에 대해 JwtAuthenticationFilter를 적용시키기 위해 API Gateway에서 라우팅 설정을 추가했습니다.

---
## 📚 참고사항

-


[LCR-220]: https://lgcns-retail.atlassian.net/browse/LCR-220?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ