### PR TITLE
feat: 마이페이지 예약 목록 조회 구현

### DIFF
--- a/popi-reservation-service/src/main/java/com/lgcns/client/managerClient/ManagerServiceClient.java
+++ b/popi-reservation-service/src/main/java/com/lgcns/client/managerClient/ManagerServiceClient.java
@@ -1,6 +1,6 @@
-package com.lgcns.client;
+package com.lgcns.client.managerClient;
 
-import com.lgcns.client.dto.MonthlyReservationResponse;
+import com.lgcns.client.managerClient.dto.response.MonthlyReservationResponse;
 import com.lgcns.config.FeignConfig;
 import com.lgcns.dto.response.SurveyChoiceResponse;
 import java.util.List;

--- a/popi-reservation-service/src/main/java/com/lgcns/client/managerClient/ManagerServiceClient.java
+++ b/popi-reservation-service/src/main/java/com/lgcns/client/managerClient/ManagerServiceClient.java
@@ -1,13 +1,13 @@
 package com.lgcns.client.managerClient;
 
+import com.lgcns.client.managerClient.dto.request.PopupIdsRequest;
 import com.lgcns.client.managerClient.dto.response.MonthlyReservationResponse;
+import com.lgcns.client.managerClient.dto.response.ReservationPopupInfoResponse;
 import com.lgcns.config.FeignConfig;
 import com.lgcns.dto.response.SurveyChoiceResponse;
 import java.util.List;
 import org.springframework.cloud.openfeign.FeignClient;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.*;
 
 @FeignClient(
         name = "${manager.service.name}",
@@ -20,4 +20,7 @@ public interface ManagerServiceClient {
 
     @GetMapping("/internal/reservations/popups/{popupId}/survey")
     List<SurveyChoiceResponse> findSurveyChoicesByPopupId(@PathVariable Long popupId);
+
+    @PostMapping("/internal/reservations")
+    List<ReservationPopupInfoResponse> findReservedPopupInfo(@RequestBody PopupIdsRequest request);
 }

--- a/popi-reservation-service/src/main/java/com/lgcns/client/managerClient/dto/request/PopupIdsRequest.java
+++ b/popi-reservation-service/src/main/java/com/lgcns/client/managerClient/dto/request/PopupIdsRequest.java
@@ -1,0 +1,11 @@
+package com.lgcns.client.managerClient.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+
+public record PopupIdsRequest(
+        @Schema(description = "상세 조회 원하는 팝업 ID 리스트", example = "[1, 2, 4]") List<Long> popupIds) {
+    public static PopupIdsRequest of(List<Long> popupIds) {
+        return new PopupIdsRequest(popupIds);
+    }
+}

--- a/popi-reservation-service/src/main/java/com/lgcns/client/managerClient/dto/response/DailyReservation.java
+++ b/popi-reservation-service/src/main/java/com/lgcns/client/managerClient/dto/response/DailyReservation.java
@@ -1,4 +1,4 @@
-package com.lgcns.client.dto;
+package com.lgcns.client.managerClient.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDate;

--- a/popi-reservation-service/src/main/java/com/lgcns/client/managerClient/dto/response/MonthlyReservationResponse.java
+++ b/popi-reservation-service/src/main/java/com/lgcns/client/managerClient/dto/response/MonthlyReservationResponse.java
@@ -1,4 +1,4 @@
-package com.lgcns.client.dto;
+package com.lgcns.client.managerClient.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDate;

--- a/popi-reservation-service/src/main/java/com/lgcns/client/managerClient/dto/response/ReservationPopupInfoResponse.java
+++ b/popi-reservation-service/src/main/java/com/lgcns/client/managerClient/dto/response/ReservationPopupInfoResponse.java
@@ -1,0 +1,15 @@
+package com.lgcns.client.managerClient.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record ReservationPopupInfoResponse(
+        @Schema(description = "팝업스토어 ID", example = "1") Long popupId,
+        @Schema(description = "팝업스토어 이름", example = "BLACKPINK 팝업스토어") String popupName,
+        @Schema(description = "팝업스토어 주소", example = "서울특별시 강남구 테헤란로 12, 1층 201호") String address,
+        @Schema(description = "위도", example = "37.5665") Double latitude,
+        @Schema(description = "경도", example = "126.9780") Double longitude) {
+    public static ReservationPopupInfoResponse of(
+            Long popupId, String popupName, String address, Double latitude, Double longitude) {
+        return new ReservationPopupInfoResponse(popupId, popupName, address, latitude, longitude);
+    }
+}

--- a/popi-reservation-service/src/main/java/com/lgcns/client/managerClient/dto/response/TimeSlot.java
+++ b/popi-reservation-service/src/main/java/com/lgcns/client/managerClient/dto/response/TimeSlot.java
@@ -1,4 +1,4 @@
-package com.lgcns.client.dto;
+package com.lgcns.client.managerClient.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalTime;

--- a/popi-reservation-service/src/main/java/com/lgcns/dto/response/ReservationDetailResponse.java
+++ b/popi-reservation-service/src/main/java/com/lgcns/dto/response/ReservationDetailResponse.java
@@ -6,7 +6,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.format.TextStyle;
 import java.util.Locale;
 
-public record ReservationInfoResponse(
+public record ReservationDetailResponse(
         @Schema(description = "예약 ID", example = "23") Long reservationId,
         @Schema(description = "팝업 ID", example = "1") Long popupId,
         @Schema(description = "팝업 이름", example = "블랙핑크 팝업스토어") String popupName,
@@ -18,9 +18,9 @@ public record ReservationInfoResponse(
         @Schema(description = "경도", example = "127.37123456123456") Double longitude,
         @Schema(description = "QR 이미지 (Base64 인코딩)", example = "iVBORw0KGgoAAAA...")
                 String qrImage) {
-    public static ReservationInfoResponse of(
+    public static ReservationDetailResponse of(
             MemberReservation reservation, ReservationPopupInfoResponse reservationPopupInfo) {
-        return new ReservationInfoResponse(
+        return new ReservationDetailResponse(
                 reservation.getId(),
                 reservationPopupInfo.popupId(),
                 reservationPopupInfo.popupName(),

--- a/popi-reservation-service/src/main/java/com/lgcns/dto/response/ReservationInfoResponse.java
+++ b/popi-reservation-service/src/main/java/com/lgcns/dto/response/ReservationInfoResponse.java
@@ -1,0 +1,39 @@
+package com.lgcns.dto.response;
+
+import com.lgcns.client.managerClient.dto.response.ReservationPopupInfoResponse;
+import com.lgcns.domain.MemberReservation;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.format.TextStyle;
+import java.util.Locale;
+
+public record ReservationInfoResponse(
+        @Schema(description = "예약 ID", example = "23") Long reservationId,
+        @Schema(description = "팝업 ID", example = "1") Long popupId,
+        @Schema(description = "팝업 이름", example = "블랙핑크 팝업스토어") String popupName,
+        @Schema(description = "예약 날짜", example = "2025-05-26") String reservationDate,
+        @Schema(description = "예약 시간", example = "11:00") String reservationTime,
+        @Schema(description = "예약 요일", example = "MON") String reservationDay,
+        @Schema(description = "주소", example = "서울 영등포구 여의대로 108 더현대서울") String address,
+        @Schema(description = "위도", example = "37.1234561234567") Double latitude,
+        @Schema(description = "경도", example = "127.37123456123456") Double longitude,
+        @Schema(description = "QR 이미지 (Base64 인코딩)", example = "iVBORw0KGgoAAAA...")
+                String qrImage) {
+    public static ReservationInfoResponse of(
+            MemberReservation reservation, ReservationPopupInfoResponse reservationPopupInfo) {
+        return new ReservationInfoResponse(
+                reservation.getId(),
+                reservationPopupInfo.popupId(),
+                reservationPopupInfo.popupName(),
+                reservation.getReservationDate().toString(),
+                reservation.getReservationTime().toString(),
+                reservation
+                        .getReservationDate()
+                        .getDayOfWeek()
+                        .getDisplayName(TextStyle.SHORT, Locale.ENGLISH)
+                        .toUpperCase(),
+                reservationPopupInfo.address(),
+                reservationPopupInfo.latitude(),
+                reservationPopupInfo.longitude(),
+                reservation.getQrImage());
+    }
+}

--- a/popi-reservation-service/src/main/java/com/lgcns/externalApi/MemberReservationController.java
+++ b/popi-reservation-service/src/main/java/com/lgcns/externalApi/MemberReservationController.java
@@ -1,7 +1,7 @@
 package com.lgcns.externalApi;
 
 import com.lgcns.dto.response.AvailableDateResponse;
-import com.lgcns.dto.response.ReservationInfoResponse;
+import com.lgcns.dto.response.ReservationDetailResponse;
 import com.lgcns.dto.response.SurveyChoiceResponse;
 import com.lgcns.service.MemberReservationService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -35,7 +35,7 @@ public class MemberReservationController {
 
     @GetMapping("/")
     @Operation(summary = "내 예약 목록 조회", description = "사용자의 예약 목록을 조회합니다.")
-    public List<ReservationInfoResponse> reservationInfoFind(
+    public List<ReservationDetailResponse> reservationInfoFind(
             @RequestHeader("member-id") String memberId) {
         return memberReservationService.findReservationInfo(memberId);
     }

--- a/popi-reservation-service/src/main/java/com/lgcns/externalApi/MemberReservationController.java
+++ b/popi-reservation-service/src/main/java/com/lgcns/externalApi/MemberReservationController.java
@@ -1,6 +1,7 @@
 package com.lgcns.externalApi;
 
 import com.lgcns.dto.response.AvailableDateResponse;
+import com.lgcns.dto.response.ReservationInfoResponse;
 import com.lgcns.dto.response.SurveyChoiceResponse;
 import com.lgcns.service.MemberReservationService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -30,5 +31,12 @@ public class MemberReservationController {
     public List<SurveyChoiceResponse> choiceListByPopupIdFind(
             @RequestHeader("member-id") String memberId, @PathVariable Long popupId) {
         return memberReservationService.findSurveyChoicesByPopupId(memberId, popupId);
+    }
+
+    @GetMapping("/")
+    @Operation(summary = "내 예약 목록 조회", description = "사용자의 예약 목록을 조회합니다.")
+    public List<ReservationInfoResponse> reservationInfoFind(
+            @RequestHeader("member-id") String memberId) {
+        return memberReservationService.findReservationInfo(memberId);
     }
 }

--- a/popi-reservation-service/src/main/java/com/lgcns/externalApi/MemberReservationController.java
+++ b/popi-reservation-service/src/main/java/com/lgcns/externalApi/MemberReservationController.java
@@ -33,7 +33,7 @@ public class MemberReservationController {
         return memberReservationService.findSurveyChoicesByPopupId(memberId, popupId);
     }
 
-    @GetMapping("/")
+    @GetMapping
     @Operation(summary = "내 예약 목록 조회", description = "사용자의 예약 목록을 조회합니다.")
     public List<ReservationDetailResponse> reservationInfoFind(
             @RequestHeader("member-id") String memberId) {

--- a/popi-reservation-service/src/main/java/com/lgcns/repository/MemberReservationRepository.java
+++ b/popi-reservation-service/src/main/java/com/lgcns/repository/MemberReservationRepository.java
@@ -1,7 +1,10 @@
 package com.lgcns.repository;
 
 import com.lgcns.domain.MemberReservation;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MemberReservationRepository
-        extends JpaRepository<MemberReservation, Long>, MemberReservationRepositoryCustom {}
+        extends JpaRepository<MemberReservation, Long>, MemberReservationRepositoryCustom {
+    List<MemberReservation> findByMemberId(Long memberId);
+}

--- a/popi-reservation-service/src/main/java/com/lgcns/service/MemberReservationService.java
+++ b/popi-reservation-service/src/main/java/com/lgcns/service/MemberReservationService.java
@@ -1,6 +1,7 @@
 package com.lgcns.service;
 
 import com.lgcns.dto.response.AvailableDateResponse;
+import com.lgcns.dto.response.ReservationInfoResponse;
 import com.lgcns.dto.response.SurveyChoiceResponse;
 import java.util.List;
 
@@ -8,4 +9,6 @@ public interface MemberReservationService {
     AvailableDateResponse findAvailableDate(String memberId, Long popupId, String date);
 
     List<SurveyChoiceResponse> findSurveyChoicesByPopupId(String memberId, Long popupId);
+
+    List<ReservationInfoResponse> findReservationInfo(String memberId);
 }

--- a/popi-reservation-service/src/main/java/com/lgcns/service/MemberReservationService.java
+++ b/popi-reservation-service/src/main/java/com/lgcns/service/MemberReservationService.java
@@ -1,7 +1,7 @@
 package com.lgcns.service;
 
 import com.lgcns.dto.response.AvailableDateResponse;
-import com.lgcns.dto.response.ReservationInfoResponse;
+import com.lgcns.dto.response.ReservationDetailResponse;
 import com.lgcns.dto.response.SurveyChoiceResponse;
 import java.util.List;
 
@@ -10,5 +10,5 @@ public interface MemberReservationService {
 
     List<SurveyChoiceResponse> findSurveyChoicesByPopupId(String memberId, Long popupId);
 
-    List<ReservationInfoResponse> findReservationInfo(String memberId);
+    List<ReservationDetailResponse> findReservationInfo(String memberId);
 }

--- a/popi-reservation-service/src/main/java/com/lgcns/service/MemberReservationServiceImpl.java
+++ b/popi-reservation-service/src/main/java/com/lgcns/service/MemberReservationServiceImpl.java
@@ -1,9 +1,12 @@
 package com.lgcns.service;
 
-import com.lgcns.client.ManagerServiceClient;
-import com.lgcns.client.dto.DailyReservation;
-import com.lgcns.client.dto.MonthlyReservationResponse;
-import com.lgcns.client.dto.TimeSlot;
+import com.lgcns.client.managerClient.ManagerServiceClient;
+import com.lgcns.client.managerClient.dto.request.PopupIdsRequest;
+import com.lgcns.client.managerClient.dto.response.DailyReservation;
+import com.lgcns.client.managerClient.dto.response.MonthlyReservationResponse;
+import com.lgcns.client.managerClient.dto.response.ReservationPopupInfoResponse;
+import com.lgcns.client.managerClient.dto.response.TimeSlot;
+import com.lgcns.domain.MemberReservation;
 import com.lgcns.dto.response.*;
 import com.lgcns.error.exception.CustomException;
 import com.lgcns.exception.MemberReservationErrorCode;
@@ -13,13 +16,16 @@ import java.time.LocalTime;
 import java.time.YearMonth;
 import java.time.format.DateTimeParseException;
 import java.util.*;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 @Transactional
+@Slf4j
 public class MemberReservationServiceImpl implements MemberReservationService {
 
     private final ManagerServiceClient managerServiceClient;
@@ -53,6 +59,40 @@ public class MemberReservationServiceImpl implements MemberReservationService {
     @Override
     public List<SurveyChoiceResponse> findSurveyChoicesByPopupId(String memberId, Long popupId) {
         return managerServiceClient.findSurveyChoicesByPopupId(popupId);
+    }
+
+    @Override
+    public List<ReservationInfoResponse> findReservationInfo(String memberId) {
+        List<MemberReservation> memberReservationList =
+                memberReservationRepository.findByMemberId(Long.parseLong(memberId));
+
+        if (memberReservationList.isEmpty()) {
+            return List.of();
+        }
+
+        List<Long> popupIds =
+                memberReservationList.stream()
+                        .map(MemberReservation::getPopupId)
+                        .distinct()
+                        .toList();
+
+        List<ReservationPopupInfoResponse> reservationPopupInfoList =
+                managerServiceClient.findReservedPopupInfo(PopupIdsRequest.of(popupIds));
+
+        Map<Long, ReservationPopupInfoResponse> reservationPopupInfoMap =
+                reservationPopupInfoList.stream()
+                        .collect(
+                                Collectors.toMap(
+                                        ReservationPopupInfoResponse::popupId,
+                                        popupInfo -> popupInfo));
+
+        return memberReservationList.stream()
+                .map(
+                        reservation ->
+                                ReservationInfoResponse.of(
+                                        reservation,
+                                        reservationPopupInfoMap.get(reservation.getPopupId())))
+                .toList();
     }
 
     private void validateYearMonthFormat(String date) {

--- a/popi-reservation-service/src/main/java/com/lgcns/service/MemberReservationServiceImpl.java
+++ b/popi-reservation-service/src/main/java/com/lgcns/service/MemberReservationServiceImpl.java
@@ -62,7 +62,7 @@ public class MemberReservationServiceImpl implements MemberReservationService {
     }
 
     @Override
-    public List<ReservationInfoResponse> findReservationInfo(String memberId) {
+    public List<ReservationDetailResponse> findReservationInfo(String memberId) {
         List<MemberReservation> memberReservationList =
                 memberReservationRepository.findByMemberId(Long.parseLong(memberId));
 
@@ -89,7 +89,7 @@ public class MemberReservationServiceImpl implements MemberReservationService {
         return memberReservationList.stream()
                 .map(
                         reservation ->
-                                ReservationInfoResponse.of(
+                                ReservationDetailResponse.of(
                                         reservation,
                                         reservationPopupInfoMap.get(reservation.getPopupId())))
                 .toList();

--- a/popi-reservation-service/src/test/java/com/lgcns/service/MemberReservationServiceTest.java
+++ b/popi-reservation-service/src/test/java/com/lgcns/service/MemberReservationServiceTest.java
@@ -392,14 +392,14 @@ class MemberReservationServiceTest extends WireMockIntegrationTest {
             stubFindReservationInfo(request, 200, expectedResponse);
 
             // when
-            List<ReservationInfoResponse> reservations =
+            List<ReservationDetailResponse> reservations =
                     memberReservationService.findReservationInfo(memberId);
 
             // then
             assertThat(reservations).isNotEmpty();
             assertThat(reservations.size()).isEqualTo(1);
 
-            ReservationInfoResponse reservationInfo = reservations.get(0);
+            ReservationDetailResponse reservationInfo = reservations.get(0);
 
             Assertions.assertAll(
                     () -> assertThat(reservationInfo.popupId()).isEqualTo(1L),
@@ -420,7 +420,7 @@ class MemberReservationServiceTest extends WireMockIntegrationTest {
             String memberId = "99";
 
             // when
-            List<ReservationInfoResponse> reservations =
+            List<ReservationDetailResponse> reservations =
                     memberReservationService.findReservationInfo(memberId);
 
             // then


### PR DESCRIPTION
## 🌱 관련 이슈

- [LCR-104]

---
## 📌 작업 내용 및 특이사항
- 마이페이지 예약 목록 조회를 구현했습니다.
- Feign 요청으로부터 받은 팝업 정보와 member_reservation의 예약 정보를 조합해 응답을 생성했습니다. 사용자가 예약을 하지 않은 경우, 빈 리스트를 반환하도록 했습니다.
- client 패키지 내에 managerClient 패키지를 생성하고, dto 내부에 request와 response로 패키지를 분리했습니다.
- 내 예약 목록 조회 기능 테스트 코드를 작성하였으며, member_reservation에 예약 데이터가 없는 경우에도 예외는 발생하지 않기 때문에 에외처리 관련 테스트는 작성하지 않았습니다.

---
## 📚 참고사항


[LCR-104]: https://lgcns-retail.atlassian.net/browse/LCR-104?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ