### PR TITLE
feat: 결제 내역 조회 기능 구현

### DIFF
--- a/popi-api-gateway/src/main/resources/application-local.yml
+++ b/popi-api-gateway/src/main/resources/application-local.yml
@@ -155,11 +155,11 @@ spring:
         - id: payment-external
           uri: lb://PAYMENTS
           predicates:
-            - Path=/payments/**
-            - Method=POST
+            - Path=/payments, /payments/**
+            - Method=GET,POST
           filters:
             - RemoveRequestHeader=Cookie
-            - RewritePath=/payments/(?<segment>.*), /$\{segment}
+            - RewritePath=/payments(?<segment>/?.*), /$\{segment}
             - JwtAuthenticationFilter
 
         - id: item-docs

--- a/popi-common/build.gradle
+++ b/popi-common/build.gradle
@@ -16,4 +16,7 @@ dependencies {
 
     // Open Feign
     implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
+
+    // Slice & Pageable
+    implementation 'org.springframework.data:spring-data-commons'
 }

--- a/popi-common/src/main/java/com/lgcns/response/SliceResponse.java
+++ b/popi-common/src/main/java/com/lgcns/response/SliceResponse.java
@@ -1,5 +1,10 @@
 package com.lgcns.response;
 
 import java.util.List;
+import org.springframework.data.domain.Slice;
 
-public record SliceResponse<T>(List<T> content, boolean isLast) {}
+public record SliceResponse<T>(List<T> content, boolean isLast) {
+    public static <T> SliceResponse<T> from(Slice<T> slice) {
+        return new SliceResponse<>(slice.getContent(), slice.isLast());
+    }
+}

--- a/popi-payment-service/src/main/java/com/lgcns/domain/PaymentItem.java
+++ b/popi-payment-service/src/main/java/com/lgcns/domain/PaymentItem.java
@@ -23,17 +23,30 @@ public class PaymentItem extends BaseTimeEntity {
 
     private Long itemId;
 
+    private String name;
+
     private int quantity;
 
+    private int price;
+
     @Builder
-    private PaymentItem(Payment payment, Long itemId, int quantity) {
+    private PaymentItem(Payment payment, Long itemId, String name, int quantity, int price) {
         this.payment = payment;
         this.itemId = itemId;
+        this.name = name;
         this.quantity = quantity;
+        this.price = price;
     }
 
-    public static PaymentItem createPaymentItem(Payment payment, Long itemId, int quantity) {
-        return PaymentItem.builder().payment(payment).itemId(itemId).quantity(quantity).build();
+    public static PaymentItem createPaymentItem(
+            Payment payment, Long itemId, String name, int quantity, int price) {
+        return PaymentItem.builder()
+                .payment(payment)
+                .itemId(itemId)
+                .name(name)
+                .quantity(quantity)
+                .price(price)
+                .build();
     }
 
     public void updatePayment(Payment payment) {

--- a/popi-payment-service/src/main/java/com/lgcns/dto/FlatPaymentItem.java
+++ b/popi-payment-service/src/main/java/com/lgcns/dto/FlatPaymentItem.java
@@ -1,0 +1,11 @@
+package com.lgcns.dto;
+
+import java.time.LocalDateTime;
+
+public record FlatPaymentItem(
+        Long paymentId,
+        Long popupId,
+        LocalDateTime paidAt,
+        String itemName,
+        int quantity,
+        int price) {}

--- a/popi-payment-service/src/main/java/com/lgcns/dto/response/PaymentHistoryResponse.java
+++ b/popi-payment-service/src/main/java/com/lgcns/dto/response/PaymentHistoryResponse.java
@@ -1,0 +1,16 @@
+package com.lgcns.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record PaymentHistoryResponse(
+        @Schema(description = "결제 ID", example = "1") Long paymentId,
+        @Schema(description = "팝업 ID", example = "1") Long popupId,
+        @Schema(description = "결제 완료 일시", example = "2024-05-31T14:00:00") LocalDateTime paidAt,
+        @Schema(description = "결제에 포함된 상품 목록") List<Item> items) {
+    public record Item(
+            @Schema(description = "상품 이름", example = "DAZED 지수") String itemName,
+            @Schema(description = "구매 수량", example = "1") int quantity,
+            @Schema(description = "상품 결제 금액", example = "15000") int price) {}
+}

--- a/popi-payment-service/src/main/java/com/lgcns/externalApi/PaymentController.java
+++ b/popi-payment-service/src/main/java/com/lgcns/externalApi/PaymentController.java
@@ -1,10 +1,13 @@
 package com.lgcns.externalApi;
 
 import com.lgcns.dto.request.PaymentReadyRequest;
+import com.lgcns.dto.response.PaymentHistoryResponse;
 import com.lgcns.dto.response.PaymentReadyResponse;
+import com.lgcns.response.SliceResponse;
 import com.lgcns.service.PaymentService;
 import com.siot.IamportRestClient.exception.IamportResponseException;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.io.IOException;
 import lombok.RequiredArgsConstructor;
@@ -33,5 +36,16 @@ public class PaymentController {
     public void paymentByImpUidFind(@PathVariable("impUid") String impUid)
             throws IamportResponseException, IOException {
         paymentService.findPaymentByImpUid(impUid);
+    }
+
+    @GetMapping
+    @Operation(summary = "결제 내역 조회", description = "회원의 결제 내역을 조회합니다.")
+    public SliceResponse<PaymentHistoryResponse> paymentHistoryFindAll(
+            @RequestHeader("member-id") String memberId,
+            @Parameter(description = "기준이 되는 결제 ID입니다. 첫 요청 시에는 비워두세요.")
+                    @RequestParam(required = false)
+                    Long lastPaymentId,
+            @Parameter(description = "페이지당 결제 내역 수", example = "1") @RequestParam int size) {
+        return paymentService.findAllPaymentHistory(memberId, lastPaymentId, size);
     }
 }

--- a/popi-payment-service/src/main/java/com/lgcns/repository/PaymentRepositoryCustom.java
+++ b/popi-payment-service/src/main/java/com/lgcns/repository/PaymentRepositoryCustom.java
@@ -1,11 +1,16 @@
 package com.lgcns.repository;
 
+import com.lgcns.dto.FlatPaymentItem;
 import com.lgcns.dto.response.AverageAmountResponse;
 import com.lgcns.dto.response.ItemBuyerCountResponse;
 import java.util.List;
+import org.springframework.data.domain.Slice;
 
 public interface PaymentRepositoryCustom {
     List<ItemBuyerCountResponse> countItemBuyerByPopupId(Long popupId);
 
     AverageAmountResponse findAverageAmountByPopupId(Long popupId);
+
+    Slice<FlatPaymentItem> findAllPaymentHistoryByMemberId(
+            Long memberId, Long lastPaymentId, int size);
 }

--- a/popi-payment-service/src/main/java/com/lgcns/repository/PaymentRepositoryImpl.java
+++ b/popi-payment-service/src/main/java/com/lgcns/repository/PaymentRepositoryImpl.java
@@ -89,7 +89,7 @@ public class PaymentRepositoryImpl implements PaymentRepositoryCustom {
                                 payment.status.eq(PaymentStatus.PAID),
                                 lastPaymentCondition(lastPaymentId))
                         .orderBy(payment.paidAt.desc(), payment.id.desc())
-                        .limit(size + 1)
+                        .limit(size + 1L)
                         .fetch();
 
         boolean hasNext = false;

--- a/popi-payment-service/src/main/java/com/lgcns/repository/PaymentRepositoryImpl.java
+++ b/popi-payment-service/src/main/java/com/lgcns/repository/PaymentRepositoryImpl.java
@@ -4,14 +4,19 @@ import static com.lgcns.domain.QPayment.payment;
 import static com.lgcns.domain.QPaymentItem.paymentItem;
 
 import com.lgcns.domain.PaymentStatus;
+import com.lgcns.dto.FlatPaymentItem;
 import com.lgcns.dto.response.AverageAmountResponse;
 import com.lgcns.dto.response.ItemBuyerCountResponse;
 import com.querydsl.core.Tuple;
 import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.time.LocalDate;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -70,5 +75,51 @@ public class PaymentRepositoryImpl implements PaymentRepositoryCustom {
                         : (todayAmount != null ? todayAmount : 0) / todayBuyers.intValue();
 
         return AverageAmountResponse.of(totalAverageAmount, todayAverageAmount);
+    }
+
+    @Override
+    public Slice<FlatPaymentItem> findAllPaymentHistoryByMemberId(
+            Long memberId, Long lastPaymentId, int size) {
+        List<Long> paymentIds =
+                queryFactory
+                        .select(payment.id)
+                        .from(payment)
+                        .where(
+                                payment.memberId.eq(memberId),
+                                payment.status.eq(PaymentStatus.PAID),
+                                lastPaymentCondition(lastPaymentId))
+                        .orderBy(payment.paidAt.desc(), payment.id.desc())
+                        .limit(size + 1)
+                        .fetch();
+
+        boolean hasNext = false;
+        if (paymentIds.size() > size) {
+            hasNext = true;
+            paymentIds.remove(size);
+        }
+
+        List<FlatPaymentItem> results =
+                queryFactory
+                        .select(
+                                Projections.constructor(
+                                        FlatPaymentItem.class,
+                                        payment.id,
+                                        payment.popupId,
+                                        payment.paidAt,
+                                        paymentItem.name,
+                                        paymentItem.quantity,
+                                        paymentItem.price))
+                        .from(payment)
+                        .join(paymentItem)
+                        .on(payment.id.eq(paymentItem.payment.id))
+                        .where(payment.id.in(paymentIds))
+                        .orderBy(payment.paidAt.desc(), payment.id.desc())
+                        .fetch();
+
+        return new SliceImpl<>(results, PageRequest.of(0, size), hasNext);
+    }
+
+    private BooleanExpression lastPaymentCondition(Long paymentId) {
+        return (paymentId != null) ? payment.id.lt(paymentId) : null;
     }
 }

--- a/popi-payment-service/src/main/java/com/lgcns/service/PaymentService.java
+++ b/popi-payment-service/src/main/java/com/lgcns/service/PaymentService.java
@@ -3,7 +3,9 @@ package com.lgcns.service;
 import com.lgcns.dto.request.PaymentReadyRequest;
 import com.lgcns.dto.response.AverageAmountResponse;
 import com.lgcns.dto.response.ItemBuyerCountResponse;
+import com.lgcns.dto.response.PaymentHistoryResponse;
 import com.lgcns.dto.response.PaymentReadyResponse;
+import com.lgcns.response.SliceResponse;
 import com.siot.IamportRestClient.exception.IamportResponseException;
 import java.io.IOException;
 import java.util.List;
@@ -16,4 +18,7 @@ public interface PaymentService {
     List<ItemBuyerCountResponse> countItemBuyerByPopupId(Long popupId);
 
     AverageAmountResponse findAverageAmount(Long popupId);
+
+    SliceResponse<PaymentHistoryResponse> findAllPaymentHistory(
+            String memberId, Long lastPaymentId, int size);
 }

--- a/popi-payment-service/src/main/resources/db/migration/V5__alter_payment_item_table_add_name_and_price_column.sql
+++ b/popi-payment-service/src/main/resources/db/migration/V5__alter_payment_item_table_add_name_and_price_column.sql
@@ -1,0 +1,2 @@
+ALTER TABLE payment_item ADD COLUMN name VARCHAR(255) NOT NULL;
+ALTER TABLE payment_item ADD COLUMN price INT NOT NULL;

--- a/popi-payment-service/src/test/java/com/lgcns/DatabaseCleaner.java
+++ b/popi-payment-service/src/test/java/com/lgcns/DatabaseCleaner.java
@@ -1,0 +1,49 @@
+package com.lgcns;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.hibernate.Session;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.stereotype.Component;
+
+@Component
+public class DatabaseCleaner implements InitializingBean {
+
+    @PersistenceContext private EntityManager entityManager;
+
+    private List<String> tableNames;
+
+    @Override
+    public void afterPropertiesSet() {
+        entityManager.unwrap(Session.class).doWork(this::extractTableNames);
+    }
+
+    private void extractTableNames(Connection conn) {
+        tableNames =
+                entityManager.getMetamodel().getEntities().stream()
+                        .map(e -> e.getName().replaceAll("([a-z])([A-Z])", "$1_$2").toLowerCase())
+                        .collect(Collectors.toList());
+    }
+
+    public void execute() {
+        entityManager.unwrap(Session.class).doWork(this::cleanTables);
+    }
+
+    private void cleanTables(Connection conn) throws SQLException {
+        Statement statement = conn.createStatement();
+        statement.executeUpdate("SET REFERENTIAL_INTEGRITY FALSE");
+
+        for (String name : tableNames) {
+            statement.executeUpdate(String.format("TRUNCATE TABLE %s", name));
+            statement.executeUpdate(
+                    String.format("ALTER TABLE %s ALTER COLUMN %s_id RESTART WITH 1", name, name));
+        }
+
+        statement.executeUpdate("SET REFERENTIAL_INTEGRITY TRUE");
+    }
+}

--- a/popi-payment-service/src/test/java/com/lgcns/service/PaymentServiceTest.java
+++ b/popi-payment-service/src/test/java/com/lgcns/service/PaymentServiceTest.java
@@ -240,8 +240,10 @@ public class PaymentServiceTest extends WireMockIntegrationTest {
                     "kakaopay",
                     PaymentStatus.PAID,
                     LocalDateTime.of(2025, 5, 31, 14, 14, 0));
-            payment1.addPaymentItem(PaymentItem.createPaymentItem(payment1, 1L, 2));
-            payment1.addPaymentItem(PaymentItem.createPaymentItem(payment1, 2L, 1));
+            payment1.addPaymentItem(
+                    PaymentItem.createPaymentItem(payment1, 1L, "DAZED 지수", 2, 15000));
+            payment1.addPaymentItem(
+                    PaymentItem.createPaymentItem(payment1, 2L, "DAZED 로제", 1, 15000));
 
             Payment payment2 = Payment.createPayment(2L, "merchantUid2", 20000, 1L);
             payment2.updatePayment(
@@ -249,8 +251,10 @@ public class PaymentServiceTest extends WireMockIntegrationTest {
                     "tosspay",
                     PaymentStatus.PAID,
                     LocalDateTime.of(2025, 6, 1, 18, 0, 0));
-            payment2.addPaymentItem(PaymentItem.createPaymentItem(payment2, 1L, 1));
-            payment2.addPaymentItem(PaymentItem.createPaymentItem(payment2, 3L, 2));
+            payment2.addPaymentItem(
+                    PaymentItem.createPaymentItem(payment2, 1L, "DAZED 지수", 2, 15000));
+            payment2.addPaymentItem(
+                    PaymentItem.createPaymentItem(payment2, 3L, "DAZED 제니", 2, 9500));
 
             paymentRepository.saveAll(List.of(payment1, payment2));
         }
@@ -286,17 +290,22 @@ public class PaymentServiceTest extends WireMockIntegrationTest {
                     "kakaopay",
                     PaymentStatus.PAID,
                     LocalDateTime.of(2025, 6, 1, 14, 14, 0));
-            payment1.addPaymentItem(PaymentItem.createPaymentItem(payment1, 1L, 2));
-            payment1.addPaymentItem(PaymentItem.createPaymentItem(payment1, 2L, 1));
+            payment1.addPaymentItem(
+                    PaymentItem.createPaymentItem(payment1, 1L, "DAZED 지수", 2, 15000));
+            payment1.addPaymentItem(
+                    PaymentItem.createPaymentItem(payment1, 2L, "DAZED 로제", 1, 15000));
 
             Payment payment2 = Payment.createPayment(2L, "merchantUid2", 34000, 1L);
             payment2.updatePayment("impUid2", "tosspay", PaymentStatus.PAID, LocalDateTime.now());
-            payment2.addPaymentItem(PaymentItem.createPaymentItem(payment2, 1L, 1));
-            payment2.addPaymentItem(PaymentItem.createPaymentItem(payment2, 3L, 2));
+            payment2.addPaymentItem(
+                    PaymentItem.createPaymentItem(payment2, 1L, "DAZED 지수", 2, 15000));
+            payment2.addPaymentItem(
+                    PaymentItem.createPaymentItem(payment2, 3L, "DAZED 제니", 2, 9500));
 
             Payment payment3 = Payment.createPayment(3L, "merchantUid3", 15000, 1L);
             payment3.updatePayment("impUid3", "kakaopay", PaymentStatus.PAID, LocalDateTime.now());
-            payment3.addPaymentItem(PaymentItem.createPaymentItem(payment3, 13L, 1));
+            payment3.addPaymentItem(
+                    PaymentItem.createPaymentItem(payment3, 13L, "포스터 세트", 1, 15000));
 
             paymentRepository.saveAll(List.of(payment1, payment2, payment3));
         }

--- a/popi-payment-service/src/test/java/com/lgcns/service/PaymentServiceTest.java
+++ b/popi-payment-service/src/test/java/com/lgcns/service/PaymentServiceTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.lgcns.DatabaseCleaner;
 import com.lgcns.WireMockIntegrationTest;
 import com.lgcns.domain.Payment;
 import com.lgcns.domain.PaymentItem;
@@ -41,6 +42,8 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 public class PaymentServiceTest extends WireMockIntegrationTest {
 
+    @Autowired protected DatabaseCleaner databaseCleaner;
+
     @Autowired PaymentService paymentService;
     @Autowired PaymentRepository paymentRepository;
 
@@ -49,6 +52,11 @@ public class PaymentServiceTest extends WireMockIntegrationTest {
     @Mock com.siot.IamportRestClient.response.Payment iamportPayment;
 
     private static final ObjectMapper objectMapper = new ObjectMapper();
+
+    @BeforeEach
+    void setUp() {
+        databaseCleaner.execute();
+    }
 
     @Nested
     class 결제_준비할_때 {


### PR DESCRIPTION
## 🌱 관련 이슈

- [LCR-301]

---
## 📌 작업 내용 및 특이사항

- 결제 내역 조회 API를 구현했습니다.
- 쿼리 성능을 고려해 Flat 구조의 DTO(FlatPaymentItem)를 조회한 후, 메모리 상에서 paymentId 기준으로 그룹핑해 응답 데이터를 
구성했습니다.
- 하나의 결제에는 여러 상품이 포함될 수 있기 때문에, Map<Long, List<FlatPaymentItem>>으로 결제 ID별로 묶어 List<PaymentHistoryResponse>로 변환합니다.
- 응답 항목은 paymentId, popupId, paidAt을 포함하고, 각 상품은 itemName, quantity, price를 가지며, 개별 상품 금액은 
quantity * price로 계산됩니다.
- 페이징은 Slice 기반으로 구현해 무한 스크롤 방식에 적합하도록 처리했고, lastPaymentId를 기준으로 이후 결제 내역을 조회할 수 있도록 
했습니다.

---
## 📚 참고사항

- 실제 앱 화면에서의 UI 요구사항을 고려해 설계했습니다.
- 자세한 응답 구조는 API 명세서 참고하시길 바랍니다.

![image](https://github.com/user-attachments/assets/4cefac18-a770-4afa-a4c8-69e5a835ecf4)




[LCR-301]: https://lgcns-retail.atlassian.net/browse/LCR-301?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ