### PR TITLE
feat: 설문지 답변 등록 엔드포인트 구현

### DIFF
--- a/popi-api-gateway/src/main/resources/application-local.yml
+++ b/popi-api-gateway/src/main/resources/application-local.yml
@@ -222,6 +222,3 @@ jwt:
 logging:
   level:
     org.hibernate.SQL: debug
-    org.springframework.cloud.gateway: DEBUG
-    reactor.netty.http.client: DEBUG
-    org.springframework.web.reactive.function.client.ExchangeFunctions: TRACE

--- a/popi-reservation-service/src/main/java/com/lgcns/dto/request/SurveyChoiceRequest.java
+++ b/popi-reservation-service/src/main/java/com/lgcns/dto/request/SurveyChoiceRequest.java
@@ -4,7 +4,5 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 
 public record SurveyChoiceRequest(
-        @Schema(description = "설문지 ID", example = "24") @NotNull(message = "선지를 선택해주세요.")
-                Long surveyId,
-        @Schema(description = "선지 ID", example = "130") @NotNull(message = "선지를 선택해주세요.")
-                Long choiceId) {}
+        @Schema(description = "설문지 ID", example = "24") @NotNull Long surveyId,
+        @Schema(description = "선지 ID", example = "130") @NotNull Long choiceId) {}

--- a/popi-reservation-service/src/main/java/com/lgcns/dto/request/SurveyChoiceRequest.java
+++ b/popi-reservation-service/src/main/java/com/lgcns/dto/request/SurveyChoiceRequest.java
@@ -1,0 +1,7 @@
+package com.lgcns.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record SurveyChoiceRequest(
+        @Schema(description = "설문지 ID", example = "24") Long surveyId,
+        @Schema(description = "선지 ID", example = "130") Long choiceId) {}

--- a/popi-reservation-service/src/main/java/com/lgcns/dto/request/SurveyChoiceRequest.java
+++ b/popi-reservation-service/src/main/java/com/lgcns/dto/request/SurveyChoiceRequest.java
@@ -1,7 +1,10 @@
 package com.lgcns.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
 
 public record SurveyChoiceRequest(
-        @Schema(description = "설문지 ID", example = "24") Long surveyId,
-        @Schema(description = "선지 ID", example = "130") Long choiceId) {}
+        @Schema(description = "설문지 ID", example = "24") @NotNull(message = "선지를 선택해주세요.")
+                Long surveyId,
+        @Schema(description = "선지 ID", example = "130") @NotNull(message = "선지를 선택해주세요.")
+                Long choiceId) {}

--- a/popi-reservation-service/src/main/java/com/lgcns/exception/MemberReservationErrorCode.java
+++ b/popi-reservation-service/src/main/java/com/lgcns/exception/MemberReservationErrorCode.java
@@ -18,6 +18,7 @@ public enum MemberReservationErrorCode implements ErrorCode {
     QR_CODE_GENERATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "QR 코드 생성에 실패했습니다."),
 
     INVALID_DATE_FORMAT(HttpStatus.BAD_REQUEST, "유효한 날짜 범위 또는 yyyy-MM 형식이 아닙니다."),
+    SURVEY_CHOICES_EMPTY(HttpStatus.BAD_REQUEST, "선택하지 않은 문항이 있습니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/popi-reservation-service/src/main/java/com/lgcns/exception/MemberReservationErrorCode.java
+++ b/popi-reservation-service/src/main/java/com/lgcns/exception/MemberReservationErrorCode.java
@@ -18,7 +18,7 @@ public enum MemberReservationErrorCode implements ErrorCode {
     QR_CODE_GENERATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "QR 코드 생성에 실패했습니다."),
 
     INVALID_DATE_FORMAT(HttpStatus.BAD_REQUEST, "유효한 날짜 범위 또는 yyyy-MM 형식이 아닙니다."),
-    SURVEY_CHOICES_EMPTY(HttpStatus.BAD_REQUEST, "선택하지 않은 문항이 있습니다."),
+    INVALID_SURVEY_CHOICES_COUNT(HttpStatus.BAD_REQUEST, "선택하지 않은 문항이 있습니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/popi-reservation-service/src/main/java/com/lgcns/externalApi/MemberReservationController.java
+++ b/popi-reservation-service/src/main/java/com/lgcns/externalApi/MemberReservationController.java
@@ -7,6 +7,7 @@ import com.lgcns.dto.response.SurveyChoiceResponse;
 import com.lgcns.service.MemberReservationService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -38,7 +39,7 @@ public class MemberReservationController {
     public ResponseEntity<Void> memberAnswerCreate(
             @PathVariable Long popupId,
             @RequestHeader("member-id") String memberId,
-            @RequestBody List<SurveyChoiceRequest> surveyChoices) {
+            @Valid @RequestBody List<SurveyChoiceRequest> surveyChoices) {
         memberReservationService.createMemberAnswer(popupId, memberId, surveyChoices);
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }

--- a/popi-reservation-service/src/main/java/com/lgcns/externalApi/MemberReservationController.java
+++ b/popi-reservation-service/src/main/java/com/lgcns/externalApi/MemberReservationController.java
@@ -1,5 +1,6 @@
 package com.lgcns.externalApi;
 
+import com.lgcns.dto.request.SurveyChoiceRequest;
 import com.lgcns.dto.response.AvailableDateResponse;
 import com.lgcns.dto.response.ReservationDetailResponse;
 import com.lgcns.dto.response.SurveyChoiceResponse;
@@ -30,6 +31,16 @@ public class MemberReservationController {
     @Operation(summary = "설문지 조회", description = "해당 팝업에 대한 설문지 선지들을 조회합니다.")
     public List<SurveyChoiceResponse> choiceListByPopupIdFind(@PathVariable Long popupId) {
         return memberReservationService.findSurveyChoicesByPopupId(popupId);
+    }
+
+    @PostMapping("/popups/{popupId}/survey")
+    @Operation(summary = "설문지 응답 저장", description = "해당 팝업에 대한 설문지 응답을 저장합니다.")
+    public ResponseEntity<Void> memberAnswerCreate(
+            @PathVariable Long popupId,
+            @RequestHeader("member-id") String memberId,
+            @RequestBody List<SurveyChoiceRequest> surveyChoices) {
+        memberReservationService.createMemberAnswer(popupId, memberId, surveyChoices);
+        return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 
     @PostMapping("/{reservationId}")

--- a/popi-reservation-service/src/main/java/com/lgcns/service/MemberReservationService.java
+++ b/popi-reservation-service/src/main/java/com/lgcns/service/MemberReservationService.java
@@ -1,5 +1,6 @@
 package com.lgcns.service;
 
+import com.lgcns.dto.request.SurveyChoiceRequest;
 import com.lgcns.dto.response.AvailableDateResponse;
 import com.lgcns.dto.response.DailyMemberReservationCountResponse;
 import com.lgcns.dto.response.ReservationDetailResponse;
@@ -24,4 +25,6 @@ public interface MemberReservationService {
     List<Long> findHotPopupIds();
 
     DailyMemberReservationCountResponse findDailyMemberReservationCount(Long popupId);
+
+    void createMemberAnswer(Long popupId, String memberId, List<SurveyChoiceRequest> surveyChoices);
 }

--- a/popi-reservation-service/src/main/java/com/lgcns/service/MemberReservationServiceImpl.java
+++ b/popi-reservation-service/src/main/java/com/lgcns/service/MemberReservationServiceImpl.java
@@ -84,8 +84,13 @@ public class MemberReservationServiceImpl implements MemberReservationService {
     @Override
     public void createMemberAnswer(
             Long popupId, String memberId, List<SurveyChoiceRequest> surveyChoices) {
+        final int DEFAULT_CHOICE_COUNT = 4;
+
+        if (surveyChoices.size() != DEFAULT_CHOICE_COUNT) {
+            throw new CustomException(MemberReservationErrorCode.SURVEY_CHOICES_EMPTY);
+        }
+
         // TODO manager 서비스에 회원 설문 응답 저장 메시지 발행
-        log.info("surveyChoices: {}", surveyChoices);
 
         // TODO 설문 응답 저장 후, 추천 서비스로 메시지 발행
 

--- a/popi-reservation-service/src/main/java/com/lgcns/service/MemberReservationServiceImpl.java
+++ b/popi-reservation-service/src/main/java/com/lgcns/service/MemberReservationServiceImpl.java
@@ -51,7 +51,7 @@ public class MemberReservationServiceImpl implements MemberReservationService {
     private final ApplicationEventPublisher eventPublisher;
     private final RedisTemplate<String, Long> redisTemplate;
 
-    private static final int DEFAULT_CHOICE_COUNT = 4;
+    private static final int DEFAULT_SURVEY_COUNT = 4;
 
     @Override
     public AvailableDateResponse findAvailableDate(Long popupId, String date) {
@@ -87,7 +87,7 @@ public class MemberReservationServiceImpl implements MemberReservationService {
     public void createMemberAnswer(
             Long popupId, String memberId, List<SurveyChoiceRequest> surveyChoices) {
 
-        if (surveyChoices.size() != DEFAULT_CHOICE_COUNT) {
+        if (surveyChoices.size() != DEFAULT_SURVEY_COUNT) {
             throw new CustomException(MemberReservationErrorCode.INVALID_SURVEY_CHOICES_COUNT);
         }
 

--- a/popi-reservation-service/src/main/java/com/lgcns/service/MemberReservationServiceImpl.java
+++ b/popi-reservation-service/src/main/java/com/lgcns/service/MemberReservationServiceImpl.java
@@ -51,6 +51,8 @@ public class MemberReservationServiceImpl implements MemberReservationService {
     private final ApplicationEventPublisher eventPublisher;
     private final RedisTemplate<String, Long> redisTemplate;
 
+    private static final int DEFAULT_CHOICE_COUNT = 4;
+
     @Override
     public AvailableDateResponse findAvailableDate(Long popupId, String date) {
 
@@ -84,10 +86,9 @@ public class MemberReservationServiceImpl implements MemberReservationService {
     @Override
     public void createMemberAnswer(
             Long popupId, String memberId, List<SurveyChoiceRequest> surveyChoices) {
-        final int DEFAULT_CHOICE_COUNT = 4;
 
         if (surveyChoices.size() != DEFAULT_CHOICE_COUNT) {
-            throw new CustomException(MemberReservationErrorCode.SURVEY_CHOICES_EMPTY);
+            throw new CustomException(MemberReservationErrorCode.INVALID_SURVEY_CHOICES_COUNT);
         }
 
         // TODO manager 서비스에 회원 설문 응답 저장 메시지 발행

--- a/popi-reservation-service/src/main/java/com/lgcns/service/MemberReservationServiceImpl.java
+++ b/popi-reservation-service/src/main/java/com/lgcns/service/MemberReservationServiceImpl.java
@@ -13,6 +13,7 @@ import com.lgcns.client.managerClient.dto.request.PopupIdsRequest;
 import com.lgcns.client.managerClient.dto.response.*;
 import com.lgcns.client.memberClient.MemberServiceClient;
 import com.lgcns.domain.MemberReservation;
+import com.lgcns.dto.request.SurveyChoiceRequest;
 import com.lgcns.dto.response.*;
 import com.lgcns.error.exception.CustomException;
 import com.lgcns.event.dto.MemberReservationUpdateEvent;
@@ -78,6 +79,16 @@ public class MemberReservationServiceImpl implements MemberReservationService {
     @Override
     public List<SurveyChoiceResponse> findSurveyChoicesByPopupId(Long popupId) {
         return managerServiceClient.findSurveyChoicesByPopupId(popupId);
+    }
+
+    @Override
+    public void createMemberAnswer(
+            Long popupId, String memberId, List<SurveyChoiceRequest> surveyChoices) {
+        // TODO manager 서비스에 회원 설문 응답 저장 메시지 발행
+        log.info("surveyChoices: {}", surveyChoices);
+
+        // TODO 설문 응답 저장 후, 추천 서비스로 메시지 발행
+
     }
 
     @Override

--- a/popi-reservation-service/src/test/java/com/lgcns/service/MemberReservationServiceTest.java
+++ b/popi-reservation-service/src/test/java/com/lgcns/service/MemberReservationServiceTest.java
@@ -12,6 +12,7 @@ import com.lgcns.WireMockIntegrationTest;
 import com.lgcns.client.managerClient.dto.request.PopupIdsRequest;
 import com.lgcns.domain.MemberReservation;
 import com.lgcns.domain.MemberReservationStatus;
+import com.lgcns.dto.request.SurveyChoiceRequest;
 import com.lgcns.dto.response.*;
 import com.lgcns.error.exception.CustomException;
 import com.lgcns.error.feign.FeignErrorCode;
@@ -427,6 +428,45 @@ class MemberReservationServiceTest extends WireMockIntegrationTest {
             assertSurveyChoice(choices.get(1), 2L, 6L);
             assertSurveyChoice(choices.get(2), 3L, 11L);
             assertSurveyChoice(choices.get(3), 4L, 16L);
+        }
+    }
+
+    @Nested
+    class 설문지_등록_할_때 {
+        @Test
+        void 설문지_응답이_정상적으로_저장된다() throws JsonProcessingException {
+            // given
+            List<SurveyChoiceRequest> surveyChoices =
+                    List.of(
+                            new SurveyChoiceRequest(1L, 1L),
+                            new SurveyChoiceRequest(2L, 5L),
+                            new SurveyChoiceRequest(3L, 9L),
+                            new SurveyChoiceRequest(4L, 13L));
+
+            // when
+            memberReservationService.createMemberAnswer(popupId, memberId, surveyChoices);
+
+            // then
+            // TODO kafka를 통해 응답이 잘 저장되었는지 검증하는 테스트 코드 필요
+        }
+
+        @Test
+        void 설문지_응답이_4개가_아니면_예외가_발생한다() {
+            // given
+            List<SurveyChoiceRequest> surveyChoices =
+                    List.of(
+                            new SurveyChoiceRequest(1L, 1L),
+                            new SurveyChoiceRequest(2L, 2L),
+                            new SurveyChoiceRequest(3L, 3L));
+
+            // when & then
+            assertThatThrownBy(
+                            () ->
+                                    memberReservationService.createMemberAnswer(
+                                            popupId, memberId, surveyChoices))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessageContaining(
+                            MemberReservationErrorCode.SURVEY_CHOICES_EMPTY.getMessage());
         }
     }
 

--- a/popi-reservation-service/src/test/java/com/lgcns/service/MemberReservationServiceTest.java
+++ b/popi-reservation-service/src/test/java/com/lgcns/service/MemberReservationServiceTest.java
@@ -466,7 +466,7 @@ class MemberReservationServiceTest extends WireMockIntegrationTest {
                                             popupId, memberId, surveyChoices))
                     .isInstanceOf(CustomException.class)
                     .hasMessageContaining(
-                            MemberReservationErrorCode.SURVEY_CHOICES_EMPTY.getMessage());
+                            MemberReservationErrorCode.INVALID_SURVEY_CHOICES_COUNT.getMessage());
         }
     }
 


### PR DESCRIPTION
## 🌱 관련 이슈

- [LCR-169]

---
## 📌 작업 내용 및 특이사항

- 설문 응답 저장용 API를 구현했습니다.
- 설문 응답 개수가 4개가 아닌 경우에 대한 예외 처리와 테스트 코드 작성했습니다.

---
## 📚 참고사항

- 설문지 답변 등록 시 @RequestBody 구조가 어색하여, 기존의 MemberAnswerCreateRequest 래퍼 클래스를 제거하고 리스트 형태로 바로 받도록 수정했습니다. 이에 따라 API 명세서도 함께 수정했습니다. [명세서 링크](https://www.notion.so/API-1e1483a29ee480949f5be94fd080e72b?p=1f8483a29ee480d2b4e8d025cb7d40be&pm=s)
- 프론트엔드에서 4xx 에러 없이 요청을 보낼 수 있도록 엔드포인트만 우선 구현했습니다. Kafka를 통해 설문 응답을 저장하고, 추천 서버로 전달하는 비동기 처리 로직은 추후에 추가할 예정입니다.


[LCR-169]: https://lgcns-retail.atlassian.net/browse/LCR-169?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ