### PR TITLE
feat: 결제 검증 로직 구현

### DIFF
--- a/popi-payment-service/build.gradle
+++ b/popi-payment-service/build.gradle
@@ -1,3 +1,8 @@
+repositories {
+    mavenCentral()
+    maven { url 'https://jitpack.io' }
+}
+
 dependencies {
     implementation project(':popi-domain')
     implementation project(':popi-common')
@@ -31,4 +36,7 @@ dependencies {
 
     // WireMock
     testImplementation 'org.springframework.cloud:spring-cloud-contract-wiremock:4.2.1'
+
+    // Iamport
+    implementation 'com.github.iamport:iamport-rest-client-java:0.2.23'
 }

--- a/popi-payment-service/src/main/java/com/lgcns/domain/Payment.java
+++ b/popi-payment-service/src/main/java/com/lgcns/domain/Payment.java
@@ -43,4 +43,10 @@ public class Payment extends BaseTimeEntity {
                 .status(PaymentStatus.READY)
                 .build();
     }
+
+    public void updatePayment(String impUid, String pgProvider, int amount) {
+        this.impUid = impUid;
+        this.pgProvider = pgProvider;
+        this.amount = amount;
+    }
 }

--- a/popi-payment-service/src/main/java/com/lgcns/domain/Payment.java
+++ b/popi-payment-service/src/main/java/com/lgcns/domain/Payment.java
@@ -44,9 +44,10 @@ public class Payment extends BaseTimeEntity {
                 .build();
     }
 
-    public void updatePayment(String impUid, String pgProvider, int amount) {
+    public void updatePayment(String impUid, String pgProvider, int amount, PaymentStatus status) {
         this.impUid = impUid;
         this.pgProvider = pgProvider;
         this.amount = amount;
+        this.status = status;
     }
 }

--- a/popi-payment-service/src/main/java/com/lgcns/exception/PaymentErrorCode.java
+++ b/popi-payment-service/src/main/java/com/lgcns/exception/PaymentErrorCode.java
@@ -10,6 +10,10 @@ import org.springframework.http.HttpStatus;
 public enum PaymentErrorCode implements ErrorCode {
     ITEM_NOT_FOUND(HttpStatus.NOT_FOUND, "결제 대상 상품 정보를 찾을 수 없습니다."),
     OUT_OF_STOCK(HttpStatus.BAD_REQUEST, "상품 재고가 부족합니다."),
+
+    PAYMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "결제 정보를 찾을 수 없습니다."),
+    INVALID_AMOUNT(HttpStatus.BAD_REQUEST, "결제 금액이 일치하지 않습니다."),
+    NOT_PAID(HttpStatus.BAD_REQUEST, "결제가 완료되지 않았습니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/popi-payment-service/src/main/java/com/lgcns/externalApi/PaymentController.java
+++ b/popi-payment-service/src/main/java/com/lgcns/externalApi/PaymentController.java
@@ -3,13 +3,12 @@ package com.lgcns.externalApi;
 import com.lgcns.dto.request.PaymentReadyRequest;
 import com.lgcns.dto.response.PaymentReadyResponse;
 import com.lgcns.service.PaymentService;
+import com.siot.IamportRestClient.exception.IamportResponseException;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.io.IOException;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestHeader;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -25,5 +24,14 @@ public class PaymentController {
     public PaymentReadyResponse paymentPrepare(
             @RequestHeader("member-id") String memberId, @RequestBody PaymentReadyRequest request) {
         return paymentService.preparePayment(memberId, request);
+    }
+
+    @PostMapping("/verify/{impUid}")
+    @Operation(
+            summary = "impUid 기반 결제 검증",
+            description = "impUid에 해당하는 결제 정보를 아임포트에서 조회하고, 결제 금액과 상태를 검증합니다.")
+    public void paymentByImpUidFind(@PathVariable("impUid") String impUid)
+            throws IamportResponseException, IOException {
+        paymentService.findPaymentByImpUid(impUid);
     }
 }

--- a/popi-payment-service/src/main/java/com/lgcns/infra/config/IamportClientConfig.java
+++ b/popi-payment-service/src/main/java/com/lgcns/infra/config/IamportClientConfig.java
@@ -1,0 +1,19 @@
+package com.lgcns.infra.config;
+
+import com.lgcns.infra.iamport.IamportProperties;
+import com.siot.IamportRestClient.IamportClient;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@RequiredArgsConstructor
+public class IamportClientConfig {
+
+    private final IamportProperties iamportProperties;
+
+    @Bean
+    public IamportClient iamportClient() {
+        return new IamportClient(iamportProperties.key(), iamportProperties.secret());
+    }
+}

--- a/popi-payment-service/src/main/java/com/lgcns/infra/iamport/IamportProperties.java
+++ b/popi-payment-service/src/main/java/com/lgcns/infra/iamport/IamportProperties.java
@@ -1,0 +1,6 @@
+package com.lgcns.infra.iamport;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "iamport")
+public record IamportProperties(String key, String secret) {}

--- a/popi-payment-service/src/main/java/com/lgcns/infra/properties/PropertiesConfig.java
+++ b/popi-payment-service/src/main/java/com/lgcns/infra/properties/PropertiesConfig.java
@@ -1,0 +1,9 @@
+package com.lgcns.infra.properties;
+
+import com.lgcns.infra.iamport.IamportProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@EnableConfigurationProperties({IamportProperties.class})
+@Configuration
+public class PropertiesConfig {}

--- a/popi-payment-service/src/main/java/com/lgcns/repository/PaymentRepository.java
+++ b/popi-payment-service/src/main/java/com/lgcns/repository/PaymentRepository.java
@@ -1,6 +1,9 @@
 package com.lgcns.repository;
 
 import com.lgcns.domain.Payment;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface PaymentRepository extends JpaRepository<Payment, Long> {}
+public interface PaymentRepository extends JpaRepository<Payment, Long> {
+    Optional<Payment> findByMerchantUid(String merchantUid);
+}

--- a/popi-payment-service/src/main/java/com/lgcns/service/PaymentService.java
+++ b/popi-payment-service/src/main/java/com/lgcns/service/PaymentService.java
@@ -2,7 +2,11 @@ package com.lgcns.service;
 
 import com.lgcns.dto.request.PaymentReadyRequest;
 import com.lgcns.dto.response.PaymentReadyResponse;
+import com.siot.IamportRestClient.exception.IamportResponseException;
+import java.io.IOException;
 
 public interface PaymentService {
     PaymentReadyResponse preparePayment(String memberId, PaymentReadyRequest request);
+
+    void findPaymentByImpUid(String impUid) throws IamportResponseException, IOException;
 }

--- a/popi-payment-service/src/main/java/com/lgcns/service/PaymentServiceImpl.java
+++ b/popi-payment-service/src/main/java/com/lgcns/service/PaymentServiceImpl.java
@@ -104,6 +104,6 @@ public class PaymentServiceImpl implements PaymentService {
             throw new CustomException(PaymentErrorCode.NOT_PAID);
         }
 
-        payment.updatePayment(impUid, pgProvider, amount);
+        payment.updatePayment(impUid, pgProvider, amount, PaymentStatus.PAID);
     }
 }

--- a/popi-payment-service/src/main/resources/application-local.yml
+++ b/popi-payment-service/src/main/resources/application-local.yml
@@ -26,6 +26,10 @@ spring:
     baseline-on-migrate: true
     locations: classpath:db/migration
 
+iamport:
+  key: ${IAMPORT_KEY}
+  secret: ${IAMPORT_SECRET}
+
 eureka:
   instance:
     instance-id: ${spring.cloud.client.hostname}:${spring.application.instance_id:${random.value}}


### PR DESCRIPTION
## 🌱 관련 이슈

- [LCR-236]

---
## 📌 작업 내용 및 특이사항

- imp_uid를 이용해 아임포트 결제 조회 API를 호출하여 실제 결제 정보를 받아오고, 해당 정보를 기반으로 DB의 결제 정보를 검증 및 업데이트하는 로직을 구현했습니다.
- 다음과 같은 유효성 검사를 수행합니다:
  - 결제 금액이 DB와 다른 경우: 
    - 사용자가 의도적으로 결제 금액을 변조했을 가능성이 있어 INVALID_AMOUNT 예외를 발생시켜 결제 처리를 중단합니다.
  - 결제 상태가 PAID가 아닌 경우:
    - 결제가 정상적으로 완료되지 않은 상태(ready, cancelled 등)일 수 있어, 해당 결제는 유효하지 않다고 판단하고 NOT_PAID 예외를 발생시킵니다.
- 검증 통과 시 DB에 결제정보를 반영하여 impUid, pgProvider, amount를 저장합니다.

---
## 📚 참고사항

- 실제 결제 처리가 완료되면 상품의 재고와 구매 카운트 이벤트 발행하는 부분은 빠른 프론트 API 연동을 위해 별도의 백로그로 진행하겠습니다.


[LCR-236]: https://lgcns-retail.atlassian.net/browse/LCR-236?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ