### PR TITLE
fix: 인기 팝업 리스트 조회 기능 수정

### DIFF
--- a/popi-api-gateway/src/main/resources/application-local.yml
+++ b/popi-api-gateway/src/main/resources/application-local.yml
@@ -106,11 +106,11 @@ spring:
         - id: popup-service
           uri: lb://POPUPS
           predicates:
-            - Path=/popups/**
+            - Path=/popups, /popups/**
             - Method=GET,POST,DELETE
           filters:
             - RemoveRequestHeader=Cookie
-            - RewritePath=/popups/(?<segment>.*), /$\{segment}
+            - RewritePath=/popups/(?<segment>.*), $\{segment}
 
         - id: notification-docs
           uri: lb://NOTIFICATIONS

--- a/popi-popup-service/src/main/java/com/lgcns/client/managerClient/ManagerServiceClient.java
+++ b/popi-popup-service/src/main/java/com/lgcns/client/managerClient/ManagerServiceClient.java
@@ -1,4 +1,4 @@
-package com.lgcns.client;
+package com.lgcns.client.managerClient;
 
 import com.lgcns.config.FeignConfig;
 import com.lgcns.dto.response.PopupDetailsResponse;

--- a/popi-popup-service/src/main/java/com/lgcns/client/managerClient/ManagerServiceClient.java
+++ b/popi-popup-service/src/main/java/com/lgcns/client/managerClient/ManagerServiceClient.java
@@ -1,5 +1,6 @@
 package com.lgcns.client.managerClient;
 
+import com.lgcns.client.managerClient.dto.PopupIdsRequest;
 import com.lgcns.config.FeignConfig;
 import com.lgcns.dto.response.PopupDetailsResponse;
 import com.lgcns.dto.response.PopupInfoResponse;

--- a/popi-popup-service/src/main/java/com/lgcns/client/managerClient/PopupIdsRequest.java
+++ b/popi-popup-service/src/main/java/com/lgcns/client/managerClient/PopupIdsRequest.java
@@ -1,4 +1,4 @@
-package com.lgcns.client;
+package com.lgcns.client.managerClient;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;

--- a/popi-popup-service/src/main/java/com/lgcns/client/managerClient/dto/PopupIdsRequest.java
+++ b/popi-popup-service/src/main/java/com/lgcns/client/managerClient/dto/PopupIdsRequest.java
@@ -1,4 +1,4 @@
-package com.lgcns.client.managerClient;
+package com.lgcns.client.managerClient.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;

--- a/popi-popup-service/src/main/java/com/lgcns/client/reservationClient/ReservationServiceClient.java
+++ b/popi-popup-service/src/main/java/com/lgcns/client/reservationClient/ReservationServiceClient.java
@@ -1,4 +1,4 @@
-package com.lgcns.client;
+package com.lgcns.client.reservationClient;
 
 import com.lgcns.config.FeignConfig;
 import java.util.List;

--- a/popi-popup-service/src/main/java/com/lgcns/service/PopupServiceImpl.java
+++ b/popi-popup-service/src/main/java/com/lgcns/service/PopupServiceImpl.java
@@ -1,7 +1,7 @@
 package com.lgcns.service;
 
 import com.lgcns.client.managerClient.ManagerServiceClient;
-import com.lgcns.client.managerClient.PopupIdsRequest;
+import com.lgcns.client.managerClient.dto.PopupIdsRequest;
 import com.lgcns.client.reservationClient.ReservationServiceClient;
 import com.lgcns.dto.response.PopupDetailsResponse;
 import com.lgcns.dto.response.PopupInfoResponse;

--- a/popi-popup-service/src/main/java/com/lgcns/service/PopupServiceImpl.java
+++ b/popi-popup-service/src/main/java/com/lgcns/service/PopupServiceImpl.java
@@ -1,8 +1,8 @@
 package com.lgcns.service;
 
-import com.lgcns.client.ManagerServiceClient;
-import com.lgcns.client.PopupIdsRequest;
-import com.lgcns.client.ReservationServiceClient;
+import com.lgcns.client.managerClient.ManagerServiceClient;
+import com.lgcns.client.managerClient.PopupIdsRequest;
+import com.lgcns.client.reservationClient.ReservationServiceClient;
 import com.lgcns.dto.response.PopupDetailsResponse;
 import com.lgcns.dto.response.PopupInfoResponse;
 import com.lgcns.response.SliceResponse;

--- a/popi-popup-service/src/main/java/com/lgcns/service/PopupServiceImpl.java
+++ b/popi-popup-service/src/main/java/com/lgcns/service/PopupServiceImpl.java
@@ -31,8 +31,6 @@ public class PopupServiceImpl implements PopupService {
     @Override
     public List<PopupInfoResponse> findHotPopups() {
         List<Long> popupIds = reservationServiceClient.findHotPopupIds();
-        if (popupIds.isEmpty()) return List.of();
-
         PopupIdsRequest popupIdsRequest = new PopupIdsRequest(popupIds);
         return managerServiceClient.findHotPopupsByIds(popupIdsRequest);
     }

--- a/popi-popup-service/src/test/java/com/lgcns/service/PopupServiceTest.java
+++ b/popi-popup-service/src/test/java/com/lgcns/service/PopupServiceTest.java
@@ -7,7 +7,7 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.lgcns.WireMockIntegrationTest;
-import com.lgcns.client.PopupIdsRequest;
+import com.lgcns.client.managerClient.PopupIdsRequest;
 import com.lgcns.dto.response.PopupDetailsResponse;
 import com.lgcns.dto.response.PopupInfoResponse;
 import com.lgcns.error.exception.CustomException;

--- a/popi-popup-service/src/test/java/com/lgcns/service/PopupServiceTest.java
+++ b/popi-popup-service/src/test/java/com/lgcns/service/PopupServiceTest.java
@@ -7,7 +7,7 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.lgcns.WireMockIntegrationTest;
-import com.lgcns.client.managerClient.PopupIdsRequest;
+import com.lgcns.client.managerClient.dto.PopupIdsRequest;
 import com.lgcns.dto.response.PopupDetailsResponse;
 import com.lgcns.dto.response.PopupInfoResponse;
 import com.lgcns.error.exception.CustomException;

--- a/popi-popup-service/src/test/java/com/lgcns/service/PopupServiceTest.java
+++ b/popi-popup-service/src/test/java/com/lgcns/service/PopupServiceTest.java
@@ -387,9 +387,9 @@ public class PopupServiceTest extends WireMockIntegrationTest {
     class 인기_팝업_목록을_조회할_때 {
 
         @Test
-        void 인기_팝업_아이디가_존재하면_해당_팝업들의_정보를_반환한다() throws JsonProcessingException {
+        void 인기_팝업_아이디가_4개인_경우_정확히_4개를_인기순으로_반환한다() throws JsonProcessingException {
             // given
-            List<Long> hotPopupIds = List.of(1L, 3L, 5L, 7L);
+            List<Long> hotPopupIds = List.of(7L, 3L, 1L, 5L); // 인기순
             PopupIdsRequest hotPopupIdsRequest = new PopupIdsRequest(hotPopupIds);
 
             String expectedIdsResponse = objectMapper.writeValueAsString(hotPopupIds);
@@ -398,12 +398,12 @@ public class PopupServiceTest extends WireMockIntegrationTest {
                     objectMapper.writeValueAsString(
                             List.of(
                                     Map.of(
-                                            "popupId", 1,
-                                            "popupName", "BTS 팝업스토어",
-                                            "imageUrl", "https://bucket/bts.jpg",
-                                            "popupOpenDate", "2025-05-01",
-                                            "popupCloseDate", "2025-06-01",
-                                            "address", "서울특별시 강남구 테헤란로 1, 1층"),
+                                            "popupId", 7,
+                                            "popupName", "에스파 팝업스토어",
+                                            "imageUrl", "https://bucket/aespa.jpg",
+                                            "popupOpenDate", "2025-05-20",
+                                            "popupCloseDate", "2025-06-20",
+                                            "address", "서울특별시 강남구 테헤란로 7, 4층"),
                                     Map.of(
                                             "popupId", 3,
                                             "popupName", "BLACKPINK 팝업스토어",
@@ -412,19 +412,19 @@ public class PopupServiceTest extends WireMockIntegrationTest {
                                             "popupCloseDate", "2025-06-10",
                                             "address", "서울특별시 강남구 테헤란로 3, 2층"),
                                     Map.of(
+                                            "popupId", 1,
+                                            "popupName", "BTS 팝업스토어",
+                                            "imageUrl", "https://bucket/bts.jpg",
+                                            "popupOpenDate", "2025-05-01",
+                                            "popupCloseDate", "2025-06-01",
+                                            "address", "서울특별시 강남구 테헤란로 1, 1층"),
+                                    Map.of(
                                             "popupId", 5,
                                             "popupName", "뉴진스 팝업스토어",
                                             "imageUrl", "https://bucket/newjeans.jpg",
                                             "popupOpenDate", "2025-05-15",
                                             "popupCloseDate", "2025-06-15",
-                                            "address", "서울특별시 강남구 테헤란로 5, 3층"),
-                                    Map.of(
-                                            "popupId", 7,
-                                            "popupName", "에스파 팝업스토어",
-                                            "imageUrl", "https://bucket/aespa.jpg",
-                                            "popupOpenDate", "2025-05-20",
-                                            "popupCloseDate", "2025-06-20",
-                                            "address", "서울특별시 강남구 테헤란로 7, 4층")));
+                                            "address", "서울특별시 강남구 테헤란로 5, 3층")));
 
             stubFindHotPopupIds(200, expectedIdsResponse);
             stubFindHotPopupsByIds(hotPopupIdsRequest, 200, expectedResponse);
@@ -436,41 +436,205 @@ public class PopupServiceTest extends WireMockIntegrationTest {
             Assertions.assertAll(
                     () -> assertThat(result).isNotNull(),
                     () -> assertThat(result).hasSize(4),
-                    () -> assertThat(result.get(0).popupId()).isEqualTo(1L),
-                    () -> assertThat(result.get(0).popupName()).isEqualTo("BTS 팝업스토어"),
-                    () -> assertThat(result.get(0).imageUrl()).isEqualTo("https://bucket/bts.jpg"),
+                    () -> assertThat(result.get(0).popupId()).isEqualTo(7L),
+                    () -> assertThat(result.get(0).popupName()).isEqualTo("에스파 팝업스토어"),
                     () -> assertThat(result.get(1).popupId()).isEqualTo(3L),
                     () -> assertThat(result.get(1).popupName()).isEqualTo("BLACKPINK 팝업스토어"),
-                    () -> assertThat(result.get(2).popupId()).isEqualTo(5L),
-                    () -> assertThat(result.get(2).popupName()).isEqualTo("뉴진스 팝업스토어"),
-                    () -> assertThat(result.get(3).popupId()).isEqualTo(7L),
-                    () -> assertThat(result.get(3).popupName()).isEqualTo("에스파 팝업스토어"));
+                    () -> assertThat(result.get(2).popupId()).isEqualTo(1L),
+                    () -> assertThat(result.get(2).popupName()).isEqualTo("BTS 팝업스토어"),
+                    () -> assertThat(result.get(3).popupId()).isEqualTo(5L),
+                    () -> assertThat(result.get(3).popupName()).isEqualTo("뉴진스 팝업스토어"),
+                    () -> {
+                        List<Long> resultIds =
+                                result.stream().map(PopupInfoResponse::popupId).toList();
+                        assertThat(resultIds).containsExactly(7L, 3L, 1L, 5L); // 정확한 순서 검증
+                    });
         }
 
         @Test
-        void 인기_팝_아이디가_빈_리스트면_두_번째_호출_없이_빈_리스트를_반환한다() throws JsonProcessingException {
+        void 인기_팝업_아이디가_4개보다_많은_경우_인기순으로_4개만_반환한다() throws JsonProcessingException {
             // given
-            List<Long> emptyPopupIds = List.of();
-            String expectedIdsResponse = objectMapper.writeValueAsString(emptyPopupIds);
+            List<Long> hotPopupIds = List.of(9L, 2L, 6L, 1L, 8L, 4L); // 인기순
+            PopupIdsRequest hotPopupIdsRequest = new PopupIdsRequest(hotPopupIds);
+
+            String expectedIdsResponse = objectMapper.writeValueAsString(hotPopupIds);
+
+            String expectedResponse =
+                    objectMapper.writeValueAsString(
+                            List.of(
+                                    Map.of(
+                                            "popupId", 9,
+                                            "popupName", "뉴진스 팝업스토어",
+                                            "imageUrl", "https://bucket/newjeans.jpg",
+                                            "popupOpenDate", "2025-05-01",
+                                            "popupCloseDate", "2025-06-01",
+                                            "address", "서울특별시 강남구 테헤란로 9, 1층"),
+                                    Map.of(
+                                            "popupId", 2,
+                                            "popupName", "IVE 팝업스토어",
+                                            "imageUrl", "https://bucket/ive.jpg",
+                                            "popupOpenDate", "2025-05-05",
+                                            "popupCloseDate", "2025-06-05",
+                                            "address", "서울특별시 홍대입구역 2번 출구"),
+                                    Map.of(
+                                            "popupId", 6,
+                                            "popupName", "레드벨벳 팝업스토어",
+                                            "imageUrl", "https://bucket/redvelvet.jpg",
+                                            "popupOpenDate", "2025-05-10",
+                                            "popupCloseDate", "2025-06-10",
+                                            "address", "서울특별시 강남구 테헤란로 6, 2층"),
+                                    Map.of(
+                                            "popupId", 1,
+                                            "popupName", "BTS 팝업스토어",
+                                            "imageUrl", "https://bucket/bts.jpg",
+                                            "popupOpenDate", "2025-05-25",
+                                            "popupCloseDate", "2025-06-25",
+                                            "address", "부산광역시 해운대구 마린시티")));
 
             stubFindHotPopupIds(200, expectedIdsResponse);
+            stubFindHotPopupsByIds(hotPopupIdsRequest, 200, expectedResponse);
 
             // when
             List<PopupInfoResponse> result = popupService.findHotPopups();
 
             // then
             Assertions.assertAll(
-                    () -> assertThat(result).isNotNull(), () -> assertThat(result).isEmpty());
-
-            // verify
-            wireMockServer.verify(
-                    0, postRequestedFor(urlPathEqualTo("/internal/popups/popularity")));
+                    () -> assertThat(result).isNotNull(),
+                    () -> assertThat(result).hasSize(4),
+                    () -> assertThat(result.get(0).popupId()).isEqualTo(9L),
+                    () -> assertThat(result.get(1).popupId()).isEqualTo(2L),
+                    () -> assertThat(result.get(2).popupId()).isEqualTo(6L),
+                    () -> assertThat(result.get(3).popupId()).isEqualTo(1L),
+                    () -> {
+                        List<Long> resultIds =
+                                result.stream().map(PopupInfoResponse::popupId).toList();
+                        assertThat(resultIds).containsExactly(9L, 2L, 6L, 1L);
+                    });
         }
 
         @Test
-        void 인기_팝업이_4개_미만이면_실제_개수만큼_반환한다() throws JsonProcessingException {
+        void 인기_팝업_아이디가_4개_미만인_경우_인기순_우선하여_랜덤으로_채워서_4개를_반환한다() throws JsonProcessingException {
             // given
-            List<Long> hotPopupIds = List.of(2L, 4L);
+            List<Long> hotPopupIds = List.of(5L, 2L); // 인기순 2개
+            PopupIdsRequest hotPopupIdsRequest = new PopupIdsRequest(hotPopupIds);
+
+            String expectedIdsResponse = objectMapper.writeValueAsString(hotPopupIds);
+
+            String expectedResponse =
+                    objectMapper.writeValueAsString(
+                            List.of(
+                                    Map.of(
+                                            "popupId", 5,
+                                            "popupName", "뉴진스 팝업스토어",
+                                            "imageUrl", "https://bucket/newjeans.jpg",
+                                            "popupOpenDate", "2025-05-15",
+                                            "popupCloseDate", "2025-06-15",
+                                            "address", "서울특별시 강남구 테헤란로 5, 3층"),
+                                    Map.of(
+                                            "popupId", 2,
+                                            "popupName", "IVE 팝업스토어",
+                                            "imageUrl", "https://bucket/ive.jpg",
+                                            "popupOpenDate", "2025-05-05",
+                                            "popupCloseDate", "2025-06-05",
+                                            "address", "서울특별시 홍대입구역 2번 출구"),
+                                    Map.of(
+                                            "popupId", 7,
+                                            "popupName", "에스파 팝업스토어",
+                                            "imageUrl", "https://bucket/aespa.jpg",
+                                            "popupOpenDate", "2025-05-01",
+                                            "popupCloseDate", "2025-06-01",
+                                            "address", "서울특별시 강남구 테헤란로 1, 1층"),
+                                    Map.of(
+                                            "popupId", 1,
+                                            "popupName", "BTS 팝업스토어",
+                                            "imageUrl", "https://bucket/bts.jpg",
+                                            "popupOpenDate", "2025-05-20",
+                                            "popupCloseDate", "2025-06-20",
+                                            "address", "부산광역시 해운대구 마린시티")));
+
+            stubFindHotPopupIds(200, expectedIdsResponse);
+            stubFindHotPopupsByIds(hotPopupIdsRequest, 200, expectedResponse);
+
+            // when
+            List<PopupInfoResponse> result = popupService.findHotPopups();
+
+            // then
+            Assertions.assertAll(
+                    () -> assertThat(result).isNotNull(),
+                    () -> assertThat(result).hasSize(4),
+                    () -> assertThat(result.get(0).popupId()).isEqualTo(5L),
+                    () -> assertThat(result.get(1).popupId()).isEqualTo(2L),
+                    // 랜덤 팝업
+                    () -> assertThat(result.get(2).popupId()).isEqualTo(7L),
+                    () -> assertThat(result.get(3).popupId()).isEqualTo(1L),
+                    () -> {
+                        List<Long> resultIds =
+                                result.stream().map(PopupInfoResponse::popupId).toList();
+                        assertThat(resultIds).contains(5L, 2L);
+                    });
+        }
+
+        @Test
+        void 인기_팝업_아이디가_빈_리스트면_랜덤으로_4개를_반환한다() throws JsonProcessingException {
+            // given
+            List<Long> emptyPopupIds = List.of();
+            PopupIdsRequest emptyPopupIdsRequest = new PopupIdsRequest(emptyPopupIds);
+
+            String expectedIdsResponse = objectMapper.writeValueAsString(emptyPopupIds);
+
+            String expectedResponse =
+                    objectMapper.writeValueAsString(
+                            List.of(
+                                    Map.of(
+                                            "popupId", 3,
+                                            "popupName", "BLACKPINK 팝업스토어",
+                                            "imageUrl", "https://bucket/blackpink.jpg",
+                                            "popupOpenDate", "2025-05-10",
+                                            "popupCloseDate", "2025-06-10",
+                                            "address", "서울특별시 강남구 테헤란로 3, 2층"),
+                                    Map.of(
+                                            "popupId", 8,
+                                            "popupName", "레드벨벳 팝업스토어",
+                                            "imageUrl", "https://bucket/redvelvet.jpg",
+                                            "popupOpenDate", "2025-05-25",
+                                            "popupCloseDate", "2025-06-25",
+                                            "address", "부산광역시 해운대구 마린시티"),
+                                    Map.of(
+                                            "popupId", 1,
+                                            "popupName", "BTS 팝업스토어",
+                                            "imageUrl", "https://bucket/bts.jpg",
+                                            "popupOpenDate", "2025-05-01",
+                                            "popupCloseDate", "2025-06-01",
+                                            "address", "서울특별시 강남구 테헤란로 1, 1층"),
+                                    Map.of(
+                                            "popupId", 6,
+                                            "popupName", "뉴진스 팝업스토어",
+                                            "imageUrl", "https://bucket/newjeans.jpg",
+                                            "popupOpenDate", "2025-05-15",
+                                            "popupCloseDate", "2025-06-15",
+                                            "address", "서울특별시 강남구 테헤란로 5, 3층")));
+
+            stubFindHotPopupIds(200, expectedIdsResponse);
+            stubFindHotPopupsByIds(emptyPopupIdsRequest, 200, expectedResponse);
+
+            // when
+            List<PopupInfoResponse> result = popupService.findHotPopups();
+
+            // then
+            Assertions.assertAll(
+                    () -> assertThat(result).isNotNull(),
+                    () -> assertThat(result).hasSize(4),
+                    () -> {
+                        List<Long> resultIds =
+                                result.stream().map(PopupInfoResponse::popupId).toList();
+                        assertThat(resultIds).containsExactlyInAnyOrder(3L, 8L, 1L, 6L);
+                    });
+        }
+
+        @Test
+        void 전체_팝업이_4개_미만인_경우_존재하는_만큼만_반환한다() throws JsonProcessingException {
+            // given
+            List<Long> hotPopupIds = List.of(2L);
             PopupIdsRequest hotPopupIdsRequest = new PopupIdsRequest(hotPopupIds);
 
             String expectedIdsResponse = objectMapper.writeValueAsString(hotPopupIds);
@@ -486,12 +650,19 @@ public class PopupServiceTest extends WireMockIntegrationTest {
                                             "popupCloseDate", "2025-06-05",
                                             "address", "서울특별시 홍대입구역 2번 출구"),
                                     Map.of(
-                                            "popupId", 4,
-                                            "popupName", "레드벨벳 팝업스토어",
-                                            "imageUrl", "https://bucket/redvelvet.jpg",
-                                            "popupOpenDate", "2025-05-25",
-                                            "popupCloseDate", "2025-06-25",
-                                            "address", "부산광역시 해운대구 마린시티")));
+                                            "popupId", 5,
+                                            "popupName", "뉴진스 팝업스토어",
+                                            "imageUrl", "https://bucket/newjeans.jpg",
+                                            "popupOpenDate", "2025-05-15",
+                                            "popupCloseDate", "2025-06-15",
+                                            "address", "서울특별시 강남구 테헤란로 5, 3층"),
+                                    Map.of(
+                                            "popupId", 1,
+                                            "popupName", "BTS 팝업스토어",
+                                            "imageUrl", "https://bucket/bts.jpg",
+                                            "popupOpenDate", "2025-05-01",
+                                            "popupCloseDate", "2025-06-01",
+                                            "address", "서울특별시 강남구 테헤란로 1, 1층")));
 
             stubFindHotPopupIds(200, expectedIdsResponse);
             stubFindHotPopupsByIds(hotPopupIdsRequest, 200, expectedResponse);
@@ -502,11 +673,16 @@ public class PopupServiceTest extends WireMockIntegrationTest {
             // then
             Assertions.assertAll(
                     () -> assertThat(result).isNotNull(),
-                    () -> assertThat(result).hasSize(2),
+                    () -> assertThat(result).hasSize(3),
                     () -> assertThat(result.get(0).popupId()).isEqualTo(2L),
                     () -> assertThat(result.get(0).popupName()).isEqualTo("IVE 팝업스토어"),
-                    () -> assertThat(result.get(1).popupId()).isEqualTo(4L),
-                    () -> assertThat(result.get(1).popupName()).isEqualTo("레드벨벳 팝업스토어"));
+                    () -> assertThat(result.get(1).popupId()).isEqualTo(5L),
+                    () -> assertThat(result.get(2).popupId()).isEqualTo(1L),
+                    () -> {
+                        List<Long> resultIds =
+                                result.stream().map(PopupInfoResponse::popupId).toList();
+                        assertThat(resultIds).contains(2L);
+                    });
         }
     }
 


### PR DESCRIPTION
## 🌱 관련 이슈

- [LCR-255]

---
## 📌 작업 내용 및 특이사항
#### `/popups/keyword=abc` 문제 해결
- api-gateway에 팝업서비스 route 설정을 수정하여 `/popups?keyword=abc` 와 같이 쿼리스트링이 올바르게 기입되도록 수정했습니다.

#### 패키지 구조 변경
- feignClient 패키지에 하위 패키지를 생성하여 managerClient와 reservationClient로 분리했습니다.

#### 로직 변경
- 서비스 로직은  manager 서비스의 조회 로직(랜덤 값 포함 4개 반환)이 변경되었으므로 if(isEmpty)로 분기하여 feign 요청을 관리하는 흐름에서 둘 다 feign 요청을 보내도록 수정했습니다.
- 변경된 서비스 로직에 대한 테스트 케이스도 변경, 추가했습니다.
- 모든 팝업이 예약자 수 가 없는 경우를 제외하고 항상 예약자 수가 많은 순(인기 순)으로 응답을 반환하는 것을 보장하게 했습니다.
---
## 📚 참고사항

<img width="562" alt="스크린샷 2025-05-29 오후 4 03 36" src="https://github.com/user-attachments/assets/67d18f85-df24-457d-8e7e-3a4661543837" />

- popi-ops 레포지토리도 변경 완료 했습니다! [해당 커밋](https://github.com/popi-official/popi-ops/commit/9d7e80f3a1bbd2a525155ca99dc63e2bb6b424d4)


[LCR-255]: https://lgcns-retail.atlassian.net/browse/LCR-255?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ