### PR TITLE
feat: 예약 상태 및 시간 기반 분기 로직 구현

### DIFF
--- a/popi-api-gateway/src/main/resources/application-local.yml
+++ b/popi-api-gateway/src/main/resources/application-local.yml
@@ -110,7 +110,7 @@ spring:
             - Method=GET,POST,DELETE
           filters:
             - RemoveRequestHeader=Cookie
-            - RewritePath=/popups/(?<segment>.*), $\{segment}
+            - RewritePath=/popups(?<segment>/?.*), /$\{segment}
 
         - id: notification-docs
           uri: lb://NOTIFICATIONS
@@ -222,3 +222,6 @@ jwt:
 logging:
   level:
     org.hibernate.SQL: debug
+    org.springframework.cloud.gateway: DEBUG
+    reactor.netty.http.client: DEBUG
+    org.springframework.web.reactive.function.client.ExchangeFunctions: TRACE

--- a/popi-reservation-service/src/main/java/com/lgcns/domain/MemberReservation.java
+++ b/popi-reservation-service/src/main/java/com/lgcns/domain/MemberReservation.java
@@ -67,8 +67,4 @@ public class MemberReservation extends BaseTimeEntity {
     public void updateIsEntered() {
         this.isEntered = true;
     }
-
-    public void updateMemberReservationStatus(MemberReservationStatus status) {
-        this.status = status;
-    }
 }

--- a/popi-reservation-service/src/main/java/com/lgcns/repository/MemberReservationRepositoryCustom.java
+++ b/popi-reservation-service/src/main/java/com/lgcns/repository/MemberReservationRepositoryCustom.java
@@ -12,7 +12,7 @@ public interface MemberReservationRepositoryCustom {
     List<DailyReservationCountResponse> findDailyReservationCount(
             Long popupId, LocalDate popupOpenDate, LocalDate popupCloseDate, String date);
 
-    MemberReservation findUpcomingReservation(Long memberId);
+    MemberReservation findUpcomingReservation(Long memberId, MemberReservationStatus status);
 
     List<Long> findHotPopupIds();
 

--- a/popi-reservation-service/src/main/java/com/lgcns/repository/MemberReservationRepositoryCustom.java
+++ b/popi-reservation-service/src/main/java/com/lgcns/repository/MemberReservationRepositoryCustom.java
@@ -1,6 +1,7 @@
 package com.lgcns.repository;
 
 import com.lgcns.domain.MemberReservation;
+import com.lgcns.domain.MemberReservationStatus;
 import com.lgcns.dto.response.DailyMemberReservationCountResponse;
 import com.lgcns.dto.response.DailyReservationCountResponse;
 import java.time.LocalDate;
@@ -14,6 +15,8 @@ public interface MemberReservationRepositoryCustom {
     MemberReservation findUpcomingReservation(Long memberId);
 
     List<Long> findHotPopupIds();
+
+    List<MemberReservation> findByMemberIdAndStatus(Long memberId, MemberReservationStatus status);
 
     DailyMemberReservationCountResponse findDailyMemberReservationCount(
             Long popupId, LocalDate today);

--- a/popi-reservation-service/src/main/java/com/lgcns/repository/MemberReservationRepositoryCustom.java
+++ b/popi-reservation-service/src/main/java/com/lgcns/repository/MemberReservationRepositoryCustom.java
@@ -12,7 +12,7 @@ public interface MemberReservationRepositoryCustom {
     List<DailyReservationCountResponse> findDailyReservationCount(
             Long popupId, LocalDate popupOpenDate, LocalDate popupCloseDate, String date);
 
-    MemberReservation findUpcomingReservation(Long memberId, MemberReservationStatus status);
+    MemberReservation findUpcomingReservation(Long memberId);
 
     List<Long> findHotPopupIds();
 

--- a/popi-reservation-service/src/main/java/com/lgcns/repository/MemberReservationRepositoryImpl.java
+++ b/popi-reservation-service/src/main/java/com/lgcns/repository/MemberReservationRepositoryImpl.java
@@ -3,6 +3,7 @@ package com.lgcns.repository;
 import static com.lgcns.domain.QMemberReservation.memberReservation;
 
 import com.lgcns.domain.MemberReservation;
+import com.lgcns.domain.MemberReservationStatus;
 import com.lgcns.dto.response.DailyMemberReservationCountResponse;
 import com.lgcns.dto.response.DailyReservationCountResponse;
 import com.lgcns.dto.response.HourlyReservationCount;
@@ -85,6 +86,34 @@ public class MemberReservationRepositoryImpl implements MemberReservationReposit
                         .fetch();
 
         return extractPopupIds(results);
+    }
+
+    @Override
+    public List<MemberReservation> findByMemberIdAndStatus(
+            Long memberId, MemberReservationStatus status) {
+        LocalDateTime now = LocalDateTime.now();
+        LocalDate nowDate = now.toLocalDate();
+        LocalTime nowTime = now.toLocalTime();
+
+        return queryFactory
+                .selectFrom(memberReservation)
+                .where(
+                        memberReservation.memberId.eq(memberId),
+                        memberReservation.status.eq(status),
+                        memberReservation
+                                .reservationDate
+                                .gt(nowDate)
+                                .or(
+                                        memberReservation
+                                                .reservationDate
+                                                .eq(nowDate)
+                                                .and(
+                                                        memberReservation.reservationTime.goe(
+                                                                nowTime))))
+                .orderBy(
+                        memberReservation.reservationDate.asc(),
+                        memberReservation.reservationTime.asc())
+                .fetch();
     }
 
     private List<Long> extractPopupIds(List<Tuple> tuples) {

--- a/popi-reservation-service/src/main/java/com/lgcns/repository/MemberReservationRepositoryImpl.java
+++ b/popi-reservation-service/src/main/java/com/lgcns/repository/MemberReservationRepositoryImpl.java
@@ -1,5 +1,6 @@
 package com.lgcns.repository;
 
+import static com.lgcns.domain.MemberReservationStatus.RESERVED;
 import static com.lgcns.domain.QMemberReservation.memberReservation;
 
 import com.lgcns.domain.MemberReservation;
@@ -42,8 +43,7 @@ public class MemberReservationRepositoryImpl implements MemberReservationReposit
     }
 
     @Override
-    public MemberReservation findUpcomingReservation(
-            Long memberId, MemberReservationStatus status) {
+    public MemberReservation findUpcomingReservation(Long memberId) {
         LocalDateTime now = LocalDateTime.now();
         LocalDate nowDate = now.toLocalDate();
         LocalTime nowTime = now.toLocalTime();
@@ -52,7 +52,7 @@ public class MemberReservationRepositoryImpl implements MemberReservationReposit
                 .selectFrom(memberReservation)
                 .where(
                         memberReservation.memberId.eq(memberId),
-                        memberReservation.status.eq(MemberReservationStatus.RESERVED),
+                        memberReservation.status.eq(RESERVED),
                         memberReservation
                                 .reservationDate
                                 .gt(nowDate)

--- a/popi-reservation-service/src/main/java/com/lgcns/repository/MemberReservationRepositoryImpl.java
+++ b/popi-reservation-service/src/main/java/com/lgcns/repository/MemberReservationRepositoryImpl.java
@@ -42,7 +42,8 @@ public class MemberReservationRepositoryImpl implements MemberReservationReposit
     }
 
     @Override
-    public MemberReservation findUpcomingReservation(Long memberId) {
+    public MemberReservation findUpcomingReservation(
+            Long memberId, MemberReservationStatus status) {
         LocalDateTime now = LocalDateTime.now();
         LocalDate nowDate = now.toLocalDate();
         LocalTime nowTime = now.toLocalTime();
@@ -50,21 +51,18 @@ public class MemberReservationRepositoryImpl implements MemberReservationReposit
         return queryFactory
                 .selectFrom(memberReservation)
                 .where(
+                        memberReservation.memberId.eq(memberId),
+                        memberReservation.status.eq(MemberReservationStatus.RESERVED),
                         memberReservation
-                                .memberId
-                                .eq(memberId)
-                                .and(
+                                .reservationDate
+                                .gt(nowDate)
+                                .or(
                                         memberReservation
                                                 .reservationDate
-                                                .gt(nowDate)
-                                                .or(
-                                                        memberReservation
-                                                                .reservationDate
-                                                                .eq(nowDate)
-                                                                .and(
-                                                                        memberReservation
-                                                                                .reservationTime
-                                                                                .goe(nowTime)))))
+                                                .eq(nowDate)
+                                                .and(
+                                                        memberReservation.reservationTime.goe(
+                                                                nowTime))))
                 .orderBy(
                         memberReservation.reservationDate.asc(),
                         memberReservation.reservationTime.asc())

--- a/popi-reservation-service/src/main/java/com/lgcns/service/MemberReservationServiceImpl.java
+++ b/popi-reservation-service/src/main/java/com/lgcns/service/MemberReservationServiceImpl.java
@@ -1,5 +1,7 @@
 package com.lgcns.service;
 
+import static com.lgcns.domain.MemberReservationStatus.RESERVED;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.zxing.BarcodeFormat;
 import com.google.zxing.WriterException;
@@ -81,7 +83,8 @@ public class MemberReservationServiceImpl implements MemberReservationService {
     @Override
     public List<ReservationDetailResponse> findReservationInfo(String memberId) {
         List<MemberReservation> memberReservationList =
-                memberReservationRepository.findByMemberId(Long.parseLong(memberId));
+                memberReservationRepository.findByMemberIdAndStatus(
+                        Long.parseLong(memberId), RESERVED);
 
         if (memberReservationList.isEmpty()) {
             return List.of();

--- a/popi-reservation-service/src/main/java/com/lgcns/service/MemberReservationServiceImpl.java
+++ b/popi-reservation-service/src/main/java/com/lgcns/service/MemberReservationServiceImpl.java
@@ -124,8 +124,7 @@ public class MemberReservationServiceImpl implements MemberReservationService {
     public ReservationDetailResponse findUpcomingReservationInfo(String memberId) {
 
         MemberReservation upcomingReservation =
-                memberReservationRepository.findUpcomingReservation(
-                        Long.parseLong(memberId), RESERVED);
+                memberReservationRepository.findUpcomingReservation(Long.parseLong(memberId));
 
         if (upcomingReservation == null) {
             return null;

--- a/popi-reservation-service/src/main/java/com/lgcns/service/MemberReservationServiceImpl.java
+++ b/popi-reservation-service/src/main/java/com/lgcns/service/MemberReservationServiceImpl.java
@@ -124,7 +124,8 @@ public class MemberReservationServiceImpl implements MemberReservationService {
     public ReservationDetailResponse findUpcomingReservationInfo(String memberId) {
 
         MemberReservation upcomingReservation =
-                memberReservationRepository.findUpcomingReservation(Long.parseLong(memberId));
+                memberReservationRepository.findUpcomingReservation(
+                        Long.parseLong(memberId), RESERVED);
 
         if (upcomingReservation == null) {
             return null;

--- a/popi-reservation-service/src/test/java/com/lgcns/service/MemberReservationServiceTest.java
+++ b/popi-reservation-service/src/test/java/com/lgcns/service/MemberReservationServiceTest.java
@@ -976,7 +976,7 @@ class MemberReservationServiceTest extends WireMockIntegrationTest {
         void 예약자가_있는_경우_조회에_성공한다() {
             // given
             LocalDate now = LocalDate.now();
-            insertMemberReservation(now, LocalTime.of(12, 0));
+            insertReservedMemberReservation(now, LocalTime.of(12, 0));
 
             // when
             DailyMemberReservationCountResponse response =

--- a/popi-reservation-service/src/test/java/com/lgcns/service/MemberReservationServiceTest.java
+++ b/popi-reservation-service/src/test/java/com/lgcns/service/MemberReservationServiceTest.java
@@ -1157,11 +1157,18 @@ class MemberReservationServiceTest extends WireMockIntegrationTest {
     private void assertSurveyChoice(
             SurveyChoiceResponse response, Long expectedSurveyId, Long startingChoiceId) {
         assertThat(response.surveyId()).isEqualTo(expectedSurveyId);
-        assertThat(response.options()).hasSize(5);
+        List<SurveyOption> options = response.options();
+        assertThat(options).hasSize(5);
 
-        for (int i = 0; i < 5; i++) {
-            assertThat(response.options().get(i).choiceId()).isEqualTo(startingChoiceId + i);
-            assertThat(response.options().get(i).content()).isEqualTo("보기" + (i + 1));
+        for (int i = 0; i < options.size(); i++) {
+            SurveyOption option = options.get(i);
+            Long expectedChoiceId = startingChoiceId + i;
+            String expectedContent = "보기" + (i + 1);
+
+            assertThat(option.choiceId()).isEqualTo(expectedChoiceId);
+            assertThat(option.content()).isEqualTo(expectedContent);
+            assertThat(option.choiceId()).isGreaterThan(0L);
+            assertThat(option.content()).isNotBlank();
         }
     }
 }

--- a/popi-reservation-service/src/test/java/com/lgcns/service/MemberReservationServiceTest.java
+++ b/popi-reservation-service/src/test/java/com/lgcns/service/MemberReservationServiceTest.java
@@ -421,14 +421,12 @@ class MemberReservationServiceTest extends WireMockIntegrationTest {
                     memberReservationService.findSurveyChoicesByPopupId(popupId);
 
             // then
-            assertThat(choices).isNotEmpty();
-            assertThat(choices.size()).isEqualTo(4);
+            assertThat(choices).hasSize(4);
 
-            for (SurveyChoiceResponse choice : choices) {
-                assertThat(choice.surveyId()).isNotNull();
-                assertThat(choice.options()).isNotEmpty();
-                assertThat(choice.options().size()).isEqualTo(5);
-            }
+            assertSurveyChoice(choices.get(0), 1L, 1L);
+            assertSurveyChoice(choices.get(1), 2L, 6L);
+            assertSurveyChoice(choices.get(2), 3L, 11L);
+            assertSurveyChoice(choices.get(3), 4L, 16L);
         }
     }
 
@@ -1137,5 +1135,16 @@ class MemberReservationServiceTest extends WireMockIntegrationTest {
         Assertions.assertAll(
                 () -> assertThat(response.popupOpenDate()).isEqualTo("2025-05-31"),
                 () -> assertThat(response.popupCloseDate()).isEqualTo("2025-06-02"));
+    }
+
+    private void assertSurveyChoice(
+            SurveyChoiceResponse response, Long expectedSurveyId, Long startingChoiceId) {
+        assertThat(response.surveyId()).isEqualTo(expectedSurveyId);
+        assertThat(response.options()).hasSize(5);
+
+        for (int i = 0; i < 5; i++) {
+            assertThat(response.options().get(i).choiceId()).isEqualTo(startingChoiceId + i);
+            assertThat(response.options().get(i).content()).isEqualTo("보기" + (i + 1));
+        }
     }
 }

--- a/popi-reservation-service/src/test/java/com/lgcns/service/MemberReservationServiceTest.java
+++ b/popi-reservation-service/src/test/java/com/lgcns/service/MemberReservationServiceTest.java
@@ -100,7 +100,7 @@ class MemberReservationServiceTest extends WireMockIntegrationTest {
         }
 
         @Test
-        void 예약이_없는_경우_모든_시간_예약_가능() throws JsonProcessingException {
+        void 예약이_없는_경우_모든_시간이_예약_가능하다() throws JsonProcessingException {
             // given
             String date = "2025-05";
 
@@ -135,7 +135,7 @@ class MemberReservationServiceTest extends WireMockIntegrationTest {
         }
 
         @Test
-        void 모든_시간이_가득_찬_날짜는_예약불가() throws JsonProcessingException {
+        void 모든_시간이_가득_찬_날짜는_예약_불가하다() throws JsonProcessingException {
             // given
             String date = "2025-06";
 


### PR DESCRIPTION
## 🌱 관련 이슈

- [LCR-260]

---
## 📌 작업 내용 및 특이사항

- MemberReservationStatus가 RESERVED이고, 현재 시간보다 이후인 예약들만 조회되도록 QueryDSL 작성했습니다.
- 불필요한 updateMemberReservationStatus 메서드 삭제했습니다.
- 기존 테스트 코드에 있던 insertMemberReservation 메서드는 MemberReservationStatus가 PENDING으로 삽입되기 때문에, insertPendingMemberReservation, insertReservedMemberReservation 메서드로 각각 분리하여 예약이 PENDING 상태인 경우와 RESERVED 상태인 경우에 대한 테스트 코드를 작성할 수 있도록 했습니다.

---
## 📚 참고사항

- SurveyOption Dto에 대한 테스트 코드를 추가했습니다.


[LCR-260]: https://lgcns-retail.atlassian.net/browse/LCR-260?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ