### PR TITLE
feat: 지도 기반 팝업 리스트 조회 기능 구현

### DIFF
--- a/popi-popup-service/src/main/java/com/lgcns/client/managerClient/ManagerServiceClient.java
+++ b/popi-popup-service/src/main/java/com/lgcns/client/managerClient/ManagerServiceClient.java
@@ -27,4 +27,11 @@ public interface ManagerServiceClient {
 
     @PostMapping("/internal/popups/popularity")
     List<PopupInfoResponse> findHotPopupsByIds(@Valid @RequestBody PopupIdsRequest request);
+
+    @GetMapping("/internal/popups/map")
+    List<PopupInfoResponse> findPopupsByMapArea(
+            @RequestParam(name = "latMin") Double latMin,
+            @RequestParam(name = "latMax") Double latMax,
+            @RequestParam(name = "lngMin") Double lngMin,
+            @RequestParam(name = "lngMax") Double lngMax);
 }

--- a/popi-popup-service/src/main/java/com/lgcns/externalApi/PopupController.java
+++ b/popi-popup-service/src/main/java/com/lgcns/externalApi/PopupController.java
@@ -47,4 +47,20 @@ public class PopupController {
     public List<PopupInfoResponse> hotPopupsFind() {
         return popupService.findHotPopups();
     }
+
+    @GetMapping("/maps")
+    @Operation(
+            summary = "지도 기반 팝업 조회",
+            description = "지도의 좌하단과 우상단 좌표를 기준으로 해당 범위 내의 팝업 목록을 조회합니다. 범위 내에 팝업이 없으면 빈 배열을 반환합니다.")
+    public List<PopupInfoResponse> popupFindByMapArea(
+            @Parameter(description = "최소 위도", example = "37.378638", required = true) @RequestParam
+                    Double latMin,
+            @Parameter(description = "최대 위도", example = "37.671877", required = true) @RequestParam
+                    Double latMax,
+            @Parameter(description = "최소 경도", example = "126.799543", required = true) @RequestParam
+                    Double lngMin,
+            @Parameter(description = "최대 경도", example = "127.184881", required = true) @RequestParam
+                    Double lngMax) {
+        return popupService.findPopupsByMapArea(latMin, latMax, lngMin, lngMax);
+    }
 }

--- a/popi-popup-service/src/main/java/com/lgcns/service/PopupService.java
+++ b/popi-popup-service/src/main/java/com/lgcns/service/PopupService.java
@@ -11,4 +11,7 @@ public interface PopupService {
     PopupDetailsResponse findPopupDetailsById(Long popupId);
 
     List<PopupInfoResponse> findHotPopups();
+
+    List<PopupInfoResponse> findPopupsByMapArea(
+            Double latMin, Double latMax, Double lngMin, Double lngMax);
 }

--- a/popi-popup-service/src/main/java/com/lgcns/service/PopupServiceImpl.java
+++ b/popi-popup-service/src/main/java/com/lgcns/service/PopupServiceImpl.java
@@ -34,4 +34,10 @@ public class PopupServiceImpl implements PopupService {
         PopupIdsRequest popupIdsRequest = new PopupIdsRequest(popupIds);
         return managerServiceClient.findHotPopupsByIds(popupIdsRequest);
     }
+
+    @Override
+    public List<PopupInfoResponse> findPopupsByMapArea(
+            Double latMin, Double latMax, Double lngMin, Double lngMax) {
+        return managerServiceClient.findPopupsByMapArea(latMin, latMax, lngMin, lngMax);
+    }
 }


### PR DESCRIPTION
## 🌱 관련 이슈

- [LCR-233]

---
## 📌 작업 내용 및 특이사항

- 클라이언트로부터 지도의 화면 크기만큼의 범위를 받아 manager-service으로 feign 요청을 보냅니다
- 요청 엔드포인트는 다음과 같습니다. `GET /popups/map?latMin=37.48&latMax=37.50&lngMin=127.02&lngMax=127.06`
- 응답 받은 값 (범위 내에 존재하는 팝업 리스트)는 별도의 정렬과 페이징 없이 전체 리스트를 반환합니다.
- 추후 프론트엔드에서 정렬 및 필터링을 진행하기로 협의했습니다.
- 범위 내에 존재하지 않는 경우 빈 리스트를 반환하면 되므로, 별도의 에러처리를 하지 않았습니다.

---
## 📚 참고사항

-


[LCR-233]: https://lgcns-retail.atlassian.net/browse/LCR-233?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ