### PR TITLE
feat: 1인 평균 구매액 조회 Internal API 구현

### DIFF
--- a/popi-payment-service/src/main/java/com/lgcns/domain/Payment.java
+++ b/popi-payment-service/src/main/java/com/lgcns/domain/Payment.java
@@ -55,10 +55,9 @@ public class Payment extends BaseTimeEntity {
                 .build();
     }
 
-    public void updatePayment(String impUid, String pgProvider, int amount, PaymentStatus status) {
+    public void updatePayment(String impUid, String pgProvider, PaymentStatus status) {
         this.impUid = impUid;
         this.pgProvider = pgProvider;
-        this.amount = amount;
         this.status = status;
     }
 

--- a/popi-payment-service/src/main/java/com/lgcns/domain/Payment.java
+++ b/popi-payment-service/src/main/java/com/lgcns/domain/Payment.java
@@ -2,6 +2,7 @@ package com.lgcns.domain;
 
 import com.lgcns.entity.BaseTimeEntity;
 import jakarta.persistence.*;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.AccessLevel;
@@ -34,6 +35,8 @@ public class Payment extends BaseTimeEntity {
     @Enumerated(EnumType.STRING)
     private PaymentStatus status;
 
+    private LocalDateTime paidAt;
+
     @Builder(access = AccessLevel.PRIVATE)
     private Payment(
             Long memberId, String merchantUid, int amount, Long popupId, PaymentStatus status) {
@@ -55,10 +58,12 @@ public class Payment extends BaseTimeEntity {
                 .build();
     }
 
-    public void updatePayment(String impUid, String pgProvider, PaymentStatus status) {
+    public void updatePayment(
+            String impUid, String pgProvider, PaymentStatus status, LocalDateTime paidAt) {
         this.impUid = impUid;
         this.pgProvider = pgProvider;
         this.status = status;
+        this.paidAt = paidAt;
     }
 
     public void addPaymentItem(PaymentItem item) {

--- a/popi-payment-service/src/main/java/com/lgcns/dto/response/AverageAmountResponse.java
+++ b/popi-payment-service/src/main/java/com/lgcns/dto/response/AverageAmountResponse.java
@@ -1,0 +1,11 @@
+package com.lgcns.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record AverageAmountResponse(
+        @Schema(description = "전체 기간 1인 평균 구매액", example = "30000") Integer totalAverageAmount,
+        @Schema(description = "오늘 1인 평균 구매액", example = "5000") Integer todayAverageAmount) {
+    public static AverageAmountResponse of(Integer totalAverageAmount, Integer todayAverageAmount) {
+        return new AverageAmountResponse(totalAverageAmount, todayAverageAmount);
+    }
+}

--- a/popi-payment-service/src/main/java/com/lgcns/inernalApi/PaymentInternalController.java
+++ b/popi-payment-service/src/main/java/com/lgcns/inernalApi/PaymentInternalController.java
@@ -1,5 +1,6 @@
 package com.lgcns.inernalApi;
 
+import com.lgcns.dto.response.AverageAmountResponse;
 import com.lgcns.dto.response.ItemBuyerCountResponse;
 import com.lgcns.service.PaymentService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -21,8 +22,13 @@ public class PaymentInternalController {
 
     @GetMapping("/{popupId}/buyer-counts")
     @Operation(summary = "상품별 구매자 수 조회", description = "해당 팝업에서 상품별로 중복되지 않는 구매자 수를 조회합니다.")
-    public List<ItemBuyerCountResponse> countItemBuyerByPopupId(
-            @PathVariable(name = "popupId") Long popupId) {
+    public List<ItemBuyerCountResponse> countItemBuyerByPopupId(@PathVariable Long popupId) {
         return paymentService.countItemBuyerByPopupId(popupId);
+    }
+
+    @GetMapping("/{popupId}/average-purchase")
+    @Operation(summary = "1인당 평균 구매액 조회", description = "팝업의 총 평균 구매액과 오늘의 평균 구매액을 조회합니다.")
+    public AverageAmountResponse averageAmountFind(@PathVariable Long popupId) {
+        return paymentService.findAverageAmount(popupId);
     }
 }

--- a/popi-payment-service/src/main/java/com/lgcns/repository/PaymentRepositoryCustom.java
+++ b/popi-payment-service/src/main/java/com/lgcns/repository/PaymentRepositoryCustom.java
@@ -1,8 +1,11 @@
 package com.lgcns.repository;
 
+import com.lgcns.dto.response.AverageAmountResponse;
 import com.lgcns.dto.response.ItemBuyerCountResponse;
 import java.util.List;
 
 public interface PaymentRepositoryCustom {
     List<ItemBuyerCountResponse> countItemBuyerByPopupId(Long popupId);
+
+    AverageAmountResponse findAverageAmountByPopupId(Long popupId);
 }

--- a/popi-payment-service/src/main/java/com/lgcns/repository/PaymentRepositoryImpl.java
+++ b/popi-payment-service/src/main/java/com/lgcns/repository/PaymentRepositoryImpl.java
@@ -4,9 +4,11 @@ import static com.lgcns.domain.QPayment.payment;
 import static com.lgcns.domain.QPaymentItem.paymentItem;
 
 import com.lgcns.domain.PaymentStatus;
+import com.lgcns.dto.response.AverageAmountResponse;
 import com.lgcns.dto.response.ItemBuyerCountResponse;
 import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.time.LocalDate;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
@@ -30,5 +32,53 @@ public class PaymentRepositoryImpl implements PaymentRepositoryCustom {
                 .where(payment.popupId.eq(popupId), payment.status.eq(PaymentStatus.PAID))
                 .groupBy(paymentItem.itemId)
                 .fetch();
+    }
+
+    @Override
+    public AverageAmountResponse findAverageAmountByPopupId(Long popupId) {
+        Integer totalAmount =
+                queryFactory
+                        .select(payment.amount.sum())
+                        .from(payment)
+                        .where(payment.popupId.eq(popupId), payment.status.eq(PaymentStatus.PAID))
+                        .fetchOne();
+
+        Long totalBuyers =
+                queryFactory
+                        .select(payment.memberId.countDistinct())
+                        .from(payment)
+                        .where(payment.popupId.eq(popupId), payment.status.eq(PaymentStatus.PAID))
+                        .fetchOne();
+
+        Integer todayAmount =
+                queryFactory
+                        .select(payment.amount.sum())
+                        .from(payment)
+                        .where(
+                                payment.popupId.eq(popupId),
+                                payment.status.eq(PaymentStatus.PAID),
+                                payment.updatedAt.goe(LocalDate.now().atStartOfDay()))
+                        .fetchOne();
+
+        Long todayBuyers =
+                queryFactory
+                        .select(payment.memberId.countDistinct())
+                        .from(payment)
+                        .where(
+                                payment.popupId.eq(popupId),
+                                payment.status.eq(PaymentStatus.PAID),
+                                payment.updatedAt.goe(LocalDate.now().atStartOfDay()))
+                        .fetchOne();
+
+        int totalAverageAmount =
+                (totalBuyers == null || totalBuyers == 0)
+                        ? 0
+                        : (totalAmount != null ? totalAmount : 0) / totalBuyers.intValue();
+        int todayAverageAmount =
+                (todayBuyers == null || todayBuyers == 0)
+                        ? 0
+                        : (todayAmount != null ? todayAmount : 0) / todayBuyers.intValue();
+
+        return AverageAmountResponse.of(totalAverageAmount, todayAverageAmount);
     }
 }

--- a/popi-payment-service/src/main/java/com/lgcns/repository/PaymentRepositoryImpl.java
+++ b/popi-payment-service/src/main/java/com/lgcns/repository/PaymentRepositoryImpl.java
@@ -57,7 +57,7 @@ public class PaymentRepositoryImpl implements PaymentRepositoryCustom {
                         .where(
                                 payment.popupId.eq(popupId),
                                 payment.status.eq(PaymentStatus.PAID),
-                                payment.updatedAt.goe(LocalDate.now().atStartOfDay()))
+                                payment.paidAt.goe(LocalDate.now().atStartOfDay()))
                         .fetchOne();
 
         Long todayBuyers =
@@ -67,7 +67,7 @@ public class PaymentRepositoryImpl implements PaymentRepositoryCustom {
                         .where(
                                 payment.popupId.eq(popupId),
                                 payment.status.eq(PaymentStatus.PAID),
-                                payment.updatedAt.goe(LocalDate.now().atStartOfDay()))
+                                payment.paidAt.goe(LocalDate.now().atStartOfDay()))
                         .fetchOne();
 
         int totalAverageAmount =

--- a/popi-payment-service/src/main/java/com/lgcns/service/PaymentService.java
+++ b/popi-payment-service/src/main/java/com/lgcns/service/PaymentService.java
@@ -1,6 +1,7 @@
 package com.lgcns.service;
 
 import com.lgcns.dto.request.PaymentReadyRequest;
+import com.lgcns.dto.response.AverageAmountResponse;
 import com.lgcns.dto.response.ItemBuyerCountResponse;
 import com.lgcns.dto.response.PaymentReadyResponse;
 import com.siot.IamportRestClient.exception.IamportResponseException;
@@ -13,4 +14,6 @@ public interface PaymentService {
     void findPaymentByImpUid(String impUid) throws IamportResponseException, IOException;
 
     List<ItemBuyerCountResponse> countItemBuyerByPopupId(Long popupId);
+
+    AverageAmountResponse findAverageAmount(Long popupId);
 }

--- a/popi-payment-service/src/main/java/com/lgcns/service/PaymentServiceImpl.java
+++ b/popi-payment-service/src/main/java/com/lgcns/service/PaymentServiceImpl.java
@@ -126,7 +126,7 @@ public class PaymentServiceImpl implements PaymentService {
                 throw new CustomException(PaymentErrorCode.NOT_PAID);
             }
 
-            payment.updatePayment(impUid, pgProvider, amount, PaymentStatus.PAID);
+            payment.updatePayment(impUid, pgProvider, PaymentStatus.PAID);
 
             itemPurchasedProducer.sendMessage(ItemPurchasedMessage.from(payment));
         } catch (IamportResponseException e) {

--- a/popi-payment-service/src/main/java/com/lgcns/service/PaymentServiceImpl.java
+++ b/popi-payment-service/src/main/java/com/lgcns/service/PaymentServiceImpl.java
@@ -20,6 +20,8 @@ import com.siot.IamportRestClient.IamportClient;
 import com.siot.IamportRestClient.exception.IamportResponseException;
 import com.siot.IamportRestClient.response.IamportResponse;
 import java.io.IOException;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
@@ -111,6 +113,12 @@ public class PaymentServiceImpl implements PaymentService {
             String pgProvider = iamportPayment.getPgProvider();
             int amount = iamportPayment.getAmount().intValue();
             PaymentStatus status = PaymentStatus.valueOf(iamportPayment.getStatus().toUpperCase());
+            LocalDateTime paidAt =
+                    iamportPayment
+                            .getPaidAt()
+                            .toInstant()
+                            .atZone(ZoneId.systemDefault())
+                            .toLocalDateTime();
 
             Payment payment =
                     paymentRepository
@@ -126,7 +134,7 @@ public class PaymentServiceImpl implements PaymentService {
                 throw new CustomException(PaymentErrorCode.NOT_PAID);
             }
 
-            payment.updatePayment(impUid, pgProvider, PaymentStatus.PAID);
+            payment.updatePayment(impUid, pgProvider, PaymentStatus.PAID, paidAt);
 
             itemPurchasedProducer.sendMessage(ItemPurchasedMessage.from(payment));
         } catch (IamportResponseException e) {

--- a/popi-payment-service/src/main/java/com/lgcns/service/PaymentServiceImpl.java
+++ b/popi-payment-service/src/main/java/com/lgcns/service/PaymentServiceImpl.java
@@ -8,6 +8,7 @@ import com.lgcns.domain.Payment;
 import com.lgcns.domain.PaymentItem;
 import com.lgcns.domain.PaymentStatus;
 import com.lgcns.dto.request.PaymentReadyRequest;
+import com.lgcns.dto.response.AverageAmountResponse;
 import com.lgcns.dto.response.ItemBuyerCountResponse;
 import com.lgcns.dto.response.PaymentReadyResponse;
 import com.lgcns.error.exception.CustomException;
@@ -139,5 +140,10 @@ public class PaymentServiceImpl implements PaymentService {
     @Transactional(readOnly = true)
     public List<ItemBuyerCountResponse> countItemBuyerByPopupId(Long popupId) {
         return paymentRepository.countItemBuyerByPopupId(popupId);
+    }
+
+    @Override
+    public AverageAmountResponse findAverageAmount(Long popupId) {
+        return paymentRepository.findAverageAmountByPopupId(popupId);
     }
 }

--- a/popi-payment-service/src/main/resources/db/migration/V4__alter_payment_table_add_paid_at_column.sql
+++ b/popi-payment-service/src/main/resources/db/migration/V4__alter_payment_table_add_paid_at_column.sql
@@ -1,0 +1,1 @@
+ALTER TABLE payment ADD COLUMN paid_at DATETIME;

--- a/popi-payment-service/src/test/java/com/lgcns/service/PaymentServiceTest.java
+++ b/popi-payment-service/src/test/java/com/lgcns/service/PaymentServiceTest.java
@@ -229,12 +229,12 @@ public class PaymentServiceTest extends WireMockIntegrationTest {
         @BeforeEach
         void setUp() {
             Payment payment1 = Payment.createPayment(1L, "merchantUid1", 10000, 1L);
-            payment1.updatePayment("impUid1", "kakaopay", 10000, PaymentStatus.PAID);
+            payment1.updatePayment("impUid1", "kakaopay", PaymentStatus.PAID);
             payment1.addPaymentItem(PaymentItem.createPaymentItem(payment1, 1L, 2));
             payment1.addPaymentItem(PaymentItem.createPaymentItem(payment1, 2L, 1));
 
             Payment payment2 = Payment.createPayment(2L, "merchantUid2", 20000, 1L);
-            payment2.updatePayment("impUid2", "tosspay", 20000, PaymentStatus.PAID);
+            payment2.updatePayment("impUid2", "tosspay", PaymentStatus.PAID);
             payment2.addPaymentItem(PaymentItem.createPaymentItem(payment2, 1L, 1));
             payment2.addPaymentItem(PaymentItem.createPaymentItem(payment2, 3L, 2));
 

--- a/popi-payment-service/src/test/java/com/lgcns/service/PaymentServiceTest.java
+++ b/popi-payment-service/src/test/java/com/lgcns/service/PaymentServiceTest.java
@@ -23,6 +23,7 @@ import com.siot.IamportRestClient.exception.IamportResponseException;
 import com.siot.IamportRestClient.response.IamportResponse;
 import java.io.IOException;
 import java.math.BigDecimal;
+import java.time.LocalDateTime;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
@@ -229,12 +230,20 @@ public class PaymentServiceTest extends WireMockIntegrationTest {
         @BeforeEach
         void setUp() {
             Payment payment1 = Payment.createPayment(1L, "merchantUid1", 10000, 1L);
-            payment1.updatePayment("impUid1", "kakaopay", PaymentStatus.PAID);
+            payment1.updatePayment(
+                    "impUid1",
+                    "kakaopay",
+                    PaymentStatus.PAID,
+                    LocalDateTime.of(2025, 5, 31, 14, 14, 0));
             payment1.addPaymentItem(PaymentItem.createPaymentItem(payment1, 1L, 2));
             payment1.addPaymentItem(PaymentItem.createPaymentItem(payment1, 2L, 1));
 
             Payment payment2 = Payment.createPayment(2L, "merchantUid2", 20000, 1L);
-            payment2.updatePayment("impUid2", "tosspay", PaymentStatus.PAID);
+            payment2.updatePayment(
+                    "impUid2",
+                    "tosspay",
+                    PaymentStatus.PAID,
+                    LocalDateTime.of(2025, 6, 1, 18, 0, 0));
             payment2.addPaymentItem(PaymentItem.createPaymentItem(payment2, 1L, 1));
             payment2.addPaymentItem(PaymentItem.createPaymentItem(payment2, 3L, 2));
 

--- a/popi-payment-service/src/test/java/com/lgcns/service/PaymentServiceTest.java
+++ b/popi-payment-service/src/test/java/com/lgcns/service/PaymentServiceTest.java
@@ -26,6 +26,7 @@ import java.io.IOException;
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.Comparator;
+import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Assertions;
@@ -177,6 +178,7 @@ public class PaymentServiceTest extends WireMockIntegrationTest {
             when(iamportPayment.getPgProvider()).thenReturn("tosspay");
             when(iamportPayment.getAmount()).thenReturn(BigDecimal.valueOf(129000));
             when(iamportPayment.getStatus()).thenReturn("PAID");
+            when(iamportPayment.getPaidAt()).thenReturn(new Date());
 
             // when
             paymentService.findPaymentByImpUid("testImpUid");
@@ -200,6 +202,7 @@ public class PaymentServiceTest extends WireMockIntegrationTest {
             when(iamportPayment.getPgProvider()).thenReturn("tosspay");
             when(iamportPayment.getAmount()).thenReturn(BigDecimal.valueOf(1000));
             when(iamportPayment.getStatus()).thenReturn("PAID");
+            when(iamportPayment.getPaidAt()).thenReturn(new Date());
 
             // when & then
             assertThatThrownBy(() -> paymentService.findPaymentByImpUid("testImpUid"))
@@ -217,6 +220,7 @@ public class PaymentServiceTest extends WireMockIntegrationTest {
             when(iamportPayment.getPgProvider()).thenReturn("tosspay");
             when(iamportPayment.getAmount()).thenReturn(BigDecimal.valueOf(129000));
             when(iamportPayment.getStatus()).thenReturn("READY");
+            when(iamportPayment.getPaidAt()).thenReturn(new Date());
 
             // when & then
             assertThatThrownBy(() -> paymentService.findPaymentByImpUid("testImpUid"))


### PR DESCRIPTION
## 🌱 관련 이슈

- [LCR-291]

---
## 📌 작업 내용 및 특이사항

- 1인 평균 구매액을 조회하는 Internal API를 구현했습니다.
  - /internal/popups/{popupId}/average-amount 경로로 요청 시 전체 기간 및 오늘 기준 평균 구매액을 응답합니다.
- 전체 기간 및 오늘의 총 결제 금액과 구매자 수를 기반으로 평균값을 계산하도록 했습니다.
  - 결제 완료 상태(PAID)를 기준으로 amount.sum()과 memberId.countDistinct()를 조회했습니다.
- 결제 준비 시점에 이미 저장된 결제 금액을 결제 완료 시 다시 저장하던 중복 로직을 제거했습니다.
- Payment 엔티티에 paidAt 필드를 추가하고, DB에도 paid_at 컬럼을 반영했습니다.
- Iamport 결제 응답에서 제공되는 paid_at 값을 LocalDateTime으로 변환해 paidAt 필드에 저장하도록 처리했습니다.
- 관련 로직에 대한 테스트 코드도 함께 작성해 평균 계산 로직이 정확히 동작하는지 검증했습니다.

[LCR-291]: https://lgcns-retail.atlassian.net/browse/LCR-291?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ