### PR TITLE
feat: 상품별 고유 구매자 수 조회 Internal API 구현

### DIFF
--- a/popi-api-gateway/src/main/resources/application-local.yml
+++ b/popi-api-gateway/src/main/resources/application-local.yml
@@ -144,7 +144,15 @@ spring:
           filters:
             - RemoveRequestHeader=Cookie
             - RewritePath=/payments/(?<segment>.*), /$\{segment}
-        - id: payment-service
+        - id: payment-internal
+          uri: lb://PAYMENTS
+          predicates:
+            - Path=/payments/internal/**
+            - Method=GET
+          filters:
+            - RemoveRequestHeader=Cookie
+            - RewritePath=/payments/(?<segment>.*), /$\{segment}
+        - id: payment-external
           uri: lb://PAYMENTS
           predicates:
             - Path=/payments/**

--- a/popi-payment-service/build.gradle
+++ b/popi-payment-service/build.gradle
@@ -43,4 +43,10 @@ dependencies {
     // Kafka
     implementation 'org.springframework.kafka:spring-kafka'
     testImplementation 'org.springframework.kafka:spring-kafka-test'
+
+    // QueryDSL
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 }

--- a/popi-payment-service/src/main/java/com/lgcns/config/QueryDslConfig.java
+++ b/popi-payment-service/src/main/java/com/lgcns/config/QueryDslConfig.java
@@ -1,0 +1,18 @@
+package com.lgcns.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QueryDslConfig {
+
+    @PersistenceContext private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/popi-payment-service/src/main/java/com/lgcns/dto/response/ItemBuyerCountResponse.java
+++ b/popi-payment-service/src/main/java/com/lgcns/dto/response/ItemBuyerCountResponse.java
@@ -1,0 +1,7 @@
+package com.lgcns.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record ItemBuyerCountResponse(
+        @Schema(description = "상품 ID", example = "1") Long itemId,
+        @Schema(description = "구매자 수", example = "42") long buyerCount) {}

--- a/popi-payment-service/src/main/java/com/lgcns/inernalApi/PaymentInternalController.java
+++ b/popi-payment-service/src/main/java/com/lgcns/inernalApi/PaymentInternalController.java
@@ -2,6 +2,7 @@ package com.lgcns.inernalApi;
 
 import com.lgcns.dto.response.ItemBuyerCountResponse;
 import com.lgcns.service.PaymentService;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -19,6 +20,7 @@ public class PaymentInternalController {
     private final PaymentService paymentService;
 
     @GetMapping("/{popupId}/buyer-counts")
+    @Operation(summary = "상품별 구매자 수 조회", description = "해당 팝업에서 상품별로 중복되지 않는 구매자 수를 조회합니다.")
     public List<ItemBuyerCountResponse> countItemBuyerByPopupId(
             @PathVariable(name = "popupId") Long popupId) {
         return paymentService.countItemBuyerByPopupId(popupId);

--- a/popi-payment-service/src/main/java/com/lgcns/inernalApi/PaymentInternalController.java
+++ b/popi-payment-service/src/main/java/com/lgcns/inernalApi/PaymentInternalController.java
@@ -1,0 +1,26 @@
+package com.lgcns.inernalApi;
+
+import com.lgcns.dto.response.ItemBuyerCountResponse;
+import com.lgcns.service.PaymentService;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/internal")
+@RequiredArgsConstructor
+@Tag(name = "결제 서버 Internal API", description = "결제 서버 Internal API입니다.")
+public class PaymentInternalController {
+
+    private final PaymentService paymentService;
+
+    @GetMapping("/{popupId}/buyer-counts")
+    public List<ItemBuyerCountResponse> countItemBuyerByPopupId(
+            @PathVariable(name = "popupId") Long popupId) {
+        return paymentService.countItemBuyerByPopupId(popupId);
+    }
+}

--- a/popi-payment-service/src/main/java/com/lgcns/repository/PaymentRepository.java
+++ b/popi-payment-service/src/main/java/com/lgcns/repository/PaymentRepository.java
@@ -4,6 +4,6 @@ import com.lgcns.domain.Payment;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface PaymentRepository extends JpaRepository<Payment, Long> {
+public interface PaymentRepository extends JpaRepository<Payment, Long>, PaymentRepositoryCustom {
     Optional<Payment> findByMerchantUid(String merchantUid);
 }

--- a/popi-payment-service/src/main/java/com/lgcns/repository/PaymentRepositoryCustom.java
+++ b/popi-payment-service/src/main/java/com/lgcns/repository/PaymentRepositoryCustom.java
@@ -1,0 +1,8 @@
+package com.lgcns.repository;
+
+import com.lgcns.dto.response.ItemBuyerCountResponse;
+import java.util.List;
+
+public interface PaymentRepositoryCustom {
+    List<ItemBuyerCountResponse> countItemBuyerByPopupId(Long popupId);
+}

--- a/popi-payment-service/src/main/java/com/lgcns/repository/PaymentRepositoryImpl.java
+++ b/popi-payment-service/src/main/java/com/lgcns/repository/PaymentRepositoryImpl.java
@@ -1,0 +1,34 @@
+package com.lgcns.repository;
+
+import static com.lgcns.domain.QPayment.payment;
+import static com.lgcns.domain.QPaymentItem.paymentItem;
+
+import com.lgcns.domain.PaymentStatus;
+import com.lgcns.dto.response.ItemBuyerCountResponse;
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class PaymentRepositoryImpl implements PaymentRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<ItemBuyerCountResponse> countItemBuyerByPopupId(Long popupId) {
+        return queryFactory
+                .select(
+                        Projections.constructor(
+                                ItemBuyerCountResponse.class,
+                                paymentItem.itemId,
+                                payment.memberId.countDistinct()))
+                .from(paymentItem)
+                .join(paymentItem.payment, payment)
+                .where(payment.popupId.eq(popupId), payment.status.eq(PaymentStatus.PAID))
+                .groupBy(paymentItem.itemId)
+                .fetch();
+    }
+}

--- a/popi-payment-service/src/main/java/com/lgcns/service/PaymentService.java
+++ b/popi-payment-service/src/main/java/com/lgcns/service/PaymentService.java
@@ -1,12 +1,16 @@
 package com.lgcns.service;
 
 import com.lgcns.dto.request.PaymentReadyRequest;
+import com.lgcns.dto.response.ItemBuyerCountResponse;
 import com.lgcns.dto.response.PaymentReadyResponse;
 import com.siot.IamportRestClient.exception.IamportResponseException;
 import java.io.IOException;
+import java.util.List;
 
 public interface PaymentService {
     PaymentReadyResponse preparePayment(String memberId, PaymentReadyRequest request);
 
     void findPaymentByImpUid(String impUid) throws IamportResponseException, IOException;
+
+    List<ItemBuyerCountResponse> countItemBuyerByPopupId(Long popupId);
 }

--- a/popi-payment-service/src/main/java/com/lgcns/service/PaymentServiceImpl.java
+++ b/popi-payment-service/src/main/java/com/lgcns/service/PaymentServiceImpl.java
@@ -8,6 +8,7 @@ import com.lgcns.domain.Payment;
 import com.lgcns.domain.PaymentItem;
 import com.lgcns.domain.PaymentStatus;
 import com.lgcns.dto.request.PaymentReadyRequest;
+import com.lgcns.dto.response.ItemBuyerCountResponse;
 import com.lgcns.dto.response.PaymentReadyResponse;
 import com.lgcns.error.exception.CustomException;
 import com.lgcns.exception.PaymentErrorCode;
@@ -132,5 +133,11 @@ public class PaymentServiceImpl implements PaymentService {
                     "Iamport API 오류: status={}, message={}", e.getHttpStatusCode(), e.getMessage());
             throw e;
         }
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<ItemBuyerCountResponse> countItemBuyerByPopupId(Long popupId) {
+        return paymentRepository.countItemBuyerByPopupId(popupId);
     }
 }


### PR DESCRIPTION
## 🌱 관련 이슈

- [LCR-290]

---
## 📌 작업 내용 및 특이사항

- 관리자 서비스에서 상품별 구매 전환율 계산을 위해 상품별 고유 구매자 수를 조회하는 Internal API를 구현했습니다.
- Payment와 PaymentItem을 기준으로 itemId별로 중복되지 않는 memberId 수를 계산하여 응답하도록 처리했습니다.
- QueryDSL을 활용해 groupBy(itemId)와 countDistinct(memberId)로 로직을 구현했습니다.
 
---
## 📚 참고사항

- A 회원이 itemId 1번을 2번 결제하고 B 회원이 itemId 1번을 1번 결제했다면 itemId 1번의 구매자 수는 2명입니다.

[LCR-290]: https://lgcns-retail.atlassian.net/browse/LCR-290?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ