### PR TITLE
fix: 예약 서비스 RewritePath 필터 경로 매핑 수정

### DIFF
--- a/popi-api-gateway/src/main/resources/application-local.yml
+++ b/popi-api-gateway/src/main/resources/application-local.yml
@@ -96,11 +96,11 @@ spring:
         - id: reservation-service
           uri: lb://RESERVATIONS
           predicates:
-            - Path=/reservations/**
+            - Path=/reservations, /reservations/**
             - Method=GET,POST,DELETE
           filters:
             - RemoveRequestHeader=Cookie
-            - RewritePath=/reservations/(?<segment>.*), /$\{segment}
+            - RewritePath=/reservations(?<segment>/?.*), /$\{segment}
             - JwtAuthenticationFilter
 
         - id: popup-service


### PR DESCRIPTION
## 🌱 관련 이슈

- [LCR-271]

---
## 📌 작업 내용 및 특이사항

- 예약 목록 조회 시, /reservations로 요청하면 405 에러가 발생하는 문제를 수정했습니다.
- /reservations/로만 정상 응답이 되던 기존 필터 로직을 개선하여, 슬래시 유무에 관계없이 동일한 결과를 반환하도록 API Gateway의 RewritePath 필터를 수정했습니다.

---
## 📚 참고사항

- popi-ops도 수정했습니다.


[LCR-271]: https://lgcns-retail.atlassian.net/browse/LCR-271?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ