### PR TITLE
feat: 가까운 날짜 예약 상세 정보 조회 구현

### DIFF
--- a/popi-reservation-service/src/main/java/com/lgcns/client/managerClient/ManagerServiceClient.java
+++ b/popi-reservation-service/src/main/java/com/lgcns/client/managerClient/ManagerServiceClient.java
@@ -26,7 +26,8 @@ public interface ManagerServiceClient {
     List<SurveyChoiceResponse> findSurveyChoicesByPopupId(@PathVariable Long popupId);
 
     @PostMapping("/internal/reservations")
-    List<ReservationPopupInfoResponse> findReservedPopupInfo(@RequestBody PopupIdsRequest request);
+    List<ReservationPopupInfoResponse> findReservedPopupInfoList(
+            @RequestBody PopupIdsRequest request);
 
     @GetMapping("/internal/popups/{popupId}")
     ReservationPopupInfoResponse findReservedPopupInfo(@PathVariable Long popupId);

--- a/popi-reservation-service/src/main/java/com/lgcns/client/managerClient/ManagerServiceClient.java
+++ b/popi-reservation-service/src/main/java/com/lgcns/client/managerClient/ManagerServiceClient.java
@@ -28,6 +28,9 @@ public interface ManagerServiceClient {
     @PostMapping("/internal/reservations")
     List<ReservationPopupInfoResponse> findReservedPopupInfo(@RequestBody PopupIdsRequest request);
 
+    @GetMapping("/internal/popups/{popupId}")
+    ReservationPopupInfoResponse findReservedPopupInfo(@PathVariable Long popupId);
+
     @GetMapping("/internal/reservations/{reservationId}")
     ReservationInfoResponse findReservationById(@PathVariable("reservationId") Long reservationId);
 }

--- a/popi-reservation-service/src/main/java/com/lgcns/externalApi/MemberReservationController.java
+++ b/popi-reservation-service/src/main/java/com/lgcns/externalApi/MemberReservationController.java
@@ -50,6 +50,13 @@ public class MemberReservationController {
         return memberReservationService.findReservationInfo(memberId);
     }
 
+    @GetMapping("/upcoming")
+    @Operation(summary = "가까운 팝업 조회", description = "사용자가 예약한 팝업 중, 가장 가까운 날짜의 팝업을 조회합니다.")
+    public ReservationDetailResponse upcomingReservationInfoFind(
+            @RequestHeader("member-id") String memberId) {
+        return memberReservationService.findUpcomingReservationInfo(memberId);
+    }
+
     @DeleteMapping("/{memberReservationId}")
     @Operation(summary = "회원 예약 취소", description = "예약 ID를 사용하여 회원의 예약을 취소합니다.")
     public ResponseEntity<Void> cancelMemberReservation(

--- a/popi-reservation-service/src/main/java/com/lgcns/externalApi/MemberReservationController.java
+++ b/popi-reservation-service/src/main/java/com/lgcns/externalApi/MemberReservationController.java
@@ -22,17 +22,14 @@ public class MemberReservationController {
     @GetMapping("/popups/{popupId}")
     @Operation(summary = "가능한 예약 날짜 조회", description = "특정 연월에 대한 예약 가능 날짜를 조회합니다.")
     public AvailableDateResponse availableDateFind(
-            @RequestHeader("member-id") String memberId,
-            @PathVariable Long popupId,
-            @RequestParam String date) {
-        return memberReservationService.findAvailableDate(memberId, popupId, date);
+            @PathVariable Long popupId, @RequestParam String date) {
+        return memberReservationService.findAvailableDate(popupId, date);
     }
 
     @GetMapping("/popups/{popupId}/survey")
     @Operation(summary = "설문지 조회", description = "해당 팝업에 대한 설문지 선지들을 조회합니다.")
-    public List<SurveyChoiceResponse> choiceListByPopupIdFind(
-            @RequestHeader("member-id") String memberId, @PathVariable Long popupId) {
-        return memberReservationService.findSurveyChoicesByPopupId(memberId, popupId);
+    public List<SurveyChoiceResponse> choiceListByPopupIdFind(@PathVariable Long popupId) {
+        return memberReservationService.findSurveyChoicesByPopupId(popupId);
     }
 
     @PostMapping("/{reservationId}")

--- a/popi-reservation-service/src/main/java/com/lgcns/repository/MemberReservationRepositoryCustom.java
+++ b/popi-reservation-service/src/main/java/com/lgcns/repository/MemberReservationRepositoryCustom.java
@@ -1,5 +1,6 @@
 package com.lgcns.repository;
 
+import com.lgcns.domain.MemberReservation;
 import com.lgcns.dto.response.DailyReservationCountResponse;
 import java.time.LocalDate;
 import java.util.List;
@@ -8,6 +9,8 @@ public interface MemberReservationRepositoryCustom {
 
     List<DailyReservationCountResponse> findDailyReservationCount(
             Long popupId, LocalDate popupOpenDate, LocalDate popupCloseDate, String date);
+
+    MemberReservation findUpcomingReservation(Long memberId);
 
     List<Long> findHotPopupIds();
 }

--- a/popi-reservation-service/src/main/java/com/lgcns/repository/MemberReservationRepositoryImpl.java
+++ b/popi-reservation-service/src/main/java/com/lgcns/repository/MemberReservationRepositoryImpl.java
@@ -2,11 +2,13 @@ package com.lgcns.repository;
 
 import static com.lgcns.domain.QMemberReservation.memberReservation;
 
+import com.lgcns.domain.MemberReservation;
 import com.lgcns.dto.response.DailyReservationCountResponse;
 import com.lgcns.dto.response.HourlyReservationCount;
 import com.querydsl.core.Tuple;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.YearMonth;
 import java.util.ArrayList;
@@ -34,6 +36,36 @@ public class MemberReservationRepositoryImpl implements MemberReservationReposit
         List<Tuple> tuples = getHourlyReservationCounts(popupId, start, end);
 
         return convertToResponseList(tuples);
+    }
+
+    @Override
+    public MemberReservation findUpcomingReservation(Long memberId) {
+        LocalDateTime now = LocalDateTime.now();
+        LocalDate nowDate = now.toLocalDate();
+        LocalTime nowTime = now.toLocalTime();
+
+        return queryFactory
+                .selectFrom(memberReservation)
+                .where(
+                        memberReservation
+                                .memberId
+                                .eq(memberId)
+                                .and(
+                                        memberReservation
+                                                .reservationDate
+                                                .gt(nowDate)
+                                                .or(
+                                                        memberReservation
+                                                                .reservationDate
+                                                                .eq(nowDate)
+                                                                .and(
+                                                                        memberReservation
+                                                                                .reservationTime
+                                                                                .goe(nowTime)))))
+                .orderBy(
+                        memberReservation.reservationDate.asc(),
+                        memberReservation.reservationTime.asc())
+                .fetchFirst();
     }
 
     @Override

--- a/popi-reservation-service/src/main/java/com/lgcns/service/MemberReservationService.java
+++ b/popi-reservation-service/src/main/java/com/lgcns/service/MemberReservationService.java
@@ -12,6 +12,8 @@ public interface MemberReservationService {
 
     List<ReservationDetailResponse> findReservationInfo(String memberId);
 
+    ReservationDetailResponse findUpcomingReservationInfo(String memberId);
+
     void createMemberReservation(String memberId, Long reservationId);
 
     void updateMemberReservation(Long memberReservationId);

--- a/popi-reservation-service/src/main/java/com/lgcns/service/MemberReservationService.java
+++ b/popi-reservation-service/src/main/java/com/lgcns/service/MemberReservationService.java
@@ -6,9 +6,9 @@ import com.lgcns.dto.response.SurveyChoiceResponse;
 import java.util.List;
 
 public interface MemberReservationService {
-    AvailableDateResponse findAvailableDate(String memberId, Long popupId, String date);
+    AvailableDateResponse findAvailableDate(Long popupId, String date);
 
-    List<SurveyChoiceResponse> findSurveyChoicesByPopupId(String memberId, Long popupId);
+    List<SurveyChoiceResponse> findSurveyChoicesByPopupId(Long popupId);
 
     List<ReservationDetailResponse> findReservationInfo(String memberId);
 

--- a/popi-reservation-service/src/main/java/com/lgcns/service/MemberReservationServiceImpl.java
+++ b/popi-reservation-service/src/main/java/com/lgcns/service/MemberReservationServiceImpl.java
@@ -94,7 +94,7 @@ public class MemberReservationServiceImpl implements MemberReservationService {
                         .toList();
 
         List<ReservationPopupInfoResponse> reservationPopupInfoList =
-                managerServiceClient.findReservedPopupInfo(PopupIdsRequest.of(popupIds));
+                managerServiceClient.findReservedPopupInfoList(PopupIdsRequest.of(popupIds));
 
         Map<Long, ReservationPopupInfoResponse> reservationPopupInfoMap =
                 reservationPopupInfoList.stream()

--- a/popi-reservation-service/src/main/java/com/lgcns/service/MemberReservationServiceImpl.java
+++ b/popi-reservation-service/src/main/java/com/lgcns/service/MemberReservationServiceImpl.java
@@ -118,6 +118,22 @@ public class MemberReservationServiceImpl implements MemberReservationService {
     }
 
     @Override
+    public ReservationDetailResponse findUpcomingReservationInfo(String memberId) {
+
+        MemberReservation upcomingReservation =
+                memberReservationRepository.findUpcomingReservation(Long.parseLong(memberId));
+
+        if (upcomingReservation == null) {
+            return null;
+        }
+
+        ReservationPopupInfoResponse reservationPopupInfo =
+                managerServiceClient.findReservedPopupInfo(upcomingReservation.getPopupId());
+
+        return ReservationDetailResponse.of(upcomingReservation, reservationPopupInfo);
+    }
+
+    @Override
     public void createMemberReservation(String memberId, Long reservationId) {
         validateMemberReservationExists(Long.parseLong(memberId), reservationId);
 

--- a/popi-reservation-service/src/main/java/com/lgcns/service/MemberReservationServiceImpl.java
+++ b/popi-reservation-service/src/main/java/com/lgcns/service/MemberReservationServiceImpl.java
@@ -49,7 +49,7 @@ public class MemberReservationServiceImpl implements MemberReservationService {
     private final RedisTemplate<String, Long> redisTemplate;
 
     @Override
-    public AvailableDateResponse findAvailableDate(String memberId, Long popupId, String date) {
+    public AvailableDateResponse findAvailableDate(Long popupId, String date) {
 
         validateYearMonthFormat(date);
 
@@ -74,7 +74,7 @@ public class MemberReservationServiceImpl implements MemberReservationService {
     }
 
     @Override
-    public List<SurveyChoiceResponse> findSurveyChoicesByPopupId(String memberId, Long popupId) {
+    public List<SurveyChoiceResponse> findSurveyChoicesByPopupId(Long popupId) {
         return managerServiceClient.findSurveyChoicesByPopupId(popupId);
     }
 

--- a/popi-reservation-service/src/main/resources/db/migration/V1_1__alter_member_reservation_table_add_column.sql
+++ b/popi-reservation-service/src/main/resources/db/migration/V1_1__alter_member_reservation_table_add_column.sql
@@ -1,3 +1,0 @@
-ALTER TABLE member_reservation
-    ADD COLUMN status VARCHAR(20) NOT NULL DEFAULT 'PENDING',
-ADD COLUMN is_entered BOOLEAN NOT NULL DEFAULT false;

--- a/popi-reservation-service/src/main/resources/db/migration/V2__alter_member_reservation_table_add_column.sql
+++ b/popi-reservation-service/src/main/resources/db/migration/V2__alter_member_reservation_table_add_column.sql
@@ -1,0 +1,3 @@
+ALTER TABLE member_reservation
+    ADD COLUMN status VARCHAR(20) NOT NULL DEFAULT 'PENDING',
+ADD COLUMN is_entered BOOLEAN NOT NULL DEFAULT false;

--- a/popi-reservation-service/src/main/resources/db/migration/V3__alert_member_reservation_table_change_qr_image_type.sql
+++ b/popi-reservation-service/src/main/resources/db/migration/V3__alert_member_reservation_table_change_qr_image_type.sql
@@ -1,0 +1,1 @@
+ALTER TABLE member_reservation MODIFY qr_image LONGTEXT;

--- a/popi-reservation-service/src/test/java/com/lgcns/service/MemberReservationServiceTest.java
+++ b/popi-reservation-service/src/test/java/com/lgcns/service/MemberReservationServiceTest.java
@@ -213,13 +213,7 @@ class MemberReservationServiceTest extends WireMockIntegrationTest {
             // given
             String date = "2025-05";
 
-            // 6월 1일은 모두 찬 상태
-            insertMemberReservation(LocalDate.of(2025, 6, 1), LocalTime.of(12, 0));
-            insertMemberReservation(LocalDate.of(2025, 6, 1), LocalTime.of(13, 0));
-            insertMemberReservation(LocalDate.of(2025, 6, 1), LocalTime.of(14, 0));
-
-            // 6월 2일은 일부만 찬 상태
-            insertMemberReservation(LocalDate.of(2025, 6, 2), LocalTime.of(13, 0));
+            createMemberReservation();
 
             String expectedResponse =
                     objectMapper.writeValueAsString(
@@ -256,13 +250,7 @@ class MemberReservationServiceTest extends WireMockIntegrationTest {
             // given
             String date = "2025-06";
 
-            // 6월 1일은 모두 찬 상태
-            insertMemberReservation(LocalDate.of(2025, 6, 1), LocalTime.of(12, 0));
-            insertMemberReservation(LocalDate.of(2025, 6, 1), LocalTime.of(13, 0));
-            insertMemberReservation(LocalDate.of(2025, 6, 1), LocalTime.of(14, 0));
-
-            // 6월 2일은 일부만 찬 상태
-            insertMemberReservation(LocalDate.of(2025, 6, 2), LocalTime.of(13, 0));
+            createMemberReservation();
 
             String expectedResponse =
                     objectMapper.writeValueAsString(
@@ -342,13 +330,7 @@ class MemberReservationServiceTest extends WireMockIntegrationTest {
             // given
             String date = "2025-06";
 
-            // 6월 1일은 모두 찬 상태
-            insertMemberReservation(LocalDate.of(2025, 6, 1), LocalTime.of(12, 0));
-            insertMemberReservation(LocalDate.of(2025, 6, 1), LocalTime.of(13, 0));
-            insertMemberReservation(LocalDate.of(2025, 6, 1), LocalTime.of(14, 0));
-
-            // 6월 2일은 일부만 찬 상태
-            insertMemberReservation(LocalDate.of(2025, 6, 2), LocalTime.of(13, 0));
+            createMemberReservation();
 
             String expectedResponse =
                     objectMapper.writeValueAsString(
@@ -363,22 +345,42 @@ class MemberReservationServiceTest extends WireMockIntegrationTest {
                                     List.of(
                                             Map.of(
                                                     "reservationDate",
-                                                    "2025-05-31",
+                                                    "2025-06-01",
                                                     "timeSlots",
                                                     List.of(
                                                             Map.of(
                                                                     "reservationId",
-                                                                    1,
+                                                                    4,
                                                                     "time",
                                                                     "12:00"),
                                                             Map.of(
                                                                     "reservationId",
-                                                                    2,
+                                                                    5,
                                                                     "time",
                                                                     "13:00"),
                                                             Map.of(
                                                                     "reservationId",
-                                                                    3,
+                                                                    6,
+                                                                    "time",
+                                                                    "14:00"))),
+                                            Map.of(
+                                                    "reservationDate",
+                                                    "2025-06-02",
+                                                    "timeSlots",
+                                                    List.of(
+                                                            Map.of(
+                                                                    "reservationId",
+                                                                    7,
+                                                                    "time",
+                                                                    "12:00"),
+                                                            Map.of(
+                                                                    "reservationId",
+                                                                    8,
+                                                                    "time",
+                                                                    "13:00"),
+                                                            Map.of(
+                                                                    "reservationId",
+                                                                    9,
                                                                     "time",
                                                                     "14:00"))))));
 
@@ -408,9 +410,23 @@ class MemberReservationServiceTest extends WireMockIntegrationTest {
         }
 
         @Test
-        void 예약_기간_아닌경우_빈_리스트_반환한다() {
+        void 예약_기간_아닌경우_빈_리스트_반환한다() throws JsonProcessingException {
             // given
             String date = "2025-07";
+
+            String expectedResponse =
+                    objectMapper.writeValueAsString(
+                            Map.of(
+                                    "popupOpenDate",
+                                    "2025-05-31",
+                                    "popupCloseDate",
+                                    "2025-06-02",
+                                    "timeCapacity",
+                                    5,
+                                    "dailyReservations",
+                                    List.of()));
+
+            stubFindAvailableDate(popupId, date, 200, expectedResponse);
 
             // when
             AvailableDateResponse response =
@@ -878,6 +894,30 @@ class MemberReservationServiceTest extends WireMockIntegrationTest {
 
             // then
             assertThat(reservations).isEmpty();
+        }
+    }
+
+    private void createMemberReservation() {
+        // 6월 1일은 모두 찬 상태
+        insertMemberReservation(LocalDate.of(2025, 6, 1), LocalTime.of(12, 0));
+        insertMemberReservation(LocalDate.of(2025, 6, 1), LocalTime.of(13, 0));
+        insertMemberReservation(LocalDate.of(2025, 6, 1), LocalTime.of(14, 0));
+
+        // 6월 2일은 일부만 찬 상태
+        insertMemberReservation(LocalDate.of(2025, 6, 2), LocalTime.of(13, 0));
+    }
+
+    private void insertMemberReservation(LocalDate date, LocalTime time) {
+        for (int i = 0; i < 5; i++) {
+            MemberReservation reservation =
+                    MemberReservation.createMemberReservation(
+                            reservationIdGenerator.getAndIncrement(),
+                            memberIdGenerator.getAndIncrement(),
+                            popupId,
+                            "iVBORw0KGgoAAAA...",
+                            date,
+                            time);
+            memberReservationRepository.save(reservation);
         }
     }
 


### PR DESCRIPTION
## 🌱 관련 이슈

- [LCR-105]

---
## 📌 작업 내용 및 특이사항

- 티켓 아이콘 클릭시, 가장 가까운 날짜의 예약 정보를 조회하는 기능을 구현했습니다.
- 예약 데이터가 과거이거나 예약이 존재하지 않을 경우 null을 반환하도록 했습니다.
- Feign 요청으로부터 받은 팝업 정보와 member_reservation의 예약 정보를 조합해 응답을 생성했습니다.

---
## 📚 참고사항


[LCR-105]: https://lgcns-retail.atlassian.net/browse/LCR-105?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ