### PR TITLE
fix: 팝업 서비스 API 엔드포인트 수정

### DIFF
--- a/popi-popup-service/src/main/java/com/lgcns/externalApi/PopupController.java
+++ b/popi-popup-service/src/main/java/com/lgcns/externalApi/PopupController.java
@@ -21,7 +21,7 @@ public class PopupController {
 
     private final PopupService popupService;
 
-    @GetMapping("/popups")
+    @GetMapping
     @Operation(summary = "팝업 목록 조회", description = "현재 운영중인 모든 팝업을 무한 스크롤을 위하여 페이징 처리한 뒤 반환합니다.")
     public SliceResponse<PopupInfoResponse> popupFindAll(
             @Parameter(description = "검색할 팝업 이름 (비워두면 모든 팝업을 반환합니다.)", example = "black")
@@ -36,13 +36,13 @@ public class PopupController {
         return popupService.findPopupsByName(keyword, lastPopupId, size);
     }
 
-    @GetMapping("/popups/{popupId}")
+    @GetMapping("/{popupId}")
     @Operation(summary = "팝업 상세 조회", description = "팝업에 대한 상세 정보를 반환합니다.")
     public PopupDetailsResponse popupDetailsFindById(@PathVariable(name = "popupId") Long popupId) {
         return popupService.findPopupDetailsById(popupId);
     }
 
-    @GetMapping("/popups/popularity")
+    @GetMapping("/popularity")
     @Operation(summary = "인기 팝업 목록 조회", description = "예약자 수가 많은 상위 4개의 팝업 리스트를 반환합니다.")
     public List<PopupInfoResponse> hotPopupsFind() {
         return popupService.findHotPopups();


### PR DESCRIPTION
## 🌱 관련 이슈

- [LCR-258]

---
## 📌 작업 내용 및 특이사항

- 기존 팝업서비스 api 엔드포인트가 /popups/popups/ 으로 되어있어, 해당 부분을 수정하였습니다.

---
## 📚 참고사항

-


[LCR-258]: https://lgcns-retail.atlassian.net/browse/LCR-258?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ