### PR TITLE
feat: Internal 오늘 예약자 수 조회 API 구현

### DIFF
--- a/popi-api-gateway/src/main/resources/application-local.yml
+++ b/popi-api-gateway/src/main/resources/application-local.yml
@@ -85,6 +85,14 @@ spring:
           filters:
               - RemoveRequestHeader=Cookie
               - RewritePath=/reservations/(?<segment>.*), /$\{segment}
+        - id: reservation-internal
+          uri: lb://RESERVATIONS
+          predicates:
+            - Path=/reservations/internal/**
+            - Method=GET
+          filters:
+            - RemoveRequestHeader=Cookie
+            - RewritePath=/reservations/(?<segment>.*), /$\{segment}
         - id: reservation-service
           uri: lb://RESERVATIONS
           predicates:

--- a/popi-reservation-service/src/main/java/com/lgcns/dto/response/DailyMemberReservationCountResponse.java
+++ b/popi-reservation-service/src/main/java/com/lgcns/dto/response/DailyMemberReservationCountResponse.java
@@ -1,0 +1,10 @@
+package com.lgcns.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record DailyMemberReservationCountResponse(
+        @Schema(description = "오늘 예약자 수", example = "100") Long reservationCount) {
+    public static DailyMemberReservationCountResponse of(Long reservationCount) {
+        return new DailyMemberReservationCountResponse(reservationCount);
+    }
+}

--- a/popi-reservation-service/src/main/java/com/lgcns/internalApi/MemberReservationInternalController.java
+++ b/popi-reservation-service/src/main/java/com/lgcns/internalApi/MemberReservationInternalController.java
@@ -1,11 +1,11 @@
 package com.lgcns.internalApi;
 
-import com.lgcns.service.MemberReservationService;
-import java.util.List;
-import lombok.RequiredArgsConstructor;
 import com.lgcns.dto.response.DailyMemberReservationCountResponse;
+import com.lgcns.service.MemberReservationService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;

--- a/popi-reservation-service/src/main/java/com/lgcns/internalApi/MemberReservationInternalController.java
+++ b/popi-reservation-service/src/main/java/com/lgcns/internalApi/MemberReservationInternalController.java
@@ -3,13 +3,18 @@ package com.lgcns.internalApi;
 import com.lgcns.service.MemberReservationService;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import com.lgcns.dto.response.DailyMemberReservationCountResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequiredArgsConstructor
 @RequestMapping("/internal")
+@RequiredArgsConstructor
+@Tag(name = "예약 서버 Internal API", description = "예약 서버 Internal API입니다.")
 public class MemberReservationInternalController {
 
     private final MemberReservationService memberReservationService;
@@ -17,5 +22,12 @@ public class MemberReservationInternalController {
     @GetMapping("/popups/popularity")
     public List<Long> findHotPopups() {
         return memberReservationService.findHotPopupIds();
+    }
+
+    @GetMapping("/{popupId}/daily-count")
+    @Operation(summary = "오늘 예약자 수 조회", description = "오늘 날짜에 해당하는 예약자 수를 조회합니다.")
+    public DailyMemberReservationCountResponse findDailyMemberReservationCount(
+            @PathVariable(name = "popupId") Long popupId) {
+        return memberReservationService.findDailyMemberReservationCount(popupId);
     }
 }

--- a/popi-reservation-service/src/main/java/com/lgcns/repository/MemberReservationRepositoryCustom.java
+++ b/popi-reservation-service/src/main/java/com/lgcns/repository/MemberReservationRepositoryCustom.java
@@ -1,6 +1,7 @@
 package com.lgcns.repository;
 
 import com.lgcns.domain.MemberReservation;
+import com.lgcns.dto.response.DailyMemberReservationCountResponse;
 import com.lgcns.dto.response.DailyReservationCountResponse;
 import java.time.LocalDate;
 import java.util.List;
@@ -13,4 +14,7 @@ public interface MemberReservationRepositoryCustom {
     MemberReservation findUpcomingReservation(Long memberId);
 
     List<Long> findHotPopupIds();
+
+    DailyMemberReservationCountResponse findDailyMemberReservationCount(
+            Long popupId, LocalDate today);
 }

--- a/popi-reservation-service/src/main/java/com/lgcns/repository/MemberReservationRepositoryImpl.java
+++ b/popi-reservation-service/src/main/java/com/lgcns/repository/MemberReservationRepositoryImpl.java
@@ -3,9 +3,11 @@ package com.lgcns.repository;
 import static com.lgcns.domain.QMemberReservation.memberReservation;
 
 import com.lgcns.domain.MemberReservation;
+import com.lgcns.dto.response.DailyMemberReservationCountResponse;
 import com.lgcns.dto.response.DailyReservationCountResponse;
 import com.lgcns.dto.response.HourlyReservationCount;
 import com.querydsl.core.Tuple;
+import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -89,6 +91,20 @@ public class MemberReservationRepositoryImpl implements MemberReservationReposit
         return tuples.stream()
                 .map(tuple -> tuple.get(memberReservation.popupId))
                 .collect(Collectors.toList());
+    }
+
+    public DailyMemberReservationCountResponse findDailyMemberReservationCount(
+            Long popupId, LocalDate today) {
+        return queryFactory
+                .select(
+                        Projections.constructor(
+                                DailyMemberReservationCountResponse.class,
+                                memberReservation.count()))
+                .from(memberReservation)
+                .where(
+                        memberReservation.popupId.eq(popupId),
+                        memberReservation.reservationDate.eq(today))
+                .fetchOne();
     }
 
     private LocalDate getStartDate(YearMonth yearMonth, LocalDate openDate) {

--- a/popi-reservation-service/src/main/java/com/lgcns/service/MemberReservationService.java
+++ b/popi-reservation-service/src/main/java/com/lgcns/service/MemberReservationService.java
@@ -2,6 +2,7 @@ package com.lgcns.service;
 
 import com.lgcns.dto.response.AvailableDateResponse;
 import com.lgcns.dto.response.ReservationDetailResponse;
+import com.lgcns.dto.response.DailyMemberReservationCountResponse;
 import com.lgcns.dto.response.SurveyChoiceResponse;
 import java.util.List;
 
@@ -21,4 +22,6 @@ public interface MemberReservationService {
     void cancelMemberReservation(Long memberReservationId);
 
     List<Long> findHotPopupIds();
+
+    DailyMemberReservationCountResponse findDailyMemberReservationCount(Long popupId);
 }

--- a/popi-reservation-service/src/main/java/com/lgcns/service/MemberReservationService.java
+++ b/popi-reservation-service/src/main/java/com/lgcns/service/MemberReservationService.java
@@ -1,8 +1,8 @@
 package com.lgcns.service;
 
 import com.lgcns.dto.response.AvailableDateResponse;
-import com.lgcns.dto.response.ReservationDetailResponse;
 import com.lgcns.dto.response.DailyMemberReservationCountResponse;
+import com.lgcns.dto.response.ReservationDetailResponse;
 import com.lgcns.dto.response.SurveyChoiceResponse;
 import java.util.List;
 

--- a/popi-reservation-service/src/main/java/com/lgcns/service/MemberReservationServiceImpl.java
+++ b/popi-reservation-service/src/main/java/com/lgcns/service/MemberReservationServiceImpl.java
@@ -210,6 +210,12 @@ public class MemberReservationServiceImpl implements MemberReservationService {
         }
     }
 
+    @Transactional(readOnly = true)
+    public DailyMemberReservationCountResponse findDailyMemberReservationCount(Long popupId) {
+        LocalDate today = LocalDate.now();
+        return memberReservationRepository.findDailyMemberReservationCount(popupId, today);
+    }
+
     private void validateYearMonthFormat(String date) {
         try {
             YearMonth.parse(date);

--- a/popi-reservation-service/src/test/java/com/lgcns/service/MemberReservationServiceTest.java
+++ b/popi-reservation-service/src/test/java/com/lgcns/service/MemberReservationServiceTest.java
@@ -943,6 +943,38 @@ class MemberReservationServiceTest extends WireMockIntegrationTest {
         }
     }
 
+    @Nested
+    class 오늘_예약자_수를_조회할_때 {
+
+        @Test
+        void 예약자가_있는_경우_조회에_성공한다() {
+            // given
+            LocalDate now = LocalDate.now();
+            insertMemberReservation(now, LocalTime.of(12, 0));
+
+            // when
+            DailyMemberReservationCountResponse response =
+                    memberReservationService.findDailyMemberReservationCount(popupId);
+
+            // then
+            Assertions.assertAll(
+                    () -> assertThat(response).isNotNull(),
+                    () -> assertThat(response.reservationCount()).isEqualTo(5));
+        }
+
+        @Test
+        void 예약자가_없는_경우_조회에_성공한다() {
+            // given & when
+            DailyMemberReservationCountResponse response =
+                    memberReservationService.findDailyMemberReservationCount(popupId);
+
+            // then
+            Assertions.assertAll(
+                    () -> assertThat(response).isNotNull(),
+                    () -> assertThat(response.reservationCount()).isEqualTo(0));
+        }
+    }
+
     private void insertMultipleReservations(Long popupId, int count) {
         for (int i = 0; i < count; i++) {
             MemberReservation reservation =


### PR DESCRIPTION
## 🌱 관련 이슈

- [LCR-240]

---
## 📌 작업 내용 및 특이사항

- 운영자 서비스에서 사용할 오늘 예약자 수 조회 Internal API를 구현했습니다.
- API Gateway에서 예약 서비스 Internal API 경로에 대해 인증 필터를 제거하고, configMap에 반영했습니다.
- 예약자가 없는 경우 count 변수에 0이 담기기 때문에 예외 처리 테스트 코드는 작성하지 않았습니다.

---
## 📚 참고사항

-


[LCR-240]: https://lgcns-retail.atlassian.net/browse/LCR-240?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ