### PR TITLE
fix: 지도 기반 팝업 리스트 조회 API 엔드포인트 수정

### DIFF
--- a/popi-popup-service/src/main/java/com/lgcns/externalApi/PopupController.java
+++ b/popi-popup-service/src/main/java/com/lgcns/externalApi/PopupController.java
@@ -48,7 +48,7 @@ public class PopupController {
         return popupService.findHotPopups();
     }
 
-    @GetMapping("/maps")
+    @GetMapping("/map")
     @Operation(
             summary = "지도 기반 팝업 조회",
             description = "지도의 좌하단과 우상단 좌표를 기준으로 해당 범위 내의 팝업 목록을 조회합니다. 범위 내에 팝업이 없으면 빈 배열을 반환합니다.")


### PR DESCRIPTION
## 🌱 관련 이슈

- [LCR-283]

---
## 📌 작업 내용 및 특이사항

- 지도 기반 팝업 리스트 조회 엔드포인트 수정했습니다.
- GET `popups/maps`  --> `popups/map`

---


[LCR-283]: https://lgcns-retail.atlassian.net/browse/LCR-283?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ