### PR TITLE
feat: 결제 성공 시 Kafka로 상품 구매 메시지 발행 기능 구현

### DIFF
--- a/docker-compose-kafka.yml
+++ b/docker-compose-kafka.yml
@@ -1,0 +1,29 @@
+services:
+  kafka:
+    container_name: kafka
+    image: confluentinc/cp-kafka:latest
+    ports:
+      - "29092:29092"
+    environment:
+      KAFKA_NODE_ID: 1
+      KAFKA_PROCESS_ROLES: 'broker,controller'
+      KAFKA_CONTROLLER_QUORUM_VOTERS: '1@kafka:29093'
+      KAFKA_LISTENERS: 'CONTROLLER://kafka:29093,PLAINTEXT://kafka:9092,PLAINTEXT_HOST://0.0.0.0:29092'
+      KAFKA_ADVERTISED_LISTENERS: 'PLAINTEXT://kafka:9092,PLAINTEXT_HOST://localhost:29092'
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: 'CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT'
+      KAFKA_CONTROLLER_LISTENER_NAMES: 'CONTROLLER'
+      KAFKA_INTER_BROKER_LISTENER_NAME: 'PLAINTEXT'
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
+      CLUSTER_ID: 'ciWo7IWazngRchmPES6q5A=='
+      KAFKA_LOG_DIRS: '/tmp/kraft-combined-logs'
+  kafka-ui:
+    container_name: kafka-ui
+    image: provectuslabs/kafka-ui:latest
+    ports:
+      - "8989:8080"
+    environment:
+      KAFKA_CLUSTERS_0_NAME: local
+      KAFKA_CLUSTERS_0_BOOTSTRAP SERVERS: kafka:9092
+    depends_on:
+      - kafka

--- a/popi-payment-service/build.gradle
+++ b/popi-payment-service/build.gradle
@@ -39,4 +39,7 @@ dependencies {
 
     // Iamport
     implementation 'com.github.iamport:iamport-rest-client-java:0.2.23'
+
+    // Kafka
+    implementation 'org.springframework.kafka:spring-kafka'
 }

--- a/popi-payment-service/build.gradle
+++ b/popi-payment-service/build.gradle
@@ -42,4 +42,5 @@ dependencies {
 
     // Kafka
     implementation 'org.springframework.kafka:spring-kafka'
+    testImplementation 'org.springframework.kafka:spring-kafka-test'
 }

--- a/popi-payment-service/src/main/java/com/lgcns/domain/Payment.java
+++ b/popi-payment-service/src/main/java/com/lgcns/domain/Payment.java
@@ -29,22 +29,28 @@ public class Payment extends BaseTimeEntity {
     @OneToMany(mappedBy = "payment", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<PaymentItem> items = new ArrayList<>();
 
+    private Long popupId;
+
     @Enumerated(EnumType.STRING)
     private PaymentStatus status;
 
     @Builder(access = AccessLevel.PRIVATE)
-    private Payment(Long memberId, String merchantUid, int amount, PaymentStatus status) {
+    private Payment(
+            Long memberId, String merchantUid, int amount, Long popupId, PaymentStatus status) {
         this.memberId = memberId;
         this.merchantUid = merchantUid;
         this.amount = amount;
+        this.popupId = popupId;
         this.status = status;
     }
 
-    public static Payment createPayment(Long memberId, String merchantUid, int amount) {
+    public static Payment createPayment(
+            Long memberId, String merchantUid, int amount, Long popupId) {
         return Payment.builder()
                 .memberId(memberId)
                 .merchantUid(merchantUid)
                 .amount(amount)
+                .popupId(popupId)
                 .status(PaymentStatus.READY)
                 .build();
     }

--- a/popi-payment-service/src/main/java/com/lgcns/domain/Payment.java
+++ b/popi-payment-service/src/main/java/com/lgcns/domain/Payment.java
@@ -2,6 +2,8 @@ package com.lgcns.domain;
 
 import com.lgcns.entity.BaseTimeEntity;
 import jakarta.persistence.*;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -23,6 +25,9 @@ public class Payment extends BaseTimeEntity {
 
     private String pgProvider;
     private int amount;
+
+    @OneToMany(mappedBy = "payment", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<PaymentItem> items = new ArrayList<>();
 
     @Enumerated(EnumType.STRING)
     private PaymentStatus status;

--- a/popi-payment-service/src/main/java/com/lgcns/domain/Payment.java
+++ b/popi-payment-service/src/main/java/com/lgcns/domain/Payment.java
@@ -55,4 +55,9 @@ public class Payment extends BaseTimeEntity {
         this.amount = amount;
         this.status = status;
     }
+
+    public void addPaymentItem(PaymentItem item) {
+        items.add(item);
+        item.updatePayment(this);
+    }
 }

--- a/popi-payment-service/src/main/java/com/lgcns/domain/PaymentItem.java
+++ b/popi-payment-service/src/main/java/com/lgcns/domain/PaymentItem.java
@@ -1,0 +1,26 @@
+package com.lgcns.domain;
+
+import com.lgcns.entity.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PaymentItem extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "payment_item_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "payment_id")
+    private Payment payment;
+
+    private Long itemId;
+
+    private int quantity;
+}

--- a/popi-payment-service/src/main/java/com/lgcns/domain/PaymentItem.java
+++ b/popi-payment-service/src/main/java/com/lgcns/domain/PaymentItem.java
@@ -3,6 +3,7 @@ package com.lgcns.domain;
 import com.lgcns.entity.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -23,4 +24,19 @@ public class PaymentItem extends BaseTimeEntity {
     private Long itemId;
 
     private int quantity;
+
+    @Builder
+    private PaymentItem(Payment payment, Long itemId, int quantity) {
+        this.payment = payment;
+        this.itemId = itemId;
+        this.quantity = quantity;
+    }
+
+    public static PaymentItem createPaymentItem(Payment payment, Long itemId, int quantity) {
+        return PaymentItem.builder().payment(payment).itemId(itemId).quantity(quantity).build();
+    }
+
+    public void updatePayment(Payment payment) {
+        this.payment = payment;
+    }
 }

--- a/popi-payment-service/src/main/java/com/lgcns/kafka/config/KafkaProducerConfig.java
+++ b/popi-payment-service/src/main/java/com/lgcns/kafka/config/KafkaProducerConfig.java
@@ -1,0 +1,38 @@
+package com.lgcns.kafka.config;
+
+import com.lgcns.kafka.message.ItemPurchasedMessage;
+import java.util.HashMap;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+import org.springframework.kafka.support.serializer.JsonSerializer;
+
+@Configuration
+@RequiredArgsConstructor
+public class KafkaProducerConfig {
+
+    @Value("${spring.kafka.bootstrap-servers}")
+    private String bootstrapServers;
+
+    @Bean
+    public ProducerFactory<String, ItemPurchasedMessage> producerFactory() {
+        Map<String, Object> configProps = new HashMap<>();
+        configProps.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        configProps.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        configProps.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class);
+
+        return new DefaultKafkaProducerFactory<>(configProps);
+    }
+
+    @Bean
+    public KafkaTemplate<String, ItemPurchasedMessage> kafkaTemplate() {
+        return new KafkaTemplate<>(producerFactory());
+    }
+}

--- a/popi-payment-service/src/main/java/com/lgcns/kafka/message/ItemPurchasedMessage.java
+++ b/popi-payment-service/src/main/java/com/lgcns/kafka/message/ItemPurchasedMessage.java
@@ -1,0 +1,17 @@
+package com.lgcns.kafka.message;
+
+import com.lgcns.domain.Payment;
+import java.util.List;
+
+public record ItemPurchasedMessage(List<Item> items) {
+    public static ItemPurchasedMessage from(Payment payment) {
+        List<Item> items =
+                payment.getItems().stream()
+                        .map(item -> new Item(item.getItemId(), item.getQuantity()))
+                        .toList();
+
+        return new ItemPurchasedMessage(items);
+    }
+
+    public record Item(Long itemId, Integer quantity) {}
+}

--- a/popi-payment-service/src/main/java/com/lgcns/kafka/message/ItemPurchasedMessage.java
+++ b/popi-payment-service/src/main/java/com/lgcns/kafka/message/ItemPurchasedMessage.java
@@ -1,16 +1,19 @@
 package com.lgcns.kafka.message;
 
 import com.lgcns.domain.Payment;
+import java.time.LocalDateTime;
 import java.util.List;
 
-public record ItemPurchasedMessage(List<Item> items) {
+public record ItemPurchasedMessage(
+        Long popupId, List<Item> items, int amount, LocalDateTime purchasedAt) {
     public static ItemPurchasedMessage from(Payment payment) {
         List<Item> items =
                 payment.getItems().stream()
                         .map(item -> new Item(item.getItemId(), item.getQuantity()))
                         .toList();
 
-        return new ItemPurchasedMessage(items);
+        return new ItemPurchasedMessage(
+                payment.getPopupId(), items, payment.getAmount(), payment.getUpdatedAt());
     }
 
     public record Item(Long itemId, Integer quantity) {}

--- a/popi-payment-service/src/main/java/com/lgcns/kafka/producer/ItemPurchasedProducer.java
+++ b/popi-payment-service/src/main/java/com/lgcns/kafka/producer/ItemPurchasedProducer.java
@@ -1,0 +1,20 @@
+package com.lgcns.kafka.producer;
+
+import com.lgcns.kafka.message.ItemPurchasedMessage;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ItemPurchasedProducer {
+
+    private static final String TOPIC = "item-purchased-topic";
+    private final KafkaTemplate<String, ItemPurchasedMessage> kafkaTemplate;
+
+    public void sendMessage(ItemPurchasedMessage message) {
+        kafkaTemplate.send(TOPIC, message);
+    }
+}

--- a/popi-payment-service/src/main/java/com/lgcns/repository/PaymentItemRepository.java
+++ b/popi-payment-service/src/main/java/com/lgcns/repository/PaymentItemRepository.java
@@ -1,6 +1,0 @@
-package com.lgcns.repository;
-
-import com.lgcns.domain.PaymentItem;
-import org.springframework.data.jpa.repository.JpaRepository;
-
-public interface PaymentItemRepository extends JpaRepository<PaymentItem, Long> {}

--- a/popi-payment-service/src/main/java/com/lgcns/repository/PaymentItemRepository.java
+++ b/popi-payment-service/src/main/java/com/lgcns/repository/PaymentItemRepository.java
@@ -1,0 +1,6 @@
+package com.lgcns.repository;
+
+import com.lgcns.domain.PaymentItem;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PaymentItemRepository extends JpaRepository<PaymentItem, Long> {}

--- a/popi-payment-service/src/main/java/com/lgcns/service/PaymentServiceImpl.java
+++ b/popi-payment-service/src/main/java/com/lgcns/service/PaymentServiceImpl.java
@@ -81,7 +81,9 @@ public class PaymentServiceImpl implements PaymentService {
         String merchantUid =
                 String.format("popup_%d_order_%s", request.popupId(), UUID.randomUUID());
 
-        Payment payment = Payment.createPayment(Long.valueOf(memberId), merchantUid, amount);
+        Payment payment =
+                Payment.createPayment(
+                        Long.valueOf(memberId), merchantUid, amount, request.popupId());
 
         for (PaymentReadyRequest.Item selected : request.items()) {
             payment.addPaymentItem(

--- a/popi-payment-service/src/main/java/com/lgcns/service/PaymentServiceImpl.java
+++ b/popi-payment-service/src/main/java/com/lgcns/service/PaymentServiceImpl.java
@@ -11,6 +11,8 @@ import com.lgcns.dto.request.PaymentReadyRequest;
 import com.lgcns.dto.response.PaymentReadyResponse;
 import com.lgcns.error.exception.CustomException;
 import com.lgcns.exception.PaymentErrorCode;
+import com.lgcns.kafka.message.ItemPurchasedMessage;
+import com.lgcns.kafka.producer.ItemPurchasedProducer;
 import com.lgcns.repository.PaymentRepository;
 import com.siot.IamportRestClient.IamportClient;
 import com.siot.IamportRestClient.exception.IamportResponseException;
@@ -34,6 +36,7 @@ public class PaymentServiceImpl implements PaymentService {
     private final MemberServiceClient memberServiceClient;
     private final ManagerServiceClient managerServiceClient;
     private final IamportClient iamportClient;
+    private final ItemPurchasedProducer itemPurchasedProducer;
 
     @Override
     public synchronized PaymentReadyResponse preparePayment(
@@ -118,6 +121,8 @@ public class PaymentServiceImpl implements PaymentService {
             }
 
             payment.updatePayment(impUid, pgProvider, amount, PaymentStatus.PAID);
+
+            itemPurchasedProducer.sendMessage(ItemPurchasedMessage.from(payment));
         } catch (IamportResponseException e) {
             log.error(
                     "Iamport API 오류: status={}, message={}", e.getHttpStatusCode(), e.getMessage());

--- a/popi-payment-service/src/main/java/com/lgcns/service/PaymentServiceImpl.java
+++ b/popi-payment-service/src/main/java/com/lgcns/service/PaymentServiceImpl.java
@@ -5,6 +5,7 @@ import com.lgcns.client.managerClient.dto.request.ItemIdsForPaymentRequest;
 import com.lgcns.client.managerClient.dto.response.ItemForPaymentResponse;
 import com.lgcns.client.memberClient.MemberServiceClient;
 import com.lgcns.domain.Payment;
+import com.lgcns.domain.PaymentItem;
 import com.lgcns.domain.PaymentStatus;
 import com.lgcns.dto.request.PaymentReadyRequest;
 import com.lgcns.dto.response.PaymentReadyResponse;
@@ -75,7 +76,14 @@ public class PaymentServiceImpl implements PaymentService {
         String merchantUid =
                 String.format("popup_%d_order_%s", request.popupId(), UUID.randomUUID());
 
-        paymentRepository.save(Payment.createPayment(Long.valueOf(memberId), merchantUid, amount));
+        Payment payment = Payment.createPayment(Long.valueOf(memberId), merchantUid, amount);
+
+        for (PaymentReadyRequest.Item selected : request.items()) {
+            payment.addPaymentItem(
+                    PaymentItem.createPaymentItem(payment, selected.itemId(), selected.quantity()));
+        }
+
+        paymentRepository.save(payment);
 
         return PaymentReadyResponse.of(buyerName, name, amount, merchantUid);
     }

--- a/popi-payment-service/src/main/java/com/lgcns/service/PaymentServiceImpl.java
+++ b/popi-payment-service/src/main/java/com/lgcns/service/PaymentServiceImpl.java
@@ -104,7 +104,7 @@ public class PaymentServiceImpl implements PaymentService {
             String merchantUid = iamportPayment.getMerchantUid();
             String pgProvider = iamportPayment.getPgProvider();
             int amount = iamportPayment.getAmount().intValue();
-            PaymentStatus status = PaymentStatus.valueOf(iamportPayment.getStatus());
+            PaymentStatus status = PaymentStatus.valueOf(iamportPayment.getStatus().toUpperCase());
 
             Payment payment =
                     paymentRepository

--- a/popi-payment-service/src/main/resources/application-local.yml
+++ b/popi-payment-service/src/main/resources/application-local.yml
@@ -26,7 +26,7 @@ spring:
     baseline-on-migrate: true
     locations: classpath:db/migration
   kafka:
-    bootstrap-servers: localhost:9092
+    bootstrap-servers: localhost:29092
 
 iamport:
   key: ${IAMPORT_KEY}

--- a/popi-payment-service/src/main/resources/application-local.yml
+++ b/popi-payment-service/src/main/resources/application-local.yml
@@ -25,6 +25,8 @@ spring:
     enabled: true
     baseline-on-migrate: true
     locations: classpath:db/migration
+  kafka:
+    bootstrap-servers: localhost:9092
 
 iamport:
   key: ${IAMPORT_KEY}

--- a/popi-payment-service/src/main/resources/db/migration/V2__create_payment_item_table.sql
+++ b/popi-payment-service/src/main/resources/db/migration/V2__create_payment_item_table.sql
@@ -1,0 +1,9 @@
+CREATE TABLE payment_item (
+                         payment_item_id BIGINT AUTO_INCREMENT PRIMARY KEY,
+                         payment_id BIGINT NOT NULL,
+                         item_id BIGINT NOT NULL,
+                         quantity INT NOT NULL,
+                         created_at DATETIME NOT NULL,
+                         updated_at DATETIME,
+                         CONSTRAINT fk_payment_item_payment FOREIGN KEY (payment_id) REFERENCES payment(payment_id) ON DELETE CASCADE
+)

--- a/popi-payment-service/src/main/resources/db/migration/V3__alter_payment_table_add_popup_id_column.sql
+++ b/popi-payment-service/src/main/resources/db/migration/V3__alter_payment_table_add_popup_id_column.sql
@@ -1,0 +1,1 @@
+ALTER TABLE payment ADD COLUMN popup_id BIGINT NOT NULL;

--- a/popi-payment-service/src/test/java/com/lgcns/kafka/EmbeddedKafkaIntegrationTest.java
+++ b/popi-payment-service/src/test/java/com/lgcns/kafka/EmbeddedKafkaIntegrationTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.lgcns.kafka.message.ItemPurchasedMessage;
 import com.lgcns.kafka.producer.ItemPurchasedProducer;
 import java.time.Duration;
+import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -33,9 +34,14 @@ class EmbeddedKafkaIntegrationTest {
     @Test
     void 상품_구매_메시지를_카프카에_발행한다() {
         // given
+        Long popupId = 1L;
         List<ItemPurchasedMessage.Item> items =
                 List.of(new ItemPurchasedMessage.Item(1L, 2), new ItemPurchasedMessage.Item(2L, 3));
-        ItemPurchasedMessage message = new ItemPurchasedMessage(items);
+        int amount = 39000;
+        LocalDateTime purchasedAt = LocalDateTime.of(2026, 6, 6, 0, 0);
+
+        ItemPurchasedMessage message =
+                new ItemPurchasedMessage(popupId, items, amount, purchasedAt);
 
         // when
         itemPurchasedProducer.sendMessage(message);
@@ -59,12 +65,14 @@ class EmbeddedKafkaIntegrationTest {
             ItemPurchasedMessage received = record.value();
 
             Assertions.assertAll(
+                    () -> assertThat(received.popupId()).isEqualTo(popupId),
                     () -> assertThat(received.items()).hasSize(2),
                     () -> assertThat(received.items()).extracting("itemId").containsExactly(1L, 2L),
+                    () -> assertThat(received.items()).extracting("quantity").containsExactly(2, 3),
+                    () -> assertThat(received.amount()).isEqualTo(39000),
                     () ->
-                            assertThat(received.items())
-                                    .extracting("quantity")
-                                    .containsExactly(2, 3));
+                            assertThat(received.purchasedAt())
+                                    .isEqualTo(LocalDateTime.of(2026, 6, 6, 0, 0)));
         }
     }
 }

--- a/popi-payment-service/src/test/java/com/lgcns/kafka/EmbeddedKafkaIntegrationTest.java
+++ b/popi-payment-service/src/test/java/com/lgcns/kafka/EmbeddedKafkaIntegrationTest.java
@@ -1,0 +1,70 @@
+package com.lgcns.kafka;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.lgcns.kafka.message.ItemPurchasedMessage;
+import com.lgcns.kafka.producer.ItemPurchasedProducer;
+import java.time.Duration;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.kafka.support.serializer.JsonDeserializer;
+import org.springframework.kafka.test.EmbeddedKafkaBroker;
+import org.springframework.kafka.test.context.EmbeddedKafka;
+import org.springframework.kafka.test.utils.KafkaTestUtils;
+import org.springframework.test.context.ActiveProfiles;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@EmbeddedKafka(partitions = 1, topics = "item-purchased-topic")
+class EmbeddedKafkaIntegrationTest {
+
+    @Autowired private EmbeddedKafkaBroker embeddedKafkaBroker;
+
+    @Autowired private ItemPurchasedProducer itemPurchasedProducer;
+
+    @Test
+    void 상품_구매_메시지를_카프카에_발행한다() {
+        // given
+        List<ItemPurchasedMessage.Item> items =
+                List.of(new ItemPurchasedMessage.Item(1L, 2), new ItemPurchasedMessage.Item(2L, 3));
+        ItemPurchasedMessage message = new ItemPurchasedMessage(items);
+
+        // when
+        itemPurchasedProducer.sendMessage(message);
+
+        // then
+        Map<String, Object> consumerProps =
+                KafkaTestUtils.consumerProps("testGroup", "true", embeddedKafkaBroker);
+        consumerProps.put(JsonDeserializer.TRUSTED_PACKAGES, "com.lgcns.kafka.message");
+
+        try (KafkaConsumer<String, ItemPurchasedMessage> consumer =
+                new KafkaConsumer<>(
+                        consumerProps,
+                        new StringDeserializer(),
+                        new JsonDeserializer<>(ItemPurchasedMessage.class, false))) {
+            consumer.subscribe(Collections.singletonList("item-purchased-topic"));
+
+            ConsumerRecord<String, ItemPurchasedMessage> record =
+                    KafkaTestUtils.getSingleRecord(
+                            consumer, "item-purchased-topic", Duration.ofSeconds(5));
+
+            ItemPurchasedMessage received = record.value();
+
+            Assertions.assertAll(
+                    () -> assertThat(received.items()).hasSize(2),
+                    () -> assertThat(received.items()).extracting("itemId").containsExactly(1L, 2L),
+                    () ->
+                            assertThat(received.items())
+                                    .extracting("quantity")
+                                    .containsExactly(2, 3));
+        }
+    }
+}

--- a/popi-payment-service/src/test/java/com/lgcns/service/PaymentServiceTest.java
+++ b/popi-payment-service/src/test/java/com/lgcns/service/PaymentServiceTest.java
@@ -158,7 +158,8 @@ public class PaymentServiceTest extends WireMockIntegrationTest {
         @BeforeEach
         void setUp() {
             paymentRepository.deleteAll();
-            paymentRepository.save(Payment.createPayment(1L, "popup_1_order_test-uuid", 129000));
+            paymentRepository.save(
+                    Payment.createPayment(1L, "popup_1_order_test-uuid", 129000, 1L));
         }
 
         @Test

--- a/popi-payment-service/src/test/resources/application-test.yml
+++ b/popi-payment-service/src/test/resources/application-test.yml
@@ -6,6 +6,8 @@ spring:
     url: jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=false;MODE=MYSQL
   flyway:
     enabled: false
+  kafka:
+    bootstrap-servers: localhost:9092
 
 manager:
   service:


### PR DESCRIPTION
## 🌱 관련 이슈

- [LCR-251]

---
## 📌 작업 내용 및 특이사항

- 결제 상품 정보를 저장하기 위해 PaymentItem 엔티티를 추가했습니다.
- 결제 준비 요청 시 itemId와 quantity를 기준으로 PaymentItem을 생성하고, Payment와 함께 DB에 저장되도록 구현했습니다.
- Kafka 메시지 전송을 위한 설정(KafkaProducerConfig, application-local.yml)을 추가했습니다.
- 결제 항목 정보를 담은 ItemPurchasedMessage DTO를 정의하고, itemId와 quantity를 포함하는 구조로 설계했습니다.
- ItemPurchasedProducer를 구현하여 결제 검증 성공 시 item-purchased-topic으로 메시지를 발행하도록 처리했습니다.
- 구매 통계 분석에 활용하기 위해 popupId, amount, purchasedAt 정보를 Kafka 메시지에 포함하도록 확장했습니다.
- 로컬 Kafka 실행용 docker-compose-kafka.yml을 추가하였습니다.

## ✅ Kafka 통합테스트
- Kafka 메시지 발행 기능을 검증하기 위해 Embedded Kafka 통합 테스트를 추가했습니다.
- `ItemPurchasedProducer`가 `item-purchased-topic`으로 메시지를 정상 발행하는지 검증합니다.
- JsonDeserializer 사용 시 역직렬화 클래스가 신뢰된 패키지에 포함되지 않으면 예외가 발생하므로, consumerProps.put(JsonDeserializer.TRUSTED_PACKAGES, "com.lgcns.kafka.message"); 설정을 통해 이를 허용했습니다.
- 메시지 수신 대기 시, 테스트 타임아웃 방지를 위해 KafkaTestUtils.getSingleRecord(..., Duration.ofSeconds(5)) 을 사용해 최대 5초까지 대기하도록 설정했습니다.
- 현재 결제 서비스에서는 Kafka Producer만 존재하여 발행 테스트만 수행합니다.
- 향후 운영자 서비스(Consumer 전용) 개발 시, 이 테스트에서 사용한 방식처럼 Embedded Kafka를 활용해 Producer를 테스트용으로 구성하고, 실제 메시지 소비 로직을 검증하는 테스트를 작성할 수 있습니다.

---
## 📚 참고사항

- Kafka Consumer의 경우 운영자 서비스에서 구현중입니다.
- 로컬에서 Kafka 메시지 수신 확인 시 다음과 같습니다.
```bash
./bin/kafka-console-consumer.sh \
  --bootstrap-server localhost:9092 \
  --topic item-purchased-topic
{"popupId":1,"items":[{"itemId":11,"quantity":2},{"itemId":4,"quantity":4}],"amount":39000,"purchasedAt":[2025,5,28,13,5,33]}
```


[LCR-251]: https://lgcns-retail.atlassian.net/browse/LCR-251?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ