### PR TITLE
feat: 상품 구매 Kafka 메시지 purchasedAt 필드 문자열 포맷으로 변경

### DIFF
--- a/popi-payment-service/src/main/java/com/lgcns/kafka/message/ItemPurchasedMessage.java
+++ b/popi-payment-service/src/main/java/com/lgcns/kafka/message/ItemPurchasedMessage.java
@@ -1,11 +1,16 @@
 package com.lgcns.kafka.message;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.lgcns.domain.Payment;
 import java.time.LocalDateTime;
 import java.util.List;
 
 public record ItemPurchasedMessage(
-        Long popupId, List<Item> items, int amount, LocalDateTime purchasedAt) {
+        Long popupId,
+        List<Item> items,
+        int amount,
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
+                LocalDateTime purchasedAt) {
     public static ItemPurchasedMessage from(Payment payment) {
         List<Item> items =
                 payment.getItems().stream()


### PR DESCRIPTION
## 🌱 관련 이슈

- [LCR-276]

---
## 📌 작업 내용 및 특이사항

- 기존에 배열로 직렬화되던 purchasedAt 필드를 문자열 형태(yyyy-MM-dd'T'HH:mm:ss)로 변경했습니다.

---
## 📚 참고사항

- Kafka 메시지에서 LocalDate, LocalDateTime, LocalTime을 사용하는 경우 Jackson 직렬화 형식이 배열로 처리되므로, 명시적으로 ```@JsonFormat``` 어노테이션을 추가해야 합니다.

[LCR-276]: https://lgcns-retail.atlassian.net/browse/LCR-276?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ