### PR TITLE
feat: Google OAuth audiences에 iOS 클라이언트 ID 추가

### DIFF
--- a/popi-auth-service/src/main/resources/application-local.yml
+++ b/popi-auth-service/src/main/resources/application-local.yml
@@ -26,6 +26,7 @@ oidc:
     audiences:
       - ${GOOGLE_WEB_CLIENT_ID:}
       - ${GOOGLE_ANDROID_CLIENT_ID:}
+      - ${GOOGLE_IOS_CLIENT_ID:}
 
 jwt:
   access-token-secret: ${JWT_ACCESS_TOKEN_SECRET}

--- a/popi-auth-service/src/test/resources/application-test.yml
+++ b/popi-auth-service/src/test/resources/application-test.yml
@@ -19,6 +19,7 @@ oidc:
     audiences:
       - ${GOOGLE_WEB_CLIENT_ID:}
       - ${GOOGLE_ANDROID_CLIENT_ID:}
+      - ${GOOGLE_IOS_CLIENT_ID:}
 
 jwt:
   access-token-secret: ${JWT_ACCESS_TOKEN_SECRET}


### PR DESCRIPTION
## 🌱 관련 이슈

- [LCR-277]

---
## 📌 작업 내용 및 특이사항

- Google OAuth 인증 과정에서 iOS 클라이언트의 토큰도 검증 가능하도록 application.yml의 audiences 항목에 GOOGLE_IOS_CLIENT_ID를 추가했습니다.


[LCR-277]: https://lgcns-retail.atlassian.net/browse/LCR-277?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ