### PR TITLE
fix: 결제 준비 시 merchantUid 길이 초과로 검증 실패하는 문제 수정

### DIFF
--- a/popi-payment-service/src/main/java/com/lgcns/service/PaymentServiceImpl.java
+++ b/popi-payment-service/src/main/java/com/lgcns/service/PaymentServiceImpl.java
@@ -79,7 +79,9 @@ public class PaymentServiceImpl implements PaymentService {
         }
 
         String merchantUid =
-                String.format("popup_%d_order_%s", request.popupId(), UUID.randomUUID());
+                String.format(
+                        "popup_%d_order_%s",
+                        request.popupId(), UUID.randomUUID().toString().substring(0, 16));
 
         Payment payment =
                 Payment.createPayment(

--- a/popi-payment-service/src/test/java/com/lgcns/service/PaymentServiceTest.java
+++ b/popi-payment-service/src/test/java/com/lgcns/service/PaymentServiceTest.java
@@ -68,7 +68,7 @@ public class PaymentServiceTest extends WireMockIntegrationTest {
                     () -> assertThat(response.amount()).isEqualTo(129000),
                     () ->
                             assertThat(response.merchantUid())
-                                    .matches("^popup_1_order_[0-9a-fA-F\\-]{36}$"));
+                                    .matches("^popup_1_order_[0-9a-fA-F\\-]{16}$"));
         }
 
         @Test


### PR DESCRIPTION
## 🌱 관련 이슈

- [LCR-281]

---
## 📌 작업 내용 및 특이사항

- 결제 준비 시 발급하는 merchantUid가 Iamport SDK의 최대 길이(40자)를 초과해 결제 검증 단계에서 매칭 실패가 발생하는 문제를 확인했습니다.
- 이에 따라 merchantUid 생성 시 UUID를 16자리로 잘라 전체 길이를 32자 이하로 제한하도록 수정했습니다.

---
## 📚 참고사항

- 형식: popup_{popupId}_order_{uuid}
- UUID는 UUID.randomUUID().toString().substring(0, 16) 사용
- Iamport 측 merchant_uid 최대 길이 제약 대응입니다.


[LCR-281]: https://lgcns-retail.atlassian.net/browse/LCR-281?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ