### PR TITLE
feat: 인기 팝업 리스트 조회 기능 구현

### DIFF
--- a/popi-popup-service/src/main/java/com/lgcns/client/ManagerServiceClient.java
+++ b/popi-popup-service/src/main/java/com/lgcns/client/ManagerServiceClient.java
@@ -23,6 +23,6 @@ public interface ManagerServiceClient {
     @GetMapping("/internal/popups/{popupId}")
     PopupDetailsResponse findPopupDetailsById(@PathVariable(name = "popupId") Long popupId);
 
-    @PostMapping("/internal/popups/hot")
+    @PostMapping("/internal/popups/popularity")
     List<PopupInfoResponse> findHotPopupsByIds(@RequestBody List<Long> popupIds);
 }

--- a/popi-popup-service/src/main/java/com/lgcns/client/ManagerServiceClient.java
+++ b/popi-popup-service/src/main/java/com/lgcns/client/ManagerServiceClient.java
@@ -16,7 +16,7 @@ public interface ManagerServiceClient {
 
     @GetMapping("/internal/popups")
     SliceResponse<PopupInfoResponse> findPopupsByName(
-            @RequestParam(name = "searchName", required = false) String searchName,
+            @RequestParam(name = "keyword", required = false) String keyword,
             @RequestParam(name = "lastPopupId", required = false) Long lastPopupId,
             @RequestParam(name = "size", defaultValue = "8") int size);
 

--- a/popi-popup-service/src/main/java/com/lgcns/client/ManagerServiceClient.java
+++ b/popi-popup-service/src/main/java/com/lgcns/client/ManagerServiceClient.java
@@ -4,10 +4,9 @@ import com.lgcns.config.FeignConfig;
 import com.lgcns.dto.response.PopupDetailsResponse;
 import com.lgcns.dto.response.PopupInfoResponse;
 import com.lgcns.response.SliceResponse;
+import java.util.List;
 import org.springframework.cloud.openfeign.FeignClient;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.*;
 
 @FeignClient(
         name = "${manager.service.name}",
@@ -23,4 +22,7 @@ public interface ManagerServiceClient {
 
     @GetMapping("/internal/popups/{popupId}")
     PopupDetailsResponse findPopupDetailsById(@PathVariable(name = "popupId") Long popupId);
+
+    @PostMapping("/internal/popups/hot")
+    List<PopupInfoResponse> findHotPopupsByIds(@RequestBody List<Long> popupIds);
 }

--- a/popi-popup-service/src/main/java/com/lgcns/client/ReservationServiceClient.java
+++ b/popi-popup-service/src/main/java/com/lgcns/client/ReservationServiceClient.java
@@ -12,5 +12,5 @@ import org.springframework.web.bind.annotation.GetMapping;
 public interface ReservationServiceClient {
 
     @GetMapping("/internal/popups/hot")
-    List<Long> getHotPopupIds();
+    List<Long> findHotPopupIds();
 }

--- a/popi-popup-service/src/main/java/com/lgcns/client/ReservationServiceClient.java
+++ b/popi-popup-service/src/main/java/com/lgcns/client/ReservationServiceClient.java
@@ -11,6 +11,6 @@ import org.springframework.web.bind.annotation.GetMapping;
         configuration = FeignConfig.class)
 public interface ReservationServiceClient {
 
-    @GetMapping("/internal/popups/hot")
+    @GetMapping("/internal/popups/popularity")
     List<Long> findHotPopupIds();
 }

--- a/popi-popup-service/src/main/java/com/lgcns/client/ReservationServiceClient.java
+++ b/popi-popup-service/src/main/java/com/lgcns/client/ReservationServiceClient.java
@@ -1,0 +1,17 @@
+package com.lgcns.client;
+
+import com.lgcns.config.FeignConfig;
+import com.lgcns.dto.response.PopupInfoResponse;
+import java.util.List;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@FeignClient(
+        name = "${reservation.service.name}",
+        url = "${reservation.service.url:}",
+        configuration = FeignConfig.class)
+public interface ReservationServiceClient {
+
+    @GetMapping("/internal/popups/hot")
+    List<PopupInfoResponse> findHotPopups();
+}

--- a/popi-popup-service/src/main/java/com/lgcns/client/ReservationServiceClient.java
+++ b/popi-popup-service/src/main/java/com/lgcns/client/ReservationServiceClient.java
@@ -1,7 +1,6 @@
 package com.lgcns.client;
 
 import com.lgcns.config.FeignConfig;
-import com.lgcns.dto.response.PopupInfoResponse;
 import java.util.List;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -13,5 +12,5 @@ import org.springframework.web.bind.annotation.GetMapping;
 public interface ReservationServiceClient {
 
     @GetMapping("/internal/popups/hot")
-    List<PopupInfoResponse> findHotPopups();
+    List<Long> getHotPopupIds();
 }

--- a/popi-popup-service/src/main/java/com/lgcns/externalApi/PopupController.java
+++ b/popi-popup-service/src/main/java/com/lgcns/externalApi/PopupController.java
@@ -7,6 +7,7 @@ import com.lgcns.service.PopupService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -39,5 +40,11 @@ public class PopupController {
     @Operation(summary = "팝업 상세 조회", description = "팝업에 대한 상세 정보를 반환합니다.")
     public PopupDetailsResponse popupDetailsFindById(@PathVariable(name = "popupId") Long popupId) {
         return popupService.findPopupDetailsById(popupId);
+    }
+
+    @GetMapping("/popups/hot")
+    @Operation(summary = "인기 팝업 목록 조회", description = "예약자 수가 많은 상위 4개의 팝업 리스트를 반환합니다.")
+    public List<PopupInfoResponse> hotPopupsFind() {
+        return popupService.findHotPopups();
     }
 }

--- a/popi-popup-service/src/main/java/com/lgcns/externalApi/PopupController.java
+++ b/popi-popup-service/src/main/java/com/lgcns/externalApi/PopupController.java
@@ -42,7 +42,7 @@ public class PopupController {
         return popupService.findPopupDetailsById(popupId);
     }
 
-    @GetMapping("/popups/hot")
+    @GetMapping("/popups/popularity")
     @Operation(summary = "인기 팝업 목록 조회", description = "예약자 수가 많은 상위 4개의 팝업 리스트를 반환합니다.")
     public List<PopupInfoResponse> hotPopupsFind() {
         return popupService.findHotPopups();

--- a/popi-popup-service/src/main/java/com/lgcns/service/PopupService.java
+++ b/popi-popup-service/src/main/java/com/lgcns/service/PopupService.java
@@ -3,9 +3,12 @@ package com.lgcns.service;
 import com.lgcns.dto.response.PopupDetailsResponse;
 import com.lgcns.dto.response.PopupInfoResponse;
 import com.lgcns.response.SliceResponse;
+import java.util.List;
 
 public interface PopupService {
     SliceResponse<PopupInfoResponse> findPopupsByName(String keyword, Long lastPopupId, int size);
 
     PopupDetailsResponse findPopupDetailsById(Long popupId);
+
+    List<PopupInfoResponse> findHotPopups();
 }

--- a/popi-popup-service/src/main/java/com/lgcns/service/PopupServiceImpl.java
+++ b/popi-popup-service/src/main/java/com/lgcns/service/PopupServiceImpl.java
@@ -1,9 +1,11 @@
 package com.lgcns.service;
 
 import com.lgcns.client.ManagerServiceClient;
+import com.lgcns.client.ReservationServiceClient;
 import com.lgcns.dto.response.PopupDetailsResponse;
 import com.lgcns.dto.response.PopupInfoResponse;
 import com.lgcns.response.SliceResponse;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -12,6 +14,7 @@ import org.springframework.stereotype.Service;
 public class PopupServiceImpl implements PopupService {
 
     private final ManagerServiceClient managerServiceClient;
+    private final ReservationServiceClient reservationServiceClient;
 
     @Override
     public SliceResponse<PopupInfoResponse> findPopupsByName(
@@ -22,5 +25,10 @@ public class PopupServiceImpl implements PopupService {
     @Override
     public PopupDetailsResponse findPopupDetailsById(Long popupId) {
         return managerServiceClient.findPopupDetailsById(popupId);
+    }
+
+    @Override
+    public List<PopupInfoResponse> findHotPopups() {
+        return reservationServiceClient.findHotPopups();
     }
 }

--- a/popi-popup-service/src/main/java/com/lgcns/service/PopupServiceImpl.java
+++ b/popi-popup-service/src/main/java/com/lgcns/service/PopupServiceImpl.java
@@ -31,7 +31,7 @@ public class PopupServiceImpl implements PopupService {
     public List<PopupInfoResponse> findHotPopups() {
         List<Long> popupIds = reservationServiceClient.findHotPopupIds();
 
-        if (popupIds == null || popupIds.isEmpty()) {
+        if (popupIds.isEmpty()) {
             return List.of();
         }
 

--- a/popi-popup-service/src/main/java/com/lgcns/service/PopupServiceImpl.java
+++ b/popi-popup-service/src/main/java/com/lgcns/service/PopupServiceImpl.java
@@ -29,6 +29,7 @@ public class PopupServiceImpl implements PopupService {
 
     @Override
     public List<PopupInfoResponse> findHotPopups() {
-        return reservationServiceClient.findHotPopups();
+        List<Long> popupIds = reservationServiceClient.getHotPopupIds();
+        // TODO: Manager에 popupIds를 보내 List<PopupInfoResponse>를 받아온다.
     }
 }

--- a/popi-popup-service/src/main/java/com/lgcns/service/PopupServiceImpl.java
+++ b/popi-popup-service/src/main/java/com/lgcns/service/PopupServiceImpl.java
@@ -29,7 +29,12 @@ public class PopupServiceImpl implements PopupService {
 
     @Override
     public List<PopupInfoResponse> findHotPopups() {
-        List<Long> popupIds = reservationServiceClient.getHotPopupIds();
-        // TODO: Manager에 popupIds를 보내 List<PopupInfoResponse>를 받아온다.
+        List<Long> popupIds = reservationServiceClient.findHotPopupIds();
+
+        if (popupIds == null || popupIds.isEmpty()) {
+            return List.of();
+        }
+
+        return managerServiceClient.findHotPopupsByIds(popupIds);
     }
 }

--- a/popi-popup-service/src/main/resources/application-local.yml
+++ b/popi-popup-service/src/main/resources/application-local.yml
@@ -33,3 +33,7 @@ manager:
   service:
     name: managers
     url: http://localhost:8080
+
+reservation:
+  service:
+    name: reservations

--- a/popi-popup-service/src/test/java/com/lgcns/service/PopupServiceTest.java
+++ b/popi-popup-service/src/test/java/com/lgcns/service/PopupServiceTest.java
@@ -461,7 +461,8 @@ public class PopupServiceTest extends WireMockIntegrationTest {
                     () -> assertThat(result).isNotNull(), () -> assertThat(result).isEmpty());
 
             // verify
-            wireMockServer.verify(0, postRequestedFor(urlPathEqualTo("/internal/popups/hot")));
+            wireMockServer.verify(
+                    0, postRequestedFor(urlPathEqualTo("/internal/popups/popularity")));
         }
 
         @Test
@@ -508,7 +509,7 @@ public class PopupServiceTest extends WireMockIntegrationTest {
 
     private void stubFindHotPopupIds(int status, String body) {
         wireMockServer.stubFor(
-                get(urlPathEqualTo("/internal/popups/hot"))
+                get(urlPathEqualTo("/internal/popups/popularity"))
                         .willReturn(
                                 aResponse()
                                         .withStatus(status)
@@ -522,7 +523,7 @@ public class PopupServiceTest extends WireMockIntegrationTest {
             String requestBody = objectMapper.writeValueAsString(popupIds);
 
             wireMockServer.stubFor(
-                    post(urlPathEqualTo("/internal/popups/hot"))
+                    post(urlPathEqualTo("/internal/popups/popularity"))
                             .withRequestBody(equalToJson(requestBody))
                             .willReturn(
                                     aResponse()

--- a/popi-popup-service/src/test/java/com/lgcns/service/PopupServiceTest.java
+++ b/popi-popup-service/src/test/java/com/lgcns/service/PopupServiceTest.java
@@ -564,7 +564,7 @@ public class PopupServiceTest extends WireMockIntegrationTest {
     private void stubFindPopupsByName(String keyword, int size, int status, String body) {
         wireMockServer.stubFor(
                 get(urlPathEqualTo("/internal/popups"))
-                        .withQueryParam("searchName", equalTo(keyword))
+                        .withQueryParam("keyword", equalTo(keyword))
                         .withQueryParam("size", equalTo(String.valueOf(size)))
                         .willReturn(
                                 aResponse()

--- a/popi-popup-service/src/test/resources/application-test.yml
+++ b/popi-popup-service/src/test/resources/application-test.yml
@@ -7,3 +7,8 @@ manager:
   service:
     name: managers
     url: http://localhost:${wiremock.server.port}
+
+reservation:
+  service:
+    name: reservations
+    url: http://localhost:${wiremock.server.port}

--- a/popi-reservation-service/src/main/java/com/lgcns/internalApi/MemberReservationInternalController.java
+++ b/popi-reservation-service/src/main/java/com/lgcns/internalApi/MemberReservationInternalController.java
@@ -1,0 +1,21 @@
+package com.lgcns.internalApi;
+
+import com.lgcns.service.MemberReservationService;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/internal")
+public class MemberReservationInternalController {
+
+    private final MemberReservationService memberReservationService;
+
+    @GetMapping("/popups/hot")
+    public List<Long> findHotPopups() {
+        return memberReservationService.findHotPopupIds();
+    }
+}

--- a/popi-reservation-service/src/main/java/com/lgcns/internalApi/MemberReservationInternalController.java
+++ b/popi-reservation-service/src/main/java/com/lgcns/internalApi/MemberReservationInternalController.java
@@ -14,7 +14,7 @@ public class MemberReservationInternalController {
 
     private final MemberReservationService memberReservationService;
 
-    @GetMapping("/popups/hot")
+    @GetMapping("/popups/popularity")
     public List<Long> findHotPopups() {
         return memberReservationService.findHotPopupIds();
     }

--- a/popi-reservation-service/src/main/java/com/lgcns/repository/MemberReservationRepositoryCustom.java
+++ b/popi-reservation-service/src/main/java/com/lgcns/repository/MemberReservationRepositoryCustom.java
@@ -8,4 +8,6 @@ public interface MemberReservationRepositoryCustom {
 
     List<DailyReservationCountResponse> findDailyReservationCount(
             Long popupId, LocalDate popupOpenDate, LocalDate popupCloseDate, String date);
+
+    List<Long> findHotPopupIds();
 }

--- a/popi-reservation-service/src/main/java/com/lgcns/service/MemberReservationService.java
+++ b/popi-reservation-service/src/main/java/com/lgcns/service/MemberReservationService.java
@@ -10,5 +10,8 @@ public interface MemberReservationService {
 
     List<SurveyChoiceResponse> findSurveyChoicesByPopupId(String memberId, Long popupId);
 
+
     List<ReservationDetailResponse> findReservationInfo(String memberId);
+
+    List<>
 }

--- a/popi-reservation-service/src/main/java/com/lgcns/service/MemberReservationService.java
+++ b/popi-reservation-service/src/main/java/com/lgcns/service/MemberReservationService.java
@@ -10,8 +10,7 @@ public interface MemberReservationService {
 
     List<SurveyChoiceResponse> findSurveyChoicesByPopupId(String memberId, Long popupId);
 
-
     List<ReservationDetailResponse> findReservationInfo(String memberId);
 
-    List<>
+    List<Long> findHotPopupIds();
 }

--- a/popi-reservation-service/src/main/java/com/lgcns/service/MemberReservationServiceImpl.java
+++ b/popi-reservation-service/src/main/java/com/lgcns/service/MemberReservationServiceImpl.java
@@ -62,6 +62,7 @@ public class MemberReservationServiceImpl implements MemberReservationService {
     }
 
     @Override
+<<<<<<< HEAD
     public List<ReservationDetailResponse> findReservationInfo(String memberId) {
         List<MemberReservation> memberReservationList =
                 memberReservationRepository.findByMemberId(Long.parseLong(memberId));
@@ -93,6 +94,10 @@ public class MemberReservationServiceImpl implements MemberReservationService {
                                         reservation,
                                         reservationPopupInfoMap.get(reservation.getPopupId())))
                 .toList();
+=======
+    public List<Long> findHotPopupIds() {
+        return memberReservationRepository.findHotPopupIds();
+>>>>>>> 06a8c1d ([LCR-223] feat: 인기 팝업 id 리스트를 반환하는 서비스 구현)
     }
 
     private void validateYearMonthFormat(String date) {

--- a/popi-reservation-service/src/main/java/com/lgcns/service/MemberReservationServiceImpl.java
+++ b/popi-reservation-service/src/main/java/com/lgcns/service/MemberReservationServiceImpl.java
@@ -62,7 +62,6 @@ public class MemberReservationServiceImpl implements MemberReservationService {
     }
 
     @Override
-<<<<<<< HEAD
     public List<ReservationDetailResponse> findReservationInfo(String memberId) {
         List<MemberReservation> memberReservationList =
                 memberReservationRepository.findByMemberId(Long.parseLong(memberId));
@@ -94,10 +93,11 @@ public class MemberReservationServiceImpl implements MemberReservationService {
                                         reservation,
                                         reservationPopupInfoMap.get(reservation.getPopupId())))
                 .toList();
-=======
+    }
+
+    @Override
     public List<Long> findHotPopupIds() {
         return memberReservationRepository.findHotPopupIds();
->>>>>>> 06a8c1d ([LCR-223] feat: 인기 팝업 id 리스트를 반환하는 서비스 구현)
     }
 
     private void validateYearMonthFormat(String date) {

--- a/popi-reservation-service/src/test/java/com/lgcns/service/MemberReservationServiceTest.java
+++ b/popi-reservation-service/src/test/java/com/lgcns/service/MemberReservationServiceTest.java
@@ -428,6 +428,89 @@ class MemberReservationServiceTest extends WireMockIntegrationTest {
         }
     }
 
+    @Nested
+    class 인기_팝업_아이디를_조회할_때 {
+
+        @Test
+        void 예약된_팝업이_4개_이상이면_크기가_4인_리스트를_예약자_수_내림차순으로_반환한다() {
+            // given
+            memberReservationRepository.deleteAll();
+
+            insertMultipleReservations(1L, 10);
+            insertMultipleReservations(2L, 8);
+            insertMultipleReservations(3L, 6);
+            insertMultipleReservations(4L, 4);
+            insertMultipleReservations(5L, 2);
+
+            // when
+            List<Long> expectedIds = memberReservationService.findHotPopupIds();
+
+            // then
+            assertThat(expectedIds).hasSize(4);
+            assertThat(expectedIds).containsExactly(1L, 2L, 3L, 4L);
+        }
+
+        @Test
+        void 예약자_수가_모두_같은_경우_팝업_아이디_오름차순으로_반환한다() {
+            // given
+            memberReservationRepository.deleteAll();
+
+            insertMultipleReservations(3L, 5);
+            insertMultipleReservations(1L, 5);
+            insertMultipleReservations(4L, 5);
+            insertMultipleReservations(2L, 5);
+
+            // when
+            List<Long> expectedIds = memberReservationService.findHotPopupIds();
+
+            // then
+            assertThat(expectedIds).hasSize(4);
+            assertThat(expectedIds).containsExactly(1L, 2L, 3L, 4L); // 팝업 ID 오름차순
+        }
+
+        @Test
+        void 예약된_팝업이_2개인_경우_크키가_2인_리스트를_예약자_수_내림차순으로_반환한다() {
+            // given
+            memberReservationRepository.deleteAll();
+
+            insertMultipleReservations(1L, 5);
+            insertMultipleReservations(2L, 7);
+
+            // when
+            List<Long> expectedIds = memberReservationService.findHotPopupIds();
+
+            // then
+            assertThat(expectedIds).hasSize(2);
+            assertThat(expectedIds).containsExactly(2L, 1L);
+        }
+
+        @Test
+        void 예약된_팝없이_없는_경우_빈_리스트를_반환한다() {
+            // given
+            memberReservationRepository.deleteAll();
+
+            // when
+            List<Long> expectedIds = memberReservationService.findHotPopupIds();
+
+            // then
+            assertThat(expectedIds).isEmpty();
+        }
+    }
+
+    private void insertMultipleReservations(Long popupId, int count) {
+        for (int i = 0; i < count; i++) {
+            MemberReservation reservation =
+                    MemberReservation.createMemberReservation(
+                            reservationIdGenerator.getAndIncrement(),
+                            memberIdGenerator.getAndIncrement(),
+                            popupId,
+                            null,
+                            LocalDate.of(2025, 6, 1),
+                            LocalTime.of(12, 0));
+            memberReservationRepository.save(reservation);
+        }
+    }
+
     private void stubFindAvailableDate(Long popupId, String date, int status, String body) {
         try {
             wireMockServer.stubFor(


### PR DESCRIPTION
## 🌱 관련 이슈

- [LCR-223]

---
## 📌 작업 내용 및 특이사항

- 메인페이지에 표시될 인기 팝업(4개) 리스트를 조회하는 기능을 구현 했습니다.
- 인기는 예약자 수로 판별하며 내림차순으로 정렬하여 반환됩니다.
- 서비스 레이어에서는 총 2개의 feignClient를 사용해 각각  reservation-service, manager-service의 순서대로 내부 요청을 보냅니다.
+ 먼저 reservation-service로부터 예약된 회원이 존재하는 팝업들의 ID 리스트를 받아옵니다.
+ 받아온 팝업ID 리스트를 가지고 manager-service로부터 PopupInfoResponse 리스트를 받아옵니다.
* 팝업 ID리스트를 @RequestBody에 담아 보내야 하므로 @PostMapping을 통해 internalApi로 요청을 보냅니다.
- 팝업ID 리스트가 빈 리스트인 경우 manager-service로 feign 요청을 보내지 않고 바로 빈 리스트를 반환하도록 했습니다.
- 이 외의 별도의 예외처리는 구현하지 않았습니다.
- 최대 4개의 리스트를 반환하며, 팝업의 예약자 수가 동일한 경우 팝업ID 오름차순으로 정렬하여 반환합니다.
- 기존 popup 검색 api에 대한 404오류가 있었는데 FeignClient의 요청 파라미터명이 잘못되어 있어서 발생한 오류였습니다.
+ 컨벤션과 동일하게 검색어 변수명을 keyword로 수정하여 해결했습니다.

---
## 📚 참고사항

- openfeign을 2번 호출하는 서비스 흐름에 따라, 테스트 코드에 verify절을 추가하여 다음 URL에 대한 호출이 실행되었는지 여부를 판단하도록 했습니다.
```java
// verify
wireMockServer.verify(0, postRequestedFor(urlPathEqualTo("/internal/popups/hot")));
```


[LCR-223]: https://lgcns-retail.atlassian.net/browse/LCR-223?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ