### PR TITLE
feat: 결제 준비 기능 구현

### DIFF
--- a/popi-common/src/main/java/com/lgcns/dto/response/MemberInternalInfoResponse.java
+++ b/popi-common/src/main/java/com/lgcns/dto/response/MemberInternalInfoResponse.java
@@ -3,4 +3,5 @@ package com.lgcns.dto.response;
 import com.lgcns.enums.MemberRole;
 import com.lgcns.enums.MemberStatus;
 
-public record MemberInternalInfoResponse(Long memberId, MemberRole role, MemberStatus status) {}
+public record MemberInternalInfoResponse(
+        Long memberId, String nickname, MemberRole role, MemberStatus status) {}

--- a/popi-member-service/src/main/java/com/lgcns/service/MemberServiceImpl.java
+++ b/popi-member-service/src/main/java/com/lgcns/service/MemberServiceImpl.java
@@ -67,7 +67,7 @@ public class MemberServiceImpl implements MemberService {
         if (optionalMember.isPresent()) {
             Member member = optionalMember.get();
             return new MemberInternalInfoResponse(
-                    member.getId(), member.getRole(), member.getStatus());
+                    member.getId(), member.getNickname(), member.getRole(), member.getStatus());
         }
 
         return null;
@@ -78,7 +78,8 @@ public class MemberServiceImpl implements MemberService {
     public MemberInternalInfoResponse findMemberId(Long memberId) {
         final Member member = findByMemberId(memberId);
 
-        return new MemberInternalInfoResponse(member.getId(), member.getRole(), member.getStatus());
+        return new MemberInternalInfoResponse(
+                member.getId(), member.getNickname(), member.getRole(), member.getStatus());
     }
 
     @Override

--- a/popi-payment-service/build.gradle
+++ b/popi-payment-service/build.gradle
@@ -28,4 +28,7 @@ dependencies {
 
     // Spring Cloud Open Feign
     implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
+
+    // WireMock
+    testImplementation 'org.springframework.cloud:spring-cloud-contract-wiremock:4.2.1'
 }

--- a/popi-payment-service/src/main/java/com/lgcns/client/managerClient/ManagerServiceClient.java
+++ b/popi-payment-service/src/main/java/com/lgcns/client/managerClient/ManagerServiceClient.java
@@ -1,0 +1,20 @@
+package com.lgcns.client.managerClient;
+
+import com.lgcns.client.managerClient.dto.request.ItemIdsForPaymentRequest;
+import com.lgcns.client.managerClient.dto.response.ItemForPaymentResponse;
+import com.lgcns.config.FeignConfig;
+import java.util.List;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@FeignClient(
+        name = "${manager.service.name}",
+        url = "${manager.service.url:}",
+        configuration = FeignConfig.class)
+public interface ManagerServiceClient {
+    @PostMapping("/internal/popups/{popupId}/items/details")
+    List<ItemForPaymentResponse> findItemsForPayment(
+            @PathVariable Long popupId, @RequestBody ItemIdsForPaymentRequest request);
+}

--- a/popi-payment-service/src/main/java/com/lgcns/client/managerClient/dto/request/ItemIdsForPaymentRequest.java
+++ b/popi-payment-service/src/main/java/com/lgcns/client/managerClient/dto/request/ItemIdsForPaymentRequest.java
@@ -1,0 +1,7 @@
+package com.lgcns.client.managerClient.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+
+public record ItemIdsForPaymentRequest(
+        @Schema(description = "결제할 아이템의 ID 리스트", example = "[1, 2, 4]") List<Long> itemIds) {}

--- a/popi-payment-service/src/main/java/com/lgcns/client/managerClient/dto/response/ItemForPaymentResponse.java
+++ b/popi-payment-service/src/main/java/com/lgcns/client/managerClient/dto/response/ItemForPaymentResponse.java
@@ -1,0 +1,3 @@
+package com.lgcns.client.managerClient.dto.response;
+
+public record ItemForPaymentResponse(Long itemId, String name, int price, int stock) {}

--- a/popi-payment-service/src/main/java/com/lgcns/client/memberClient/MemberServiceClient.java
+++ b/popi-payment-service/src/main/java/com/lgcns/client/memberClient/MemberServiceClient.java
@@ -1,0 +1,16 @@
+package com.lgcns.client.memberClient;
+
+import com.lgcns.config.FeignConfig;
+import com.lgcns.dto.response.MemberInternalInfoResponse;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
+@FeignClient(
+        name = "${member.service.name}",
+        url = "${member.service.url:}",
+        configuration = FeignConfig.class)
+public interface MemberServiceClient {
+    @GetMapping("/internal/{memberId}")
+    MemberInternalInfoResponse findMemberInfo(@PathVariable Long memberId);
+}

--- a/popi-payment-service/src/main/java/com/lgcns/domain/Payment.java
+++ b/popi-payment-service/src/main/java/com/lgcns/domain/Payment.java
@@ -1,0 +1,46 @@
+package com.lgcns.domain;
+
+import com.lgcns.entity.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Payment extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "payment_id")
+    private Long id;
+
+    private Long memberId;
+    private String merchantUid;
+    private String impUid;
+
+    private String pgProvider;
+    private int amount;
+
+    @Enumerated(EnumType.STRING)
+    private PaymentStatus status;
+
+    @Builder(access = AccessLevel.PRIVATE)
+    private Payment(Long memberId, String merchantUid, int amount, PaymentStatus status) {
+        this.memberId = memberId;
+        this.merchantUid = merchantUid;
+        this.amount = amount;
+        this.status = status;
+    }
+
+    public static Payment createPayment(Long memberId, String merchantUid, int amount) {
+        return Payment.builder()
+                .memberId(memberId)
+                .merchantUid(merchantUid)
+                .amount(amount)
+                .status(PaymentStatus.READY)
+                .build();
+    }
+}

--- a/popi-payment-service/src/main/java/com/lgcns/domain/PaymentStatus.java
+++ b/popi-payment-service/src/main/java/com/lgcns/domain/PaymentStatus.java
@@ -1,0 +1,16 @@
+package com.lgcns.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum PaymentStatus {
+    READY("READY"),
+    PAID("PAID"),
+    FAILED("FAILED"),
+    CANCELLED("CANCELLED"),
+    ;
+
+    private final String status;
+}

--- a/popi-payment-service/src/main/java/com/lgcns/dto/request/PaymentReadyRequest.java
+++ b/popi-payment-service/src/main/java/com/lgcns/dto/request/PaymentReadyRequest.java
@@ -1,0 +1,18 @@
+package com.lgcns.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import java.util.List;
+
+public record PaymentReadyRequest(
+        @NotNull(message = "팝업 ID는 비워둘 수 없습니다.") @Schema(description = "팝업 ID", example = "1")
+                Long popupId,
+        @NotNull(message = "상품 목록은 비워둘 수 없습니다.") @Schema(description = "결제할 상품 목록")
+                List<Item> items) {
+    @Schema(description = "결제할 개별 상품 정보")
+    public record Item(
+            @NotNull(message = "상품 ID는 비워둘 수 없습니다.") @Schema(description = "상품 ID", example = "11")
+                    Long itemId,
+            @NotNull(message = "구매 수량은 비워둘 수 없습니다.") @Schema(description = "구매 수량", example = "2")
+                    Integer quantity) {}
+}

--- a/popi-payment-service/src/main/java/com/lgcns/dto/response/PaymentReadyResponse.java
+++ b/popi-payment-service/src/main/java/com/lgcns/dto/response/PaymentReadyResponse.java
@@ -1,0 +1,17 @@
+package com.lgcns.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record PaymentReadyResponse(
+        @Schema(description = "구매자 이름", example = "최현태") String buyerName,
+        @Schema(description = "결제 항목 이름 (대표 상품명 외 N건)", example = "피규어 제니 외 1건") String name,
+        @Schema(description = "결제 총 금액", example = "206000") int amount,
+        @Schema(
+                        description = "결제 요청 고유 ID (merchant_uid)",
+                        example = "popup_1_order_6ef377d3-e92c-46e6-b38a-eb87227da444")
+                String merchantUid) {
+    public static PaymentReadyResponse of(
+            String buyerName, String name, int amount, String merchantUid) {
+        return new PaymentReadyResponse(buyerName, name, amount, merchantUid);
+    }
+}

--- a/popi-payment-service/src/main/java/com/lgcns/exception/PaymentErrorCode.java
+++ b/popi-payment-service/src/main/java/com/lgcns/exception/PaymentErrorCode.java
@@ -1,0 +1,17 @@
+package com.lgcns.exception;
+
+import com.lgcns.error.exception.ErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum PaymentErrorCode implements ErrorCode {
+    ITEM_NOT_FOUND(HttpStatus.NOT_FOUND, "결제 대상 상품 정보를 찾을 수 없습니다."),
+    OUT_OF_STOCK(HttpStatus.BAD_REQUEST, "상품 재고가 부족합니다."),
+    ;
+
+    private final HttpStatus httpStatus;
+    private final String message;
+}

--- a/popi-payment-service/src/main/java/com/lgcns/externalApi/PaymentController.java
+++ b/popi-payment-service/src/main/java/com/lgcns/externalApi/PaymentController.java
@@ -1,0 +1,29 @@
+package com.lgcns.externalApi;
+
+import com.lgcns.dto.request.PaymentReadyRequest;
+import com.lgcns.dto.response.PaymentReadyResponse;
+import com.lgcns.service.PaymentService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@Tag(name = "결제 서버 API", description = "결제 서버 API입니다.")
+public class PaymentController {
+
+    private final PaymentService paymentService;
+
+    @PostMapping("/ready")
+    @Operation(
+            summary = "결제 준비 정보 생성",
+            description = "사용자가 장바구니에서 선택한 상품 정보를 기반으로 결제에 필요한 정보를 생성합니다.")
+    public PaymentReadyResponse paymentPrepare(
+            @RequestHeader("member-id") String memberId, @RequestBody PaymentReadyRequest request) {
+        return paymentService.preparePayment(memberId, request);
+    }
+}

--- a/popi-payment-service/src/main/java/com/lgcns/repository/PaymentRepository.java
+++ b/popi-payment-service/src/main/java/com/lgcns/repository/PaymentRepository.java
@@ -1,0 +1,6 @@
+package com.lgcns.repository;
+
+import com.lgcns.domain.Payment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PaymentRepository extends JpaRepository<Payment, Long> {}

--- a/popi-payment-service/src/main/java/com/lgcns/service/PaymentService.java
+++ b/popi-payment-service/src/main/java/com/lgcns/service/PaymentService.java
@@ -1,74 +1,8 @@
 package com.lgcns.service;
 
-import com.lgcns.client.managerClient.ManagerServiceClient;
-import com.lgcns.client.managerClient.dto.request.ItemIdsForPaymentRequest;
-import com.lgcns.client.managerClient.dto.response.ItemForPaymentResponse;
-import com.lgcns.client.memberClient.MemberServiceClient;
-import com.lgcns.domain.Payment;
 import com.lgcns.dto.request.PaymentReadyRequest;
 import com.lgcns.dto.response.PaymentReadyResponse;
-import com.lgcns.error.exception.CustomException;
-import com.lgcns.exception.PaymentErrorCode;
-import com.lgcns.repository.PaymentRepository;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.UUID;
-import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
-@Service
-@RequiredArgsConstructor
-@Transactional
-public class PaymentService {
-
-    private final PaymentRepository paymentRepository;
-    private final MemberServiceClient memberServiceClient;
-    private final ManagerServiceClient managerServiceClient;
-
-    public PaymentReadyResponse preparePayment(String memberId, PaymentReadyRequest request) {
-        String buyerName = memberServiceClient.findMemberInfo(Long.valueOf(memberId)).nickname();
-
-        List<Long> itemIds =
-                request.items().stream().map(PaymentReadyRequest.Item::itemId).toList();
-
-        List<ItemForPaymentResponse> itemDetails =
-                managerServiceClient.findItemsForPayment(
-                        request.popupId(), new ItemIdsForPaymentRequest(itemIds));
-
-        List<String> itemNames = new ArrayList<>();
-        int amount = 0;
-
-        for (PaymentReadyRequest.Item selected : request.items()) {
-            var item =
-                    itemDetails.stream()
-                            .filter(i -> i.itemId().equals(selected.itemId()))
-                            .findFirst()
-                            .orElseThrow(
-                                    () -> new CustomException(PaymentErrorCode.ITEM_NOT_FOUND));
-
-            if (selected.quantity() > item.stock()) {
-                throw new CustomException(PaymentErrorCode.OUT_OF_STOCK);
-            }
-
-            amount += item.price() * selected.quantity();
-            itemNames.add(item.name());
-        }
-
-        String name;
-        int size = itemNames.size();
-
-        if (size == 1) {
-            name = itemNames.get(0);
-        } else {
-            name = String.format("%s 외 %d건", itemNames.get(0), size - 1);
-        }
-
-        String merchantUid =
-                String.format("popup_%d_order_%s", request.popupId(), UUID.randomUUID());
-
-        paymentRepository.save(Payment.createPayment(Long.valueOf(memberId), merchantUid, amount));
-
-        return PaymentReadyResponse.of(buyerName, name, amount, merchantUid);
-    }
+public interface PaymentService {
+    PaymentReadyResponse preparePayment(String memberId, PaymentReadyRequest request);
 }

--- a/popi-payment-service/src/main/java/com/lgcns/service/PaymentService.java
+++ b/popi-payment-service/src/main/java/com/lgcns/service/PaymentService.java
@@ -1,0 +1,74 @@
+package com.lgcns.service;
+
+import com.lgcns.client.managerClient.ManagerServiceClient;
+import com.lgcns.client.managerClient.dto.request.ItemIdsForPaymentRequest;
+import com.lgcns.client.managerClient.dto.response.ItemForPaymentResponse;
+import com.lgcns.client.memberClient.MemberServiceClient;
+import com.lgcns.domain.Payment;
+import com.lgcns.dto.request.PaymentReadyRequest;
+import com.lgcns.dto.response.PaymentReadyResponse;
+import com.lgcns.error.exception.CustomException;
+import com.lgcns.exception.PaymentErrorCode;
+import com.lgcns.repository.PaymentRepository;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class PaymentService {
+
+    private final PaymentRepository paymentRepository;
+    private final MemberServiceClient memberServiceClient;
+    private final ManagerServiceClient managerServiceClient;
+
+    public PaymentReadyResponse preparePayment(String memberId, PaymentReadyRequest request) {
+        String buyerName = memberServiceClient.findMemberInfo(Long.valueOf(memberId)).nickname();
+
+        List<Long> itemIds =
+                request.items().stream().map(PaymentReadyRequest.Item::itemId).toList();
+
+        List<ItemForPaymentResponse> itemDetails =
+                managerServiceClient.findItemsForPayment(
+                        request.popupId(), new ItemIdsForPaymentRequest(itemIds));
+
+        List<String> itemNames = new ArrayList<>();
+        int amount = 0;
+
+        for (PaymentReadyRequest.Item selected : request.items()) {
+            var item =
+                    itemDetails.stream()
+                            .filter(i -> i.itemId().equals(selected.itemId()))
+                            .findFirst()
+                            .orElseThrow(
+                                    () -> new CustomException(PaymentErrorCode.ITEM_NOT_FOUND));
+
+            if (selected.quantity() > item.stock()) {
+                throw new CustomException(PaymentErrorCode.OUT_OF_STOCK);
+            }
+
+            amount += item.price() * selected.quantity();
+            itemNames.add(item.name());
+        }
+
+        String name;
+        int size = itemNames.size();
+
+        if (size == 1) {
+            name = itemNames.get(0);
+        } else {
+            name = String.format("%s 외 %d건", itemNames.get(0), size - 1);
+        }
+
+        String merchantUid =
+                String.format("popup_%d_order_%s", request.popupId(), UUID.randomUUID());
+
+        paymentRepository.save(Payment.createPayment(Long.valueOf(memberId), merchantUid, amount));
+
+        return PaymentReadyResponse.of(buyerName, name, amount, merchantUid);
+    }
+}

--- a/popi-payment-service/src/main/java/com/lgcns/service/PaymentServiceImpl.java
+++ b/popi-payment-service/src/main/java/com/lgcns/service/PaymentServiceImpl.java
@@ -1,0 +1,75 @@
+package com.lgcns.service;
+
+import com.lgcns.client.managerClient.ManagerServiceClient;
+import com.lgcns.client.managerClient.dto.request.ItemIdsForPaymentRequest;
+import com.lgcns.client.managerClient.dto.response.ItemForPaymentResponse;
+import com.lgcns.client.memberClient.MemberServiceClient;
+import com.lgcns.domain.Payment;
+import com.lgcns.dto.request.PaymentReadyRequest;
+import com.lgcns.dto.response.PaymentReadyResponse;
+import com.lgcns.error.exception.CustomException;
+import com.lgcns.exception.PaymentErrorCode;
+import com.lgcns.repository.PaymentRepository;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class PaymentServiceImpl implements PaymentService {
+
+    private final PaymentRepository paymentRepository;
+    private final MemberServiceClient memberServiceClient;
+    private final ManagerServiceClient managerServiceClient;
+
+    @Override
+    public PaymentReadyResponse preparePayment(String memberId, PaymentReadyRequest request) {
+        String buyerName = memberServiceClient.findMemberInfo(Long.valueOf(memberId)).nickname();
+
+        List<Long> itemIds =
+                request.items().stream().map(PaymentReadyRequest.Item::itemId).toList();
+
+        List<ItemForPaymentResponse> itemDetails =
+                managerServiceClient.findItemsForPayment(
+                        request.popupId(), new ItemIdsForPaymentRequest(itemIds));
+
+        List<String> itemNames = new ArrayList<>();
+        int amount = 0;
+
+        for (PaymentReadyRequest.Item selected : request.items()) {
+            var item =
+                    itemDetails.stream()
+                            .filter(i -> i.itemId().equals(selected.itemId()))
+                            .findFirst()
+                            .orElseThrow(
+                                    () -> new CustomException(PaymentErrorCode.ITEM_NOT_FOUND));
+
+            if (selected.quantity() > item.stock()) {
+                throw new CustomException(PaymentErrorCode.OUT_OF_STOCK);
+            }
+
+            amount += item.price() * selected.quantity();
+            itemNames.add(item.name());
+        }
+
+        String name;
+        int size = itemNames.size();
+
+        if (size == 1) {
+            name = itemNames.get(0);
+        } else {
+            name = String.format("%s 외 %d건", itemNames.get(0), size - 1);
+        }
+
+        String merchantUid =
+                String.format("popup_%d_order_%s", request.popupId(), UUID.randomUUID());
+
+        paymentRepository.save(Payment.createPayment(Long.valueOf(memberId), merchantUid, amount));
+
+        return PaymentReadyResponse.of(buyerName, name, amount, merchantUid);
+    }
+}

--- a/popi-payment-service/src/main/java/com/lgcns/service/PaymentServiceImpl.java
+++ b/popi-payment-service/src/main/java/com/lgcns/service/PaymentServiceImpl.java
@@ -27,7 +27,8 @@ public class PaymentServiceImpl implements PaymentService {
     private final ManagerServiceClient managerServiceClient;
 
     @Override
-    public PaymentReadyResponse preparePayment(String memberId, PaymentReadyRequest request) {
+    public synchronized PaymentReadyResponse preparePayment(
+            String memberId, PaymentReadyRequest request) {
         String buyerName = memberServiceClient.findMemberInfo(Long.valueOf(memberId)).nickname();
 
         List<Long> itemIds =

--- a/popi-payment-service/src/main/resources/application-local.yml
+++ b/popi-payment-service/src/main/resources/application-local.yml
@@ -45,3 +45,12 @@ spring-doc:
   enable-kotlin: false
   default-consumes-media-type: application/json
   default-produces-media-type: application/json
+
+manager:
+  service:
+    name: managers
+    url: http://localhost:8080
+
+member:
+  service:
+    name: members

--- a/popi-payment-service/src/main/resources/db/migration/V1__init.sql
+++ b/popi-payment-service/src/main/resources/db/migration/V1__init.sql
@@ -1,0 +1,11 @@
+CREATE TABLE payment (
+                         payment_id BIGINT AUTO_INCREMENT PRIMARY KEY,
+                         member_id BIGINT NOT NULL,
+                         merchant_uid VARCHAR(255) NOT NULL,
+                         imp_uid VARCHAR(255),
+                         pg_provider VARCHAR(255),
+                         amount INT NOT NULL,
+                         status ENUM('READY', 'PAID', 'FAILED', 'CANCELLED') NOT NULL,
+                         created_at DATETIME NOT NULL,
+                         updated_at DATETIME
+);

--- a/popi-payment-service/src/test/java/com/lgcns/PopiPaymentServiceApplicationTests.java
+++ b/popi-payment-service/src/test/java/com/lgcns/PopiPaymentServiceApplicationTests.java
@@ -2,8 +2,10 @@ package com.lgcns;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
+@ActiveProfiles("test")
 class PopiPaymentServiceApplicationTests {
 
     @Test

--- a/popi-payment-service/src/test/java/com/lgcns/WireMockIntegrationTest.java
+++ b/popi-payment-service/src/test/java/com/lgcns/WireMockIntegrationTest.java
@@ -1,0 +1,28 @@
+package com.lgcns;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.contract.wiremock.AutoConfigureWireMock;
+import org.springframework.test.context.ActiveProfiles;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@AutoConfigureWireMock(port = 0)
+public abstract class WireMockIntegrationTest {
+
+    @Autowired private WireMockServer wireMockServer;
+
+    @BeforeEach
+    void setUp() {
+        wireMockServer.stop();
+        wireMockServer.start();
+    }
+
+    @AfterEach
+    void afterEach() {
+        wireMockServer.resetAll();
+    }
+}

--- a/popi-payment-service/src/test/java/com/lgcns/service/PaymentServiceTest.java
+++ b/popi-payment-service/src/test/java/com/lgcns/service/PaymentServiceTest.java
@@ -1,0 +1,136 @@
+package com.lgcns.service;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.lgcns.WireMockIntegrationTest;
+import com.lgcns.dto.request.PaymentReadyRequest;
+import com.lgcns.dto.response.PaymentReadyResponse;
+import com.lgcns.error.exception.CustomException;
+import com.lgcns.exception.PaymentErrorCode;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+public class PaymentServiceTest extends WireMockIntegrationTest {
+
+    @Autowired PaymentService paymentService;
+
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Nested
+    class 결제_준비할_때 {
+
+        @Test
+        void 유효한_요청이라면_결제_준비_정보를_응답한다() throws JsonProcessingException {
+            // given
+            PaymentReadyRequest request =
+                    new PaymentReadyRequest(
+                            1L,
+                            List.of(
+                                    new PaymentReadyRequest.Item(9L, 1),
+                                    new PaymentReadyRequest.Item(17L, 3)));
+
+            stubManagerInfo();
+            stubItemDetails();
+
+            // when
+            PaymentReadyResponse response = paymentService.preparePayment("1", request);
+
+            // then
+            Assertions.assertAll(
+                    () -> assertThat(response.buyerName()).isEqualTo("현태"),
+                    () -> assertThat(response.name()).isEqualTo("피규어 지수 외 1건"),
+                    () -> assertThat(response.amount()).isEqualTo(129000),
+                    () ->
+                            assertThat(response.merchantUid())
+                                    .matches("^popup_1_order_[0-9a-fA-F\\-]{36}$"));
+        }
+
+        @Test
+        void 존재하지_않는_itemId가_포함되어_있다면_예외가_발생한다() throws JsonProcessingException {
+            // given
+            PaymentReadyRequest request =
+                    new PaymentReadyRequest(
+                            1L,
+                            List.of(
+                                    new PaymentReadyRequest.Item(9L, 1),
+                                    new PaymentReadyRequest.Item(999L, 3)));
+
+            stubManagerInfo();
+            stubItemDetails();
+
+            // when & then
+            assertThatThrownBy(() -> paymentService.preparePayment("1", request))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(PaymentErrorCode.ITEM_NOT_FOUND.getMessage());
+        }
+
+        @Test
+        void 재고보다_많은_수량을_요청하면_OUT_OF_STOCK_예외가_발생한다() throws JsonProcessingException {
+            // given
+            PaymentReadyRequest request =
+                    new PaymentReadyRequest(
+                            1L,
+                            List.of(
+                                    new PaymentReadyRequest.Item(9L, 1),
+                                    new PaymentReadyRequest.Item(17L, 12)));
+
+            stubManagerInfo();
+            stubItemDetails();
+
+            // when & then
+            assertThatThrownBy(() -> paymentService.preparePayment("1", request))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(PaymentErrorCode.OUT_OF_STOCK.getMessage());
+        }
+
+        private void stubManagerInfo() throws JsonProcessingException {
+            String managerExpectedResponse =
+                    objectMapper.writeValueAsString(
+                            Map.of(
+                                    "memberId",
+                                    1,
+                                    "nickname",
+                                    "현태",
+                                    "role",
+                                    "USER",
+                                    "status",
+                                    "NORMAL"));
+
+            stubFor(
+                    get(urlEqualTo("/internal/1"))
+                            .willReturn(
+                                    aResponse()
+                                            .withStatus(200)
+                                            .withHeader("Content-Type", "application/json")
+                                            .withBody(managerExpectedResponse)));
+        }
+
+        private void stubItemDetails() throws JsonProcessingException {
+            String body =
+                    objectMapper.writeValueAsString(
+                            List.of(
+                                    Map.of(
+                                            "itemId", 9, "name", "피규어 지수", "price", 84000, "stock",
+                                            20),
+                                    Map.of(
+                                            "itemId", 17, "name", "크룽크 미니백", "price", 15000,
+                                            "stock", 10)));
+
+            stubFor(
+                    post(urlEqualTo("/internal/popups/1/items/details"))
+                            .willReturn(
+                                    aResponse()
+                                            .withStatus(200)
+                                            .withHeader("Content-Type", "application/json")
+                                            .withBody(body)));
+        }
+    }
+}

--- a/popi-payment-service/src/test/resources/application-test.yml
+++ b/popi-payment-service/src/test/resources/application-test.yml
@@ -1,7 +1,18 @@
 spring:
-  profiles:
-    active: test
+  config:
+    activate:
+      on-profile: "test"
   datasource:
     url: jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=false;MODE=MYSQL
   flyway:
     enabled: false
+
+manager:
+  service:
+    name: managers
+    url: http://localhost:${wiremock.server.port}
+
+member:
+  service:
+    name: members
+    url: http://localhost:${wiremock.server.port}


### PR DESCRIPTION
## 🌱 관련 이슈

- [LCR-227]

---
## 📌 작업 내용 및 특이사항

- 클라이언트에서 아임포트 결제창 호출에 필요한 정보를 응답하는 결제 준비 API를 구현했습니다.
- Manager 서비스의 GET /internal/{managerId}를 통해 구매자 정보를 조회합니다.
- Item 서비스의 POST /internal/popups/{popupId}/items/details를 통해 아이템 상세 정보를 조회합니다.
- 조회된 정보를 바탕으로 아래 항목을 응답합니다:
  - buyerName: 구매자명
  - name: 대표 아이템명 ("상품명 외 N건" 형식)
  - amount: 총 결제 금액
  - merchantUid: popup_{popupId}_order_{UUID} 형식의 고유 주문번호
- 잘못된 itemId가 포함되거나, 요청 수량이 재고보다 많을 경우 예외가 발생합니다.

---
## 📚 참고사항

- 결제 완료 시 구매전환율 분석을 위한 상품 카운트 증가와 상품 재고 차감 등 Kafka를 활용한 비동기 처리는 일단 결제 검증 기능 구현 마치고 진행하겠습니다.

[LCR-227]: https://lgcns-retail.atlassian.net/browse/LCR-227?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ