### PR TITLE
feat: 기본 상품 조회 기능 구현

### DIFF
--- a/popi-item-service/src/main/java/com/lgcns/client/ManagerServiceClient.java
+++ b/popi-item-service/src/main/java/com/lgcns/client/ManagerServiceClient.java
@@ -3,6 +3,7 @@ package com.lgcns.client;
 import com.lgcns.config.FeignConfig;
 import com.lgcns.dto.response.ItemInfoResponse;
 import com.lgcns.response.SliceResponse;
+import java.util.List;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -20,4 +21,7 @@ public interface ManagerServiceClient {
             @RequestParam(name = "keyword", required = false) String keyword,
             @RequestParam(name = "lastItemId", required = false) Long lastItemId,
             @RequestParam(name = "size", defaultValue = "8") int size);
+
+    @GetMapping("/internal/popups/{popupId}/items/default")
+    List<ItemInfoResponse> findItemsDefault(@PathVariable(name = "popupId") Long popupId);
 }

--- a/popi-item-service/src/main/java/com/lgcns/externalApi/ItemController.java
+++ b/popi-item-service/src/main/java/com/lgcns/externalApi/ItemController.java
@@ -24,7 +24,7 @@ public class ItemController {
             description =
                     "keyword를 포함하지 않으면 현재 팝업의 모든 상품을 무한 스크롤을 위하여 페이징 처리한 뒤 반환합니다.</br>"
                             + "keyword를 포함하여 호출하면 상품명에 keyword가 포함된 모든 상품을 페이징 처리한 뒤 반환합니다.")
-    public SliceResponse<ItemInfoResponse> userItemFindByName(
+    public SliceResponse<ItemInfoResponse> itemFindByName(
             @Parameter(description = "팝업 ID", example = "1") @PathVariable(name = "popupId")
                     Long popupId,
             @Parameter(description = "검색할 상품 이름 (비워두면 모든 상품을 반환합니다.)", example = "포토카드")
@@ -41,7 +41,7 @@ public class ItemController {
 
     @GetMapping("/default")
     @Operation(summary = "기본 상품 목록 조회", description = "무작위하게 선택된 4개의 상품을 조회합니다.")
-    public List<ItemInfoResponse> useItemFindDefault(
+    public List<ItemInfoResponse> itemFindDefault(
             @Parameter(description = "팝업 ID", example = "1") @PathVariable(name = "popupId")
                     Long popupId) {
         return itemService.findItemsDefault(popupId);

--- a/popi-item-service/src/main/java/com/lgcns/externalApi/ItemController.java
+++ b/popi-item-service/src/main/java/com/lgcns/externalApi/ItemController.java
@@ -6,6 +6,7 @@ import com.lgcns.service.ItemService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
@@ -36,5 +37,13 @@ public class ItemController {
                     @RequestParam(name = "size", defaultValue = "8")
                     int size) {
         return itemService.findItemsByName(popupId, keyword, lastItemId, size);
+    }
+
+    @GetMapping("/default")
+    @Operation(summary = "기본 상품 목록 조회", description = "무작위하게 선택된 4개의 상품을 조회합니다.")
+    public List<ItemInfoResponse> useItemFindDefault(
+            @Parameter(description = "팝업 ID", example = "1") @PathVariable(name = "popupId")
+                    Long popupId) {
+        return itemService.findItemsDefault(popupId);
     }
 }

--- a/popi-item-service/src/main/java/com/lgcns/service/ItemService.java
+++ b/popi-item-service/src/main/java/com/lgcns/service/ItemService.java
@@ -2,8 +2,11 @@ package com.lgcns.service;
 
 import com.lgcns.dto.response.ItemInfoResponse;
 import com.lgcns.response.SliceResponse;
+import java.util.List;
 
 public interface ItemService {
     SliceResponse<ItemInfoResponse> findItemsByName(
             Long popupId, String keyword, Long lastItemId, int size);
+
+    List<ItemInfoResponse> findItemsDefault(Long popupId);
 }

--- a/popi-item-service/src/main/java/com/lgcns/service/ItemServiceImpl.java
+++ b/popi-item-service/src/main/java/com/lgcns/service/ItemServiceImpl.java
@@ -3,6 +3,7 @@ package com.lgcns.service;
 import com.lgcns.client.ManagerServiceClient;
 import com.lgcns.dto.response.ItemInfoResponse;
 import com.lgcns.response.SliceResponse;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -16,5 +17,10 @@ public class ItemServiceImpl implements ItemService {
     public SliceResponse<ItemInfoResponse> findItemsByName(
             Long popupId, String keyword, Long lastItemId, int size) {
         return managerServiceClient.findItemsByName(popupId, keyword, lastItemId, size);
+    }
+
+    @Override
+    public List<ItemInfoResponse> findItemsDefault(Long popupId) {
+        return managerServiceClient.findItemsDefault(popupId);
     }
 }

--- a/popi-item-service/src/test/java/com/lgcns/service/ItemServiceTest.java
+++ b/popi-item-service/src/test/java/com/lgcns/service/ItemServiceTest.java
@@ -10,6 +10,7 @@ import com.github.tomakehurst.wiremock.client.MappingBuilder;
 import com.lgcns.WireMockIntegrationTest;
 import com.lgcns.dto.response.ItemInfoResponse;
 import com.lgcns.response.SliceResponse;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Assertions;
@@ -259,13 +260,117 @@ public class ItemServiceTest extends WireMockIntegrationTest {
         }
     }
 
+    @Nested
+    class 기본_상품_목록을_조회할_때 {
+        @Test
+        void 무작위로_선택된_4개의_상품_조회에_성공한다() throws JsonProcessingException {
+            // given
+            String expectedResponse =
+                    objectMapper.writeValueAsString(
+                            List.of(
+                                    Map.of(
+                                            "itemId",
+                                            18,
+                                            "name",
+                                            "크룽크 라운드백",
+                                            "imageUrl",
+                                            "https://ygselect.com/web/product/big/shop1_cdf3bd187203a3987f4c262e73061334.png",
+                                            "price",
+                                            20000),
+                                    Map.of(
+                                            "itemId",
+                                            4,
+                                            "name",
+                                            "DAZED 리사",
+                                            "imageUrl",
+                                            "https://image.aladin.co.kr/product/17920/59/cover500/k142534034_1.jpg",
+                                            "price",
+                                            8000),
+                                    Map.of(
+                                            "itemId",
+                                            17,
+                                            "name",
+                                            "크룽크 미니백",
+                                            "imageUrl",
+                                            "https://ygselect.com/web/product/big/shop1_738be1088b092afab065be5299d5e2a4.png",
+                                            "price",
+                                            15000),
+                                    Map.of(
+                                            "itemId",
+                                            9,
+                                            "name",
+                                            "피규어 지수",
+                                            "imageUrl",
+                                            "https://m.ygselect.com/web/product/big/202110/51086d5fd28f00991986031b2ed3f742.jpg",
+                                            "price",
+                                            84000)));
+
+            stubFindItemsDefault(popupId, 200, expectedResponse);
+
+            // when
+            List<ItemInfoResponse> result = itemService.findItemsDefault(popupId);
+
+            // then
+            Assertions.assertAll(
+                    () -> assertThat(result).isNotNull(),
+                    () -> assertThat(result).hasSize(4),
+                    () -> assertThat(new HashSet<>(result)).hasSize(result.size()));
+        }
+
+        @Test
+        void 상품_데이터가_4개보다_적으면_전체_데이터_수_만큼_상품이_조회된다() throws JsonProcessingException {
+            // given
+            String expectedResponse =
+                    objectMapper.writeValueAsString(
+                            List.of(
+                                    Map.of(
+                                            "itemId",
+                                            18,
+                                            "name",
+                                            "크룽크 라운드백",
+                                            "imageUrl",
+                                            "https://ygselect.com/web/product/big/shop1_cdf3bd187203a3987f4c262e73061334.png",
+                                            "price",
+                                            20000),
+                                    Map.of(
+                                            "itemId",
+                                            4,
+                                            "name",
+                                            "DAZED 리사",
+                                            "imageUrl",
+                                            "https://image.aladin.co.kr/product/17920/59/cover500/k142534034_1.jpg",
+                                            "price",
+                                            8000),
+                                    Map.of(
+                                            "itemId",
+                                            9,
+                                            "name",
+                                            "피규어 지수",
+                                            "imageUrl",
+                                            "https://m.ygselect.com/web/product/big/202110/51086d5fd28f00991986031b2ed3f742.jpg",
+                                            "price",
+                                            84000)));
+
+            stubFindItemsDefault(popupId, 200, expectedResponse);
+
+            // when
+            List<ItemInfoResponse> result = itemService.findItemsDefault(popupId);
+
+            // then
+            Assertions.assertAll(
+                    () -> assertThat(result).isNotNull(),
+                    () -> assertThat(result).hasSize(3),
+                    () -> assertThat(new HashSet<>(result)).hasSize(result.size()));
+        }
+    }
+
     private void stubFindItemsByName(
             Long popupId, String keyword, Long lastItemId, int size, int status, String body) {
         MappingBuilder mappingBuilder =
                 get(urlPathEqualTo("/internal/popups/" + popupId + "/items"))
                         .withQueryParam("size", equalTo(String.valueOf(size)));
 
-        mappingBuilder = applySearchNameIfPresent(mappingBuilder, keyword);
+        mappingBuilder = applyKeywordIfPresent(mappingBuilder, keyword);
         mappingBuilder = applyLastItemIdIfPresent(mappingBuilder, lastItemId);
 
         wireMockServer.stubFor(
@@ -276,8 +381,22 @@ public class ItemServiceTest extends WireMockIntegrationTest {
                                 .withBody(body)));
     }
 
-    private MappingBuilder applySearchNameIfPresent(MappingBuilder builder, String keyword) {
-        return (keyword != null) ? builder.withQueryParam("keyword", equalTo(keyword)) : builder;
+    private void stubFindItemsDefault(Long popupId, int status, String body) {
+        MappingBuilder mappingBuilder =
+                get(urlPathEqualTo("/internal/popups/" + popupId + "/items/default"));
+
+        wireMockServer.stubFor(
+                mappingBuilder.willReturn(
+                        aResponse()
+                                .withStatus(status)
+                                .withHeader("Content-Type", MediaType.APPLICATION_JSON_VALUE)
+                                .withBody(body)));
+    }
+
+    private MappingBuilder applyKeywordIfPresent(MappingBuilder builder, String keyword) {
+        return (keyword != null)
+                ? builder.withQueryParam("keyeword", equalTo(keyword))
+                : builder;
     }
 
     private MappingBuilder applyLastItemIdIfPresent(MappingBuilder builder, Long lastItemId) {

--- a/popi-item-service/src/test/java/com/lgcns/service/ItemServiceTest.java
+++ b/popi-item-service/src/test/java/com/lgcns/service/ItemServiceTest.java
@@ -394,9 +394,7 @@ public class ItemServiceTest extends WireMockIntegrationTest {
     }
 
     private MappingBuilder applyKeywordIfPresent(MappingBuilder builder, String keyword) {
-        return (keyword != null)
-                ? builder.withQueryParam("keyeword", equalTo(keyword))
-                : builder;
+        return (keyword != null) ? builder.withQueryParam("keyword", equalTo(keyword)) : builder;
     }
 
     private MappingBuilder applyLastItemIdIfPresent(MappingBuilder builder, Long lastItemId) {


### PR DESCRIPTION
## 🌱 관련 이슈

- [LCR-211]

---
## 📌 작업 내용 및 특이사항

- 기본 상품 목록 조회 기능을 구현하였습니다.
- 상품 데이터가 4개 이상일 경우 무작위로 선택된 4개의 상품이 조회됩니다.
- 상품 데이터가 4개보다 적은 경우 전체 상품 데이터 수 만큼 조회됩니다.
- 기본 상품 목록 조회 기능 테스트 코드를 작성하였으며, 상품 데이터가 없는 경우에도 예외는 발생하지 않기 때문에 에외처리 관련 테스트는 작성하지 않았습니다.

---
## 📚 참고사항

-


[LCR-211]: https://lgcns-retail.atlassian.net/browse/LCR-211?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ