### PR TITLE
feat: 예약 회원 입장 API 구현

### DIFF
--- a/popi-api-gateway/src/main/resources/application-local.yml
+++ b/popi-api-gateway/src/main/resources/application-local.yml
@@ -85,6 +85,14 @@ spring:
           filters:
               - RemoveRequestHeader=Cookie
               - RewritePath=/reservations/(?<segment>.*), /$\{segment}
+        - id: reservation-entrance
+          uri: lb://RESERVATIONS
+          predicates:
+            - Path=/reservations/entrance/**
+            - Method=POST
+          filters:
+            - RemoveRequestHeader=Cookie
+            - RewritePath=/reservations/(?<segment>.*), /$\{segment}
         - id: reservation-internal
           uri: lb://RESERVATIONS
           predicates:

--- a/popi-reservation-service/build.gradle
+++ b/popi-reservation-service/build.gradle
@@ -50,4 +50,8 @@ dependencies {
 	// Flyway
 	implementation 'org.flywaydb:flyway-core'
 	implementation 'org.flywaydb:flyway-mysql'
+
+	// Kafka
+	implementation 'org.springframework.kafka:spring-kafka'
+	testImplementation 'org.springframework.kafka:spring-kafka-test'
 }

--- a/popi-reservation-service/src/main/java/com/lgcns/dto/request/QrEntranceInfoRequest.java
+++ b/popi-reservation-service/src/main/java/com/lgcns/dto/request/QrEntranceInfoRequest.java
@@ -1,0 +1,15 @@
+package com.lgcns.dto.request;
+
+import com.lgcns.enums.MemberAge;
+import com.lgcns.enums.MemberGender;
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+public record QrEntranceInfoRequest(
+        Long memberReservationId,
+        Long reservationId,
+        Long popupId,
+        MemberAge age,
+        MemberGender gender,
+        LocalDate reservationDate,
+        LocalTime reservationTime) {}

--- a/popi-reservation-service/src/main/java/com/lgcns/dto/request/QrEntranceInfoRequest.java
+++ b/popi-reservation-service/src/main/java/com/lgcns/dto/request/QrEntranceInfoRequest.java
@@ -2,14 +2,27 @@ package com.lgcns.dto.request;
 
 import com.lgcns.enums.MemberAge;
 import com.lgcns.enums.MemberGender;
-import java.time.LocalDate;
-import java.time.LocalTime;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
 
 public record QrEntranceInfoRequest(
-        Long memberReservationId,
-        Long reservationId,
-        Long popupId,
-        MemberAge age,
-        MemberGender gender,
-        LocalDate reservationDate,
-        LocalTime reservationTime) {}
+        @Schema(description = "회원 예약 ID", example = "1") @NotNull(message = "회원 예약 ID는 필수입니다.")
+                Long memberReservationId,
+        @Schema(description = "예약 ID", example = "1") @NotNull(message = "예약 ID는 필수입니다.")
+                Long reservationId,
+        @Schema(description = "팝업 ID", example = "1") @NotNull(message = "팝업 ID는 필수입니다.")
+                Long popupId,
+        @Schema(description = "연령대", example = "TWENTIES") @NotNull(message = "연령대는 비워둘 수 없습니다.")
+                MemberAge age,
+        @Schema(description = "성별", example = "MALE") @NotNull(message = "성별은 비워둘 수 없습니다.")
+                MemberGender gender,
+        @Schema(description = "예약 날짜", example = "2025-05-13")
+                @NotBlank(message = "예약 날짜는 필수입니다.")
+                @Pattern(regexp = "^\\d{4}-\\d{2}-\\d{2}$", message = "날짜 형식은 yyyy-MM-dd이어야 합니다.")
+                String reservationDate,
+        @Schema(description = "예약 시간", example = "10:00:00")
+                @NotBlank(message = "예약 시간은 필수입니다.")
+                @Pattern(regexp = "^\\d{2}:\\d{2}:\\d{2}$", message = "시간 형식은 HH:mm:ss이어야 합니다.")
+                String reservationTime) {}

--- a/popi-reservation-service/src/main/java/com/lgcns/dto/request/QrEntranceInfoRequest.java
+++ b/popi-reservation-service/src/main/java/com/lgcns/dto/request/QrEntranceInfoRequest.java
@@ -1,11 +1,12 @@
 package com.lgcns.dto.request;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.lgcns.enums.MemberAge;
 import com.lgcns.enums.MemberGender;
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Pattern;
+import java.time.LocalDate;
+import java.time.LocalTime;
 
 public record QrEntranceInfoRequest(
         @Schema(description = "회원 예약 ID", example = "1") @NotNull(message = "회원 예약 ID는 필수입니다.")
@@ -19,10 +20,16 @@ public record QrEntranceInfoRequest(
         @Schema(description = "성별", example = "MALE") @NotNull(message = "성별은 비워둘 수 없습니다.")
                 MemberGender gender,
         @Schema(description = "예약 날짜", example = "2025-05-13")
-                @NotBlank(message = "예약 날짜는 필수입니다.")
-                @Pattern(regexp = "^\\d{4}-\\d{2}-\\d{2}$", message = "날짜 형식은 yyyy-MM-dd이어야 합니다.")
-                String reservationDate,
+                @NotNull(message = "예약 날짜는 필수입니다.")
+                @JsonFormat(
+                        shape = JsonFormat.Shape.STRING,
+                        pattern = "yyyy-MM-dd",
+                        timezone = "Asia/Seoul")
+                LocalDate reservationDate,
         @Schema(description = "예약 시간", example = "10:00:00")
-                @NotBlank(message = "예약 시간은 필수입니다.")
-                @Pattern(regexp = "^\\d{2}:\\d{2}:\\d{2}$", message = "시간 형식은 HH:mm:ss이어야 합니다.")
-                String reservationTime) {}
+                @NotNull(message = "예약 시간은 필수입니다.")
+                @JsonFormat(
+                        shape = JsonFormat.Shape.STRING,
+                        pattern = "HH:mm:ss",
+                        timezone = "Asia/Seoul")
+                LocalTime reservationTime) {}

--- a/popi-reservation-service/src/main/java/com/lgcns/event/handler/MemberReservationEventHandler.java
+++ b/popi-reservation-service/src/main/java/com/lgcns/event/handler/MemberReservationEventHandler.java
@@ -3,6 +3,8 @@ package com.lgcns.event.handler;
 import com.lgcns.error.exception.CustomException;
 import com.lgcns.event.dto.MemberReservationUpdateEvent;
 import com.lgcns.exception.MemberReservationErrorCode;
+import com.lgcns.kafka.message.MemberEnteredMessage;
+import com.lgcns.kafka.producer.MemberEnteredProducer;
 import com.lgcns.service.MemberReservationService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -14,14 +16,21 @@ import org.springframework.transaction.event.TransactionalEventListener;
 @RequiredArgsConstructor
 @Component
 @Slf4j
-public class MemberReservationUpdateEventHandler {
+public class MemberReservationEventHandler {
 
     private final MemberReservationService memberReservationService;
+    private final MemberEnteredProducer memberEnteredProducer;
 
     @Async
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handleMemberReservationUpdateEvent(MemberReservationUpdateEvent event) {
         tryUpdateEvent(event.memberReservationId(), event.waitTime(), 0);
+    }
+
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleMemberEnteredEvent(MemberEnteredMessage message) {
+        memberEnteredProducer.sendMessage(message);
     }
 
     private void tryUpdateEvent(Long memberReservationId, long waitTime, int retryCount) {

--- a/popi-reservation-service/src/main/java/com/lgcns/exception/MemberReservationErrorCode.java
+++ b/popi-reservation-service/src/main/java/com/lgcns/exception/MemberReservationErrorCode.java
@@ -23,7 +23,7 @@ public enum MemberReservationErrorCode implements ErrorCode {
     RESERVATION_ALREADY_ENTERED(HttpStatus.BAD_REQUEST, "이미 입장한 예약입니다."),
     RESERVATION_POPUP_MISMATCH(HttpStatus.BAD_REQUEST, "예약과 입장 팝업이 일치하지 않습니다."),
     RESERVATION_DATE_MISMATCH(HttpStatus.BAD_REQUEST, "예약 날짜가 일치하지 않습니다."),
-    RESERVATION_TIME_PASSED(HttpStatus.BAD_REQUEST, "입장 가능 시간이 지났습니다.");
+    RESERVATION_TIME_MISMATCH(HttpStatus.BAD_REQUEST, "입장 가능 시간이 아닙니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/popi-reservation-service/src/main/java/com/lgcns/exception/MemberReservationErrorCode.java
+++ b/popi-reservation-service/src/main/java/com/lgcns/exception/MemberReservationErrorCode.java
@@ -19,7 +19,11 @@ public enum MemberReservationErrorCode implements ErrorCode {
 
     INVALID_DATE_FORMAT(HttpStatus.BAD_REQUEST, "유효한 날짜 범위 또는 yyyy-MM 형식이 아닙니다."),
     INVALID_SURVEY_CHOICES_COUNT(HttpStatus.BAD_REQUEST, "선택하지 않은 문항이 있습니다."),
-    ;
+    INVALID_QR_CODE(HttpStatus.BAD_REQUEST, "유효하지 않은 QR 코드입니다."),
+    RESERVATION_ALREADY_ENTERED(HttpStatus.BAD_REQUEST, "이미 입장한 예약입니다."),
+    RESERVATION_POPUP_MISMATCH(HttpStatus.BAD_REQUEST, "예약과 입장 팝업이 일치하지 않습니다."),
+    RESERVATION_DATE_MISMATCH(HttpStatus.BAD_REQUEST, "예약 날짜가 일치하지 않습니다."),
+    RESERVATION_TIME_PASSED(HttpStatus.BAD_REQUEST, "입장 가능 시간이 지났습니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/popi-reservation-service/src/main/java/com/lgcns/externalApi/MemberReservationController.java
+++ b/popi-reservation-service/src/main/java/com/lgcns/externalApi/MemberReservationController.java
@@ -1,6 +1,7 @@
 package com.lgcns.externalApi;
 
 import com.lgcns.dto.request.SurveyChoiceRequest;
+import com.lgcns.dto.request.QrEntranceInfoRequest;
 import com.lgcns.dto.response.AvailableDateResponse;
 import com.lgcns.dto.response.ReservationDetailResponse;
 import com.lgcns.dto.response.SurveyChoiceResponse;
@@ -71,6 +72,15 @@ public class MemberReservationController {
     public ResponseEntity<Void> memberReservationCancel(
             @PathVariable("memberReservationId") Long memberReservationId) {
         memberReservationService.cancelMemberReservation(memberReservationId);
+        return ResponseEntity.status(HttpStatus.OK).build();
+    }
+
+    @PostMapping("/entrance}")
+    @Operation(summary = "회원 예약 입장", description = "예약 ID를 사용하여 회원의 예약을 입장 처리합니다.")
+    public ResponseEntity<Void> memberReservationEntrance(
+            @Valid @RequestBody QrEntranceInfoRequest qrEntranceInfoRequest,
+            @RequestParam Long popupId) {
+        memberReservationService.isReservationPossible(qrEntranceInfoRequest, popupId);
         return ResponseEntity.status(HttpStatus.OK).build();
     }
 }

--- a/popi-reservation-service/src/main/java/com/lgcns/externalApi/MemberReservationController.java
+++ b/popi-reservation-service/src/main/java/com/lgcns/externalApi/MemberReservationController.java
@@ -46,7 +46,7 @@ public class MemberReservationController {
 
     @PostMapping("/{reservationId}")
     @Operation(summary = "회원 예약 생성", description = "예약을 생성합니다. 예약 ID를 사용하여 예약을 생성합니다.")
-    public ResponseEntity<Void> createMemberReservation(
+    public ResponseEntity<Void> memberReservationCreate(
             @RequestHeader("member-id") String memberId, @PathVariable Long reservationId) {
         memberReservationService.createMemberReservation(memberId, reservationId);
         return ResponseEntity.status(HttpStatus.CREATED).build();
@@ -68,7 +68,7 @@ public class MemberReservationController {
 
     @DeleteMapping("/{memberReservationId}")
     @Operation(summary = "회원 예약 취소", description = "예약 ID를 사용하여 회원의 예약을 취소합니다.")
-    public ResponseEntity<Void> cancelMemberReservation(
+    public ResponseEntity<Void> memberReservationCancel(
             @PathVariable("memberReservationId") Long memberReservationId) {
         memberReservationService.cancelMemberReservation(memberReservationId);
         return ResponseEntity.status(HttpStatus.OK).build();

--- a/popi-reservation-service/src/main/java/com/lgcns/externalApi/MemberReservationController.java
+++ b/popi-reservation-service/src/main/java/com/lgcns/externalApi/MemberReservationController.java
@@ -80,7 +80,7 @@ public class MemberReservationController {
     public ResponseEntity<Void> memberReservationEntrance(
             @Valid @RequestBody QrEntranceInfoRequest qrEntranceInfoRequest,
             @RequestParam Long popupId) {
-        memberReservationService.isReservationPossible(qrEntranceInfoRequest, popupId);
+        memberReservationService.isEnterancePossible(qrEntranceInfoRequest, popupId);
         return ResponseEntity.status(HttpStatus.OK).build();
     }
 }

--- a/popi-reservation-service/src/main/java/com/lgcns/externalApi/MemberReservationController.java
+++ b/popi-reservation-service/src/main/java/com/lgcns/externalApi/MemberReservationController.java
@@ -1,7 +1,7 @@
 package com.lgcns.externalApi;
 
-import com.lgcns.dto.request.SurveyChoiceRequest;
 import com.lgcns.dto.request.QrEntranceInfoRequest;
+import com.lgcns.dto.request.SurveyChoiceRequest;
 import com.lgcns.dto.response.AvailableDateResponse;
 import com.lgcns.dto.response.ReservationDetailResponse;
 import com.lgcns.dto.response.SurveyChoiceResponse;

--- a/popi-reservation-service/src/main/java/com/lgcns/externalApi/MemberReservationController.java
+++ b/popi-reservation-service/src/main/java/com/lgcns/externalApi/MemberReservationController.java
@@ -75,8 +75,8 @@ public class MemberReservationController {
         return ResponseEntity.status(HttpStatus.OK).build();
     }
 
-    @PostMapping("/entrance}")
-    @Operation(summary = "회원 예약 입장", description = "예약 ID를 사용하여 회원의 예약을 입장 처리합니다.")
+    @PostMapping("/entrance")
+    @Operation(summary = "예약 회원 입장", description = "예약 ID를 사용하여 회원의 예약을 입장 처리합니다.")
     public ResponseEntity<Void> memberReservationEntrance(
             @Valid @RequestBody QrEntranceInfoRequest qrEntranceInfoRequest,
             @RequestParam Long popupId) {

--- a/popi-reservation-service/src/main/java/com/lgcns/kafka/config/KafkaProducerConfig.java
+++ b/popi-reservation-service/src/main/java/com/lgcns/kafka/config/KafkaProducerConfig.java
@@ -1,6 +1,5 @@
 package com.lgcns.kafka.config;
 
-import com.lgcns.kafka.message.MemberEnteredMessage;
 import java.util.HashMap;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
@@ -22,7 +21,7 @@ public class KafkaProducerConfig {
     private String bootstrapServers;
 
     @Bean
-    public ProducerFactory<String, MemberEnteredMessage> producerFactory() {
+    public ProducerFactory<String, Object> producerFactory() {
         Map<String, Object> properties = new HashMap<>();
         properties.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
         properties.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
@@ -31,7 +30,7 @@ public class KafkaProducerConfig {
     }
 
     @Bean
-    public KafkaTemplate<String, MemberEnteredMessage> kafkaTemplate() {
+    public KafkaTemplate<String, Object> kafkaTemplate() {
         return new KafkaTemplate<>(producerFactory());
     }
 }

--- a/popi-reservation-service/src/main/java/com/lgcns/kafka/config/KafkaProducerConfig.java
+++ b/popi-reservation-service/src/main/java/com/lgcns/kafka/config/KafkaProducerConfig.java
@@ -1,0 +1,37 @@
+package com.lgcns.kafka.config;
+
+import com.lgcns.kafka.message.MemberEnteredMessage;
+import java.util.HashMap;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+import org.springframework.kafka.support.serializer.JsonSerializer;
+
+@Configuration
+@RequiredArgsConstructor
+public class KafkaProducerConfig {
+
+    @Value("${spring.kafka.bootstrap-servers}")
+    private String bootstrapServers;
+
+    @Bean
+    public ProducerFactory<String, MemberEnteredMessage> producerFactory() {
+        Map<String, Object> properties = new HashMap<>();
+        properties.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        properties.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        properties.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class);
+        return new DefaultKafkaProducerFactory<>(properties);
+    }
+
+    @Bean
+    public KafkaTemplate<String, MemberEnteredMessage> kafkaTemplate() {
+        return new KafkaTemplate<>(producerFactory());
+    }
+}

--- a/popi-reservation-service/src/main/java/com/lgcns/kafka/message/MemberEnteredMessage.java
+++ b/popi-reservation-service/src/main/java/com/lgcns/kafka/message/MemberEnteredMessage.java
@@ -5,8 +5,6 @@ import com.lgcns.enums.MemberAge;
 import com.lgcns.enums.MemberGender;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
-import java.time.LocalDate;
-import java.time.LocalTime;
 
 public record MemberEnteredMessage(
         @NotNull(message = "팝업 ID는 필수입니다.") @Schema(description = "팝업 ID", example = "1")
@@ -17,15 +15,15 @@ public record MemberEnteredMessage(
                 MemberAge age,
         @NotNull(message = "예약 날짜는 필수입니다.")
                 @Schema(description = "팝업 예약 날짜", example = "2025-05-13")
-                LocalDate reservationDate,
+                String reservationDate,
         @NotNull(message = "예약 시간은 필수입니다.") @Schema(description = "팝업 예약 시간", example = "10:00:00")
-                LocalTime reservationTime) {
+                String reservationTime) {
     public static MemberEnteredMessage from(QrEntranceInfoRequest qrEntranceInfoRequest) {
         return new MemberEnteredMessage(
                 qrEntranceInfoRequest.popupId(),
                 qrEntranceInfoRequest.gender(),
                 qrEntranceInfoRequest.age(),
-                LocalDate.parse(qrEntranceInfoRequest.reservationDate()),
-                LocalTime.parse(qrEntranceInfoRequest.reservationTime()));
+                qrEntranceInfoRequest.reservationDate(),
+                qrEntranceInfoRequest.reservationTime());
     }
 }

--- a/popi-reservation-service/src/main/java/com/lgcns/kafka/message/MemberEnteredMessage.java
+++ b/popi-reservation-service/src/main/java/com/lgcns/kafka/message/MemberEnteredMessage.java
@@ -17,6 +17,7 @@ public record MemberEnteredMessage(
         @NotNull(message = "방문자 나이대는 필수입니다.") @Schema(description = "방문자 나이대", example = "20")
                 MemberAge age,
         @NotNull(message = "예약 날짜는 필수입니다.")
+                @Schema(description = "예약 날짜", example = "2023-10-01")
                 @JsonFormat(
                         shape = JsonFormat.Shape.STRING,
                         pattern = "yyyy-MM-dd",

--- a/popi-reservation-service/src/main/java/com/lgcns/kafka/message/MemberEnteredMessage.java
+++ b/popi-reservation-service/src/main/java/com/lgcns/kafka/message/MemberEnteredMessage.java
@@ -1,10 +1,13 @@
 package com.lgcns.kafka.message;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.lgcns.dto.request.QrEntranceInfoRequest;
 import com.lgcns.enums.MemberAge;
 import com.lgcns.enums.MemberGender;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
+import java.time.LocalDate;
+import java.time.LocalTime;
 
 public record MemberEnteredMessage(
         @NotNull(message = "팝업 ID는 필수입니다.") @Schema(description = "팝업 ID", example = "1")
@@ -14,10 +17,18 @@ public record MemberEnteredMessage(
         @NotNull(message = "방문자 나이대는 필수입니다.") @Schema(description = "방문자 나이대", example = "20")
                 MemberAge age,
         @NotNull(message = "예약 날짜는 필수입니다.")
-                @Schema(description = "팝업 예약 날짜", example = "2025-05-13")
-                String reservationDate,
-        @NotNull(message = "예약 시간은 필수입니다.") @Schema(description = "팝업 예약 시간", example = "10:00:00")
-                String reservationTime) {
+                @JsonFormat(
+                        shape = JsonFormat.Shape.STRING,
+                        pattern = "yyyy-MM-dd",
+                        timezone = "Asia/Seoul")
+                LocalDate reservationDate,
+        @NotNull(message = "예약 시간은 필수입니다.")
+                @Schema(description = "팝업 예약 시간", example = "10:00:00")
+                @JsonFormat(
+                        shape = JsonFormat.Shape.STRING,
+                        pattern = "HH:mm:ss",
+                        timezone = "Asia/Seoul")
+                LocalTime reservationTime) {
     public static MemberEnteredMessage from(QrEntranceInfoRequest qrEntranceInfoRequest) {
         return new MemberEnteredMessage(
                 qrEntranceInfoRequest.popupId(),

--- a/popi-reservation-service/src/main/java/com/lgcns/kafka/message/MemberEnteredMessage.java
+++ b/popi-reservation-service/src/main/java/com/lgcns/kafka/message/MemberEnteredMessage.java
@@ -1,0 +1,31 @@
+package com.lgcns.kafka.message;
+
+import com.lgcns.dto.request.QrEntranceInfoRequest;
+import com.lgcns.enums.MemberAge;
+import com.lgcns.enums.MemberGender;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+public record MemberEnteredMessage(
+        @NotNull(message = "팝업 ID는 필수입니다.") @Schema(description = "팝업 ID", example = "1")
+                Long popupId,
+        @NotNull(message = "방문자 성별은 필수입니다.") @Schema(description = "방문자 성별", example = "FEMALE")
+                MemberGender gender,
+        @NotNull(message = "방문자 나이대는 필수입니다.") @Schema(description = "방문자 나이대", example = "20")
+                MemberAge age,
+        @NotNull(message = "예약 날짜는 필수입니다.")
+                @Schema(description = "팝업 예약 날짜", example = "2025-05-13")
+                LocalDate reservationDate,
+        @NotNull(message = "예약 시간은 필수입니다.") @Schema(description = "팝업 예약 시간", example = "10:00:00")
+                LocalTime reservationTime) {
+    public static MemberEnteredMessage from(QrEntranceInfoRequest qrEntranceInfoRequest) {
+        return new MemberEnteredMessage(
+                qrEntranceInfoRequest.popupId(),
+                qrEntranceInfoRequest.gender(),
+                qrEntranceInfoRequest.age(),
+                LocalDate.parse(qrEntranceInfoRequest.reservationDate()),
+                LocalTime.parse(qrEntranceInfoRequest.reservationTime()));
+    }
+}

--- a/popi-reservation-service/src/main/java/com/lgcns/kafka/producer/MemberEnteredProducer.java
+++ b/popi-reservation-service/src/main/java/com/lgcns/kafka/producer/MemberEnteredProducer.java
@@ -1,0 +1,18 @@
+package com.lgcns.kafka.producer;
+
+import com.lgcns.kafka.message.MemberEnteredMessage;
+import lombok.RequiredArgsConstructor;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MemberEnteredProducer {
+
+    private static final String TOPIC = "member-entered-topic";
+    private final KafkaTemplate<String, MemberEnteredMessage> kafkaTemplate;
+
+    public void sendMessage(MemberEnteredMessage message) {
+        kafkaTemplate.send(TOPIC, message);
+    }
+}

--- a/popi-reservation-service/src/main/java/com/lgcns/kafka/producer/MemberEnteredProducer.java
+++ b/popi-reservation-service/src/main/java/com/lgcns/kafka/producer/MemberEnteredProducer.java
@@ -10,7 +10,7 @@ import org.springframework.stereotype.Service;
 public class MemberEnteredProducer {
 
     private static final String TOPIC = "member-entered-topic";
-    private final KafkaTemplate<String, MemberEnteredMessage> kafkaTemplate;
+    private final KafkaTemplate<String, Object> kafkaTemplate;
 
     public void sendMessage(MemberEnteredMessage message) {
         kafkaTemplate.send(TOPIC, message);

--- a/popi-reservation-service/src/main/java/com/lgcns/service/MemberReservationService.java
+++ b/popi-reservation-service/src/main/java/com/lgcns/service/MemberReservationService.java
@@ -29,6 +29,5 @@ public interface MemberReservationService {
 
     void createMemberAnswer(Long popupId, String memberId, List<SurveyChoiceRequest> surveyChoices);
 
-    void isReservationPossible(QrEntranceInfoRequest qrEntranceInfoRequest, Long popupId);
-
+    void isEnterancePossible(QrEntranceInfoRequest qrEntranceInfoRequest, Long popupId);
 }

--- a/popi-reservation-service/src/main/java/com/lgcns/service/MemberReservationService.java
+++ b/popi-reservation-service/src/main/java/com/lgcns/service/MemberReservationService.java
@@ -1,6 +1,7 @@
 package com.lgcns.service;
 
 import com.lgcns.dto.request.SurveyChoiceRequest;
+import com.lgcns.dto.request.QrEntranceInfoRequest;
 import com.lgcns.dto.response.AvailableDateResponse;
 import com.lgcns.dto.response.DailyMemberReservationCountResponse;
 import com.lgcns.dto.response.ReservationDetailResponse;
@@ -27,4 +28,7 @@ public interface MemberReservationService {
     DailyMemberReservationCountResponse findDailyMemberReservationCount(Long popupId);
 
     void createMemberAnswer(Long popupId, String memberId, List<SurveyChoiceRequest> surveyChoices);
+
+    void isReservationPossible(QrEntranceInfoRequest qrEntranceInfoRequest, Long popupId);
+
 }

--- a/popi-reservation-service/src/main/java/com/lgcns/service/MemberReservationService.java
+++ b/popi-reservation-service/src/main/java/com/lgcns/service/MemberReservationService.java
@@ -1,7 +1,7 @@
 package com.lgcns.service;
 
-import com.lgcns.dto.request.SurveyChoiceRequest;
 import com.lgcns.dto.request.QrEntranceInfoRequest;
+import com.lgcns.dto.request.SurveyChoiceRequest;
 import com.lgcns.dto.response.AvailableDateResponse;
 import com.lgcns.dto.response.DailyMemberReservationCountResponse;
 import com.lgcns.dto.response.ReservationDetailResponse;

--- a/popi-reservation-service/src/main/java/com/lgcns/service/MemberReservationServiceImpl.java
+++ b/popi-reservation-service/src/main/java/com/lgcns/service/MemberReservationServiceImpl.java
@@ -20,7 +20,6 @@ import com.lgcns.error.exception.CustomException;
 import com.lgcns.event.dto.MemberReservationUpdateEvent;
 import com.lgcns.exception.MemberReservationErrorCode;
 import com.lgcns.kafka.message.MemberEnteredMessage;
-import com.lgcns.kafka.producer.MemberEnteredProducer;
 import com.lgcns.repository.MemberReservationRepository;
 import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
 import io.github.resilience4j.retry.annotation.Retry;
@@ -53,7 +52,6 @@ public class MemberReservationServiceImpl implements MemberReservationService {
 
     private final ApplicationEventPublisher eventPublisher;
     private final RedisTemplate<String, Long> redisTemplate;
-    private final MemberEnteredProducer memberEnteredProducer;
 
     private static final int DEFAULT_SURVEY_COUNT = 4;
 
@@ -192,7 +190,7 @@ public class MemberReservationServiceImpl implements MemberReservationService {
         }
 
         memberReservation.updateIsEntered();
-        memberEnteredProducer.sendMessage(MemberEnteredMessage.from(qrEntranceInfoRequest));
+        eventPublisher.publishEvent(MemberEnteredMessage.from(qrEntranceInfoRequest));
     }
 
     @Override

--- a/popi-reservation-service/src/main/java/com/lgcns/service/MemberReservationServiceImpl.java
+++ b/popi-reservation-service/src/main/java/com/lgcns/service/MemberReservationServiceImpl.java
@@ -19,6 +19,8 @@ import com.lgcns.dto.response.*;
 import com.lgcns.error.exception.CustomException;
 import com.lgcns.event.dto.MemberReservationUpdateEvent;
 import com.lgcns.exception.MemberReservationErrorCode;
+import com.lgcns.kafka.message.MemberEnteredMessage;
+import com.lgcns.kafka.producer.MemberEnteredProducer;
 import com.lgcns.repository.MemberReservationRepository;
 import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
 import io.github.resilience4j.retry.annotation.Retry;
@@ -48,9 +50,10 @@ public class MemberReservationServiceImpl implements MemberReservationService {
 
     private final ManagerServiceClient managerServiceClient;
     private final MemberServiceClient memberServiceClient;
-
+    ;
     private final ApplicationEventPublisher eventPublisher;
     private final RedisTemplate<String, Long> redisTemplate;
+    private final MemberEnteredProducer memberEnteredProducer;
 
     private static final int DEFAULT_SURVEY_COUNT = 4;
 
@@ -189,6 +192,7 @@ public class MemberReservationServiceImpl implements MemberReservationService {
         }
 
         memberReservation.updateIsEntered();
+        memberEnteredProducer.sendMessage(MemberEnteredMessage.from(qrEntranceInfoRequest));
     }
 
     @Override

--- a/popi-reservation-service/src/main/java/com/lgcns/service/MemberReservationServiceImpl.java
+++ b/popi-reservation-service/src/main/java/com/lgcns/service/MemberReservationServiceImpl.java
@@ -50,7 +50,7 @@ public class MemberReservationServiceImpl implements MemberReservationService {
 
     private final ManagerServiceClient managerServiceClient;
     private final MemberServiceClient memberServiceClient;
-    ;
+
     private final ApplicationEventPublisher eventPublisher;
     private final RedisTemplate<String, Long> redisTemplate;
     private final MemberEnteredProducer memberEnteredProducer;
@@ -158,7 +158,7 @@ public class MemberReservationServiceImpl implements MemberReservationService {
     }
 
     @Override
-    public void isReservationPossible(QrEntranceInfoRequest qrEntranceInfoRequest, Long popupId) {
+    public void isEnterancePossible(QrEntranceInfoRequest qrEntranceInfoRequest, Long popupId) {
         LocalDate currentDate = LocalDate.now();
         LocalTime currentTime = LocalTime.now();
 

--- a/popi-reservation-service/src/main/java/com/lgcns/service/MemberReservationServiceImpl.java
+++ b/popi-reservation-service/src/main/java/com/lgcns/service/MemberReservationServiceImpl.java
@@ -13,8 +13,8 @@ import com.lgcns.client.managerClient.dto.request.PopupIdsRequest;
 import com.lgcns.client.managerClient.dto.response.*;
 import com.lgcns.client.memberClient.MemberServiceClient;
 import com.lgcns.domain.MemberReservation;
-import com.lgcns.dto.request.SurveyChoiceRequest;
 import com.lgcns.dto.request.QrEntranceInfoRequest;
+import com.lgcns.dto.request.SurveyChoiceRequest;
 import com.lgcns.dto.response.*;
 import com.lgcns.error.exception.CustomException;
 import com.lgcns.event.dto.MemberReservationUpdateEvent;
@@ -185,8 +185,12 @@ public class MemberReservationServiceImpl implements MemberReservationService {
             throw new CustomException(MemberReservationErrorCode.RESERVATION_DATE_MISMATCH);
         }
 
+        if (currentTime.isBefore(memberReservation.getReservationTime())) {
+            throw new CustomException(MemberReservationErrorCode.RESERVATION_TIME_MISMATCH);
+        }
+
         if (currentTime.isAfter(memberReservation.getReservationTime().plusMinutes(31))) {
-            throw new CustomException(MemberReservationErrorCode.RESERVATION_TIME_PASSED);
+            throw new CustomException(MemberReservationErrorCode.RESERVATION_TIME_MISMATCH);
         }
 
         memberReservation.updateIsEntered();

--- a/popi-reservation-service/src/main/resources/application-local.yml
+++ b/popi-reservation-service/src/main/resources/application-local.yml
@@ -31,6 +31,8 @@ spring:
     enabled: true
     baseline-on-migrate: true
     locations: classpath:db/migration
+  kafka:
+    bootstrap-servers: localhost:9092
 
 eureka:
   instance:

--- a/popi-reservation-service/src/main/resources/application-local.yml
+++ b/popi-reservation-service/src/main/resources/application-local.yml
@@ -32,7 +32,7 @@ spring:
     baseline-on-migrate: true
     locations: classpath:db/migration
   kafka:
-    bootstrap-servers: localhost:9092
+    bootstrap-servers: localhost:29092
 
 eureka:
   instance:

--- a/popi-reservation-service/src/test/java/com/lgcns/kafka/EmbeddedKafkaIntegrationTest.java
+++ b/popi-reservation-service/src/test/java/com/lgcns/kafka/EmbeddedKafkaIntegrationTest.java
@@ -41,8 +41,8 @@ public class EmbeddedKafkaIntegrationTest {
                         1L,
                         MemberAge.TWENTIES,
                         MemberGender.MALE,
-                        LocalDate.now().toString(),
-                        LocalTime.now().toString());
+                        LocalDate.now(),
+                        LocalTime.now());
 
         MemberEnteredMessage memberEnteredMessage =
                 MemberEnteredMessage.from(qrEntranceInfoRequest);

--- a/popi-reservation-service/src/test/java/com/lgcns/kafka/EmbeddedKafkaIntegrationTest.java
+++ b/popi-reservation-service/src/test/java/com/lgcns/kafka/EmbeddedKafkaIntegrationTest.java
@@ -7,6 +7,7 @@ import com.lgcns.kafka.message.MemberEnteredMessage;
 import com.lgcns.kafka.producer.MemberEnteredProducer;
 import java.time.LocalDate;
 import java.time.LocalTime;
+import java.time.temporal.ChronoUnit;
 import java.util.Collections;
 import java.util.Map;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
@@ -42,7 +43,7 @@ public class EmbeddedKafkaIntegrationTest {
                         MemberAge.TWENTIES,
                         MemberGender.MALE,
                         LocalDate.now(),
-                        LocalTime.now());
+                        LocalTime.now().truncatedTo(ChronoUnit.SECONDS));
 
         MemberEnteredMessage memberEnteredMessage =
                 MemberEnteredMessage.from(qrEntranceInfoRequest);

--- a/popi-reservation-service/src/test/java/com/lgcns/kafka/EmbeddedKafkaIntegrationTest.java
+++ b/popi-reservation-service/src/test/java/com/lgcns/kafka/EmbeddedKafkaIntegrationTest.java
@@ -1,0 +1,86 @@
+package com.lgcns.kafka;
+
+import com.lgcns.dto.request.QrEntranceInfoRequest;
+import com.lgcns.enums.MemberAge;
+import com.lgcns.enums.MemberGender;
+import com.lgcns.kafka.message.MemberEnteredMessage;
+import com.lgcns.kafka.producer.MemberEnteredProducer;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.Collections;
+import java.util.Map;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.kafka.support.serializer.JsonDeserializer;
+import org.springframework.kafka.test.EmbeddedKafkaBroker;
+import org.springframework.kafka.test.context.EmbeddedKafka;
+import org.springframework.kafka.test.utils.KafkaTestUtils;
+import org.springframework.test.context.ActiveProfiles;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@EmbeddedKafka(partitions = 1, topics = "member-entered-topic")
+public class EmbeddedKafkaIntegrationTest {
+
+    @Autowired private EmbeddedKafkaBroker embeddedKafkaBroker;
+
+    @Autowired private MemberEnteredProducer memberEnteredProducer;
+
+    @Test
+    void 방문자_입장_메세지를_카프카에_전송한다() {
+        // given
+        QrEntranceInfoRequest qrEntranceInfoRequest =
+                new QrEntranceInfoRequest(
+                        1L,
+                        1L,
+                        1L,
+                        MemberAge.TWENTIES,
+                        MemberGender.MALE,
+                        LocalDate.now().toString(),
+                        LocalTime.now().toString());
+
+        MemberEnteredMessage memberEnteredMessage =
+                MemberEnteredMessage.from(qrEntranceInfoRequest);
+
+        // when
+        memberEnteredProducer.sendMessage(memberEnteredMessage);
+
+        // then
+        Map<String, Object> consumerProps =
+                KafkaTestUtils.consumerProps("testGroup", "true", embeddedKafkaBroker);
+        consumerProps.put(JsonDeserializer.TRUSTED_PACKAGES, "com.lgcns.kafka.message");
+
+        try (KafkaConsumer<String, MemberEnteredMessage> consumer =
+                new KafkaConsumer<>(
+                        consumerProps,
+                        new StringDeserializer(),
+                        new JsonDeserializer<>(MemberEnteredMessage.class))) {
+            consumer.subscribe(Collections.singletonList("member-entered-topic"));
+
+            ConsumerRecord<String, MemberEnteredMessage> record =
+                    KafkaTestUtils.getSingleRecord(consumer, "member-entered-topic");
+
+            MemberEnteredMessage received = record.value();
+
+            Assertions.assertAll(
+                    () ->
+                            Assertions.assertEquals(
+                                    memberEnteredMessage.popupId(), received.popupId()),
+                    () -> Assertions.assertEquals(memberEnteredMessage.gender(), received.gender()),
+                    () -> Assertions.assertEquals(memberEnteredMessage.age(), received.age()),
+                    () ->
+                            Assertions.assertEquals(
+                                    memberEnteredMessage.reservationDate(),
+                                    received.reservationDate()),
+                    () ->
+                            Assertions.assertEquals(
+                                    memberEnteredMessage.reservationTime(),
+                                    received.reservationTime()));
+        }
+    }
+}

--- a/popi-reservation-service/src/test/java/com/lgcns/service/MemberReservationServiceTest.java
+++ b/popi-reservation-service/src/test/java/com/lgcns/service/MemberReservationServiceTest.java
@@ -12,8 +12,8 @@ import com.lgcns.WireMockIntegrationTest;
 import com.lgcns.client.managerClient.dto.request.PopupIdsRequest;
 import com.lgcns.domain.MemberReservation;
 import com.lgcns.domain.MemberReservationStatus;
-import com.lgcns.dto.request.SurveyChoiceRequest;
 import com.lgcns.dto.request.QrEntranceInfoRequest;
+import com.lgcns.dto.request.SurveyChoiceRequest;
 import com.lgcns.dto.response.*;
 import com.lgcns.enums.MemberAge;
 import com.lgcns.enums.MemberGender;
@@ -437,7 +437,7 @@ class MemberReservationServiceTest extends WireMockIntegrationTest {
     @Nested
     class 설문지_등록_할_때 {
         @Test
-        void 설문지_응답이_정상적으로_저장된다() throws JsonProcessingException {
+        void 설문지_응답이_정상적으로_저장된다() {
             // given
             List<SurveyChoiceRequest> surveyChoices =
                     List.of(
@@ -477,7 +477,7 @@ class MemberReservationServiceTest extends WireMockIntegrationTest {
     class 회원이_예약_생성_할_때 {
 
         @Test
-        void 예약이_존재하고_예약_가능한_상태이면_예약에_성공한다() throws JsonProcessingException {
+        void 예약이_존재하고_예약_가능한_상태이면_예약에_성공한다() {
             // given
             redisTemplate.opsForValue().set(reservationId.toString(), "10");
 
@@ -502,7 +502,7 @@ class MemberReservationServiceTest extends WireMockIntegrationTest {
         }
 
         @Test
-        void 이미_예약한_사용자는_예외가_발생한다() throws JsonProcessingException {
+        void 이미_예약한_사용자는_예외가_발생한다() {
             // given
             redisTemplate.opsForValue().set(reservationId.toString(), "10");
 
@@ -523,7 +523,7 @@ class MemberReservationServiceTest extends WireMockIntegrationTest {
         }
 
         @Test
-        void 예약가능수량이_없으면_예약에_실패하고_Redis_복구가_일어난다() throws JsonProcessingException {
+        void 예약가능수량이_없으면_예약에_실패하고_Redis_복구가_일어난다() {
             // given
             Long reservationId = 1L;
             redisTemplate.opsForValue().set(reservationId.toString(), "0");
@@ -589,7 +589,8 @@ class MemberReservationServiceTest extends WireMockIntegrationTest {
 
             // then
             MemberReservation updatedMemberReservation =
-                    memberReservationRepository.findById(memberReservation.getId()).get();
+                    findMemberReservationById(memberReservation.getId());
+
             Assertions.assertAll(
                     () ->
                             assertThat(updatedMemberReservation.getStatus())
@@ -720,7 +721,7 @@ class MemberReservationServiceTest extends WireMockIntegrationTest {
     class 회원의_예약이_취소될_때 {
 
         @Test
-        void 예약이_존재하면_예약을_취소한다() throws JsonProcessingException {
+        void 예약이_존재하면_예약을_취소한다() {
             // given
             redisTemplate.opsForValue().set(reservationId.toString(), "10");
             MemberReservation memberReservation =
@@ -1053,7 +1054,7 @@ class MemberReservationServiceTest extends WireMockIntegrationTest {
     class 회원이_팝업_입장할_때 {
 
         @Test
-        void 회원이_팝업_입장에_성공한다() throws JsonProcessingException {
+        void 회원이_팝업_입장에_성공한다() {
             // given
             Long memberReservationId =
                     createMemberReservation(
@@ -1063,15 +1064,15 @@ class MemberReservationServiceTest extends WireMockIntegrationTest {
                             memberReservationId,
                             reservationId,
                             popupId,
-                            LocalDate.now().toString(),
-                            LocalTime.now().toString());
+                            LocalDate.now(),
+                            LocalTime.now());
 
             // when
             memberReservationService.isEnterancePossible(request, popupId);
 
             // then
-            MemberReservation memberReservation =
-                    memberReservationRepository.findById(memberReservationId).get();
+            MemberReservation memberReservation = findMemberReservationById(memberReservationId);
+
             Assertions.assertAll(
                     () -> assertThat(memberReservation.getIsEntered()).isEqualTo(true));
         }
@@ -1085,8 +1086,8 @@ class MemberReservationServiceTest extends WireMockIntegrationTest {
                             invalidMemberReservationId,
                             reservationId,
                             popupId,
-                            LocalDate.now().toString(),
-                            LocalTime.now().toString());
+                            LocalDate.now(),
+                            LocalTime.now());
 
             // when & then
             assertThatThrownBy(() -> memberReservationService.isEnterancePossible(request, popupId))
@@ -1106,8 +1107,8 @@ class MemberReservationServiceTest extends WireMockIntegrationTest {
                             memberReservationId,
                             reservationId,
                             popupId,
-                            LocalDate.now().toString(),
-                            LocalTime.now().toString());
+                            LocalDate.now(),
+                            LocalTime.now());
 
             // when & then
             memberReservationService.isEnterancePossible(request, popupId);
@@ -1128,8 +1129,8 @@ class MemberReservationServiceTest extends WireMockIntegrationTest {
                             memberReservationId,
                             reservationId,
                             popupId,
-                            LocalDate.now().toString(),
-                            LocalTime.now().toString());
+                            LocalDate.now(),
+                            LocalTime.now());
             Long differentPopupId = -1L;
 
             // when & then
@@ -1155,8 +1156,8 @@ class MemberReservationServiceTest extends WireMockIntegrationTest {
                             popupId,
                             MemberAge.TWENTIES,
                             MemberGender.MALE,
-                            LocalDate.now().toString(),
-                            LocalTime.now().toString());
+                            LocalDate.now(),
+                            LocalTime.now());
 
             // when & then
             assertThatThrownBy(
@@ -1178,8 +1179,8 @@ class MemberReservationServiceTest extends WireMockIntegrationTest {
                             memberReservationId,
                             reservationId,
                             popupId,
-                            (LocalDate.now().minusDays(1)).toString(),
-                            LocalTime.now().toString());
+                            (LocalDate.now().minusDays(1)),
+                            LocalTime.now());
 
             // when & then
             assertThatThrownBy(() -> memberReservationService.isEnterancePossible(request, popupId))
@@ -1202,8 +1203,8 @@ class MemberReservationServiceTest extends WireMockIntegrationTest {
                             memberReservationId,
                             reservationId,
                             popupId,
-                            LocalDate.now().toString(),
-                            (LocalTime.now().minusMinutes(31)).toString());
+                            LocalDate.now(),
+                            (LocalTime.now().minusMinutes(31)));
 
             // when & then
             assertThatThrownBy(() -> memberReservationService.isEnterancePossible(request, popupId))
@@ -1226,15 +1227,14 @@ class MemberReservationServiceTest extends WireMockIntegrationTest {
                             memberReservationId,
                             reservationId,
                             popupId,
-                            LocalDate.now().toString(),
-                            (LocalTime.now().plusMinutes(10)).toString());
+                            LocalDate.now(),
+                            (LocalTime.now().plusMinutes(10)));
 
             // when
             memberReservationService.isEnterancePossible(request, popupId);
 
             // then
-            MemberReservation memberReservation =
-                    memberReservationRepository.findById(memberReservationId).get();
+            MemberReservation memberReservation = findMemberReservationById(memberReservationId);
             Assertions.assertAll(
                     () -> assertThat(memberReservation.getIsEntered()).isEqualTo(true));
         }
@@ -1389,22 +1389,22 @@ class MemberReservationServiceTest extends WireMockIntegrationTest {
     }
 
     private void assertSurveyChoice(
-            SurveyChoiceResponse response, Long expectedSurveyId, Long startingChoiceId){
-                assertThat(response.surveyId()).isEqualTo(expectedSurveyId);
-                List<SurveyOption> options = response.options();
-                assertThat(options).hasSize(5);
+            SurveyChoiceResponse response, Long expectedSurveyId, Long startingChoiceId) {
+        assertThat(response.surveyId()).isEqualTo(expectedSurveyId);
+        List<SurveyOption> options = response.options();
+        assertThat(options).hasSize(5);
 
-                for (int i = 0; i < options.size(); i++) {
-                    SurveyOption option = options.get(i);
-                    Long expectedChoiceId = startingChoiceId + i;
-                    String expectedContent = "보기" + (i + 1);
+        for (int i = 0; i < options.size(); i++) {
+            SurveyOption option = options.get(i);
+            Long expectedChoiceId = startingChoiceId + i;
+            String expectedContent = "보기" + (i + 1);
 
-                    assertThat(option.choiceId()).isEqualTo(expectedChoiceId);
-                    assertThat(option.content()).isEqualTo(expectedContent);
-                    assertThat(option.choiceId()).isGreaterThan(0L);
-                    assertThat(option.content()).isNotBlank();
-                }
-            }
+            assertThat(option.choiceId()).isEqualTo(expectedChoiceId);
+            assertThat(option.content()).isEqualTo(expectedContent);
+            assertThat(option.choiceId()).isGreaterThan(0L);
+            assertThat(option.content()).isNotBlank();
+        }
+    }
 
     private Long createMemberReservation(
             Long reservationId,
@@ -1424,12 +1424,21 @@ class MemberReservationServiceTest extends WireMockIntegrationTest {
         return memberReservation.getId();
     }
 
+    private MemberReservation findMemberReservationById(Long memberReservationId) {
+        return memberReservationRepository
+                .findById(memberReservationId)
+                .orElseThrow(
+                        () ->
+                                new CustomException(
+                                        MemberReservationErrorCode.MEMBER_RESERVATION_NOT_FOUND));
+    }
+
     private QrEntranceInfoRequest createQrEntranceInfoRequest(
             Long memberReservationId,
             Long reservationId,
             Long popupId,
-            String reservationDate,
-            String reservationTime) {
+            LocalDate reservationDate,
+            LocalTime reservationTime) {
         return new QrEntranceInfoRequest(
                 memberReservationId,
                 reservationId,

--- a/popi-reservation-service/src/test/java/com/lgcns/service/MemberReservationServiceTest.java
+++ b/popi-reservation-service/src/test/java/com/lgcns/service/MemberReservationServiceTest.java
@@ -1190,6 +1190,30 @@ class MemberReservationServiceTest extends WireMockIntegrationTest {
         }
 
         @Test
+        void 예약한_시간이_현재_시각_이후면_예외가_발생한다() {
+            // given
+            Long memberReservationId =
+                    createMemberReservation(
+                            reservationId,
+                            popupId,
+                            LocalDate.now(),
+                            LocalTime.now().plusMinutes(10));
+            QrEntranceInfoRequest request =
+                    createQrEntranceInfoRequest(
+                            memberReservationId,
+                            reservationId,
+                            popupId,
+                            LocalDate.now(),
+                            (LocalTime.now().plusMinutes(10)));
+
+            // when & then
+            assertThatThrownBy(() -> memberReservationService.isEnterancePossible(request, popupId))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessageContaining(
+                            MemberReservationErrorCode.RESERVATION_TIME_MISMATCH.getMessage());
+        }
+
+        @Test
         void 현재_시간이_예약시간_30분_이후면_예외가_발생한다() {
             // given
             Long memberReservationId =
@@ -1221,14 +1245,14 @@ class MemberReservationServiceTest extends WireMockIntegrationTest {
                             reservationId,
                             popupId,
                             LocalDate.now(),
-                            LocalTime.now().plusMinutes(10));
+                            LocalTime.now().minusMinutes(30));
             QrEntranceInfoRequest request =
                     createQrEntranceInfoRequest(
                             memberReservationId,
                             reservationId,
                             popupId,
                             LocalDate.now(),
-                            (LocalTime.now().plusMinutes(10)));
+                            LocalTime.now().minusMinutes((30)));
 
             // when
             memberReservationService.isEnterancePossible(request, popupId);

--- a/popi-reservation-service/src/test/java/com/lgcns/service/MemberReservationServiceTest.java
+++ b/popi-reservation-service/src/test/java/com/lgcns/service/MemberReservationServiceTest.java
@@ -1210,7 +1210,7 @@ class MemberReservationServiceTest extends WireMockIntegrationTest {
             assertThatThrownBy(() -> memberReservationService.isEnterancePossible(request, popupId))
                     .isInstanceOf(CustomException.class)
                     .hasMessageContaining(
-                            MemberReservationErrorCode.RESERVATION_TIME_PASSED.getMessage());
+                            MemberReservationErrorCode.RESERVATION_TIME_MISMATCH.getMessage());
         }
 
         @Test

--- a/popi-reservation-service/src/test/resources/application-test.yml
+++ b/popi-reservation-service/src/test/resources/application-test.yml
@@ -13,7 +13,7 @@ spring:
   flyway:
     enabled: false
   kafka:
-    bootstrap-servers: localhost:29092
+    bootstrap-servers: localhost:9092
 
 manager:
   service:

--- a/popi-reservation-service/src/test/resources/application-test.yml
+++ b/popi-reservation-service/src/test/resources/application-test.yml
@@ -12,6 +12,8 @@ spring:
       database: 1
   flyway:
     enabled: false
+  kafka:
+    bootstrap-servers: localhost:29092
 
 manager:
   service:


### PR DESCRIPTION
## 🌱 관련 이슈

- [LCR-244]

---
## 📌 작업 내용 및 특이사항

- 회원 입장할때 QR을 검증하는 API 구현했습니다.
    - 입장가능한 상태면 카프카 메세지 발행 이벤트를 발생시킵니다.
    - 이 이벤트를 감지하면 kafka로 메세지를 발행합니다.


[LCR-244]: https://lgcns-retail.atlassian.net/browse/LCR-244?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ