### PR TITLE
feat: 예약 시 알림 전송을 위한 Redis ZSET 항목 추가

### DIFF
--- a/popi-reservation-service/src/main/java/com/lgcns/infra/redis/RedisConfig.java
+++ b/popi-reservation-service/src/main/java/com/lgcns/infra/redis/RedisConfig.java
@@ -2,6 +2,7 @@ package com.lgcns.infra.redis;
 
 import java.time.Duration;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
@@ -39,11 +40,24 @@ public class RedisConfig {
     }
 
     @Bean
-    public RedisTemplate<String, Long> redisTemplate(RedisConnectionFactory connectionFactory) {
+    @Qualifier("reservationRedisTemplate")
+    public RedisTemplate<String, Long> reservationRedisTemplate(
+            RedisConnectionFactory connectionFactory) {
         RedisTemplate<String, Long> template = new RedisTemplate<>();
         template.setConnectionFactory(connectionFactory);
         template.setKeySerializer(new StringRedisSerializer());
         template.setValueSerializer(new GenericToStringSerializer<>(Long.class));
+        return template;
+    }
+
+    @Bean
+    @Qualifier("notificationRedisTemplate")
+    public RedisTemplate<String, String> notificationRedisTemplate(
+            RedisConnectionFactory connectionFactory) {
+        RedisTemplate<String, String> template = new RedisTemplate<>();
+        template.setConnectionFactory(connectionFactory);
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setValueSerializer(new StringRedisSerializer());
         return template;
     }
 }

--- a/popi-reservation-service/src/main/java/com/lgcns/service/MemberReservationServiceImpl.java
+++ b/popi-reservation-service/src/main/java/com/lgcns/service/MemberReservationServiceImpl.java
@@ -269,11 +269,9 @@ public class MemberReservationServiceImpl implements MemberReservationService {
         memberReservationRepository.delete(memberReservation);
         safeIncrement(reservationId.toString());
 
-        String reservationNotificationKey = getReservationNotificationKey(memberReservation);
+        String member = getMember(memberReservation);
 
-        notificationRedisTemplate
-                .opsForZSet()
-                .remove("reservation:notifications", reservationNotificationKey);
+        notificationRedisTemplate.opsForZSet().remove("reservation:notifications", member);
     }
 
     private MemberReservation findMemberReservationById(Long memberReservationId) {
@@ -424,18 +422,18 @@ public class MemberReservationServiceImpl implements MemberReservationService {
                             .atZone(ZoneId.of("Asia/Seoul"))
                             .toEpochSecond();
 
-            String reservationNotificationKey = getReservationNotificationKey(memberReservation);
+            String member = getMember(memberReservation);
 
             notificationRedisTemplate
                     .opsForZSet()
-                    .add("reservation:notifications", reservationNotificationKey, epochTime);
+                    .add("reservation:notifications", member, epochTime);
 
         } catch (Exception e) {
             log.error("예약 알림 등록 오류: {}", e.getMessage(), e);
         }
     }
 
-    private String getReservationNotificationKey(MemberReservation memberReservation) {
+    private String getMember(MemberReservation memberReservation) {
         return memberReservation.getId() + "|" + memberReservation.getMemberId();
     }
 }

--- a/popi-reservation-service/src/main/java/com/lgcns/service/MemberReservationServiceImpl.java
+++ b/popi-reservation-service/src/main/java/com/lgcns/service/MemberReservationServiceImpl.java
@@ -28,15 +28,14 @@ import io.github.resilience4j.retry.annotation.Retry;
 import java.awt.image.BufferedImage;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.time.LocalDate;
-import java.time.LocalTime;
-import java.time.YearMonth;
+import java.time.*;
 import java.time.format.DateTimeParseException;
 import java.util.*;
 import java.util.stream.Collectors;
 import javax.imageio.ImageIO;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
@@ -53,7 +52,12 @@ public class MemberReservationServiceImpl implements MemberReservationService {
     private final MemberServiceClient memberServiceClient;
 
     private final ApplicationEventPublisher eventPublisher;
-    private final RedisTemplate<String, Long> redisTemplate;
+
+    @Qualifier("reservationRedisTemplate")
+    private final RedisTemplate<String, Long> reservationRedisTemplate;
+
+    @Qualifier("notificationRedisTemplate")
+    private final RedisTemplate<String, String> notificationRedisTemplate;
 
     private final MemberAnswerProducer memberAnswerProducer;
 
@@ -205,7 +209,8 @@ public class MemberReservationServiceImpl implements MemberReservationService {
     public void createMemberReservation(String memberId, Long reservationId) {
         validateMemberReservationExists(Long.parseLong(memberId), reservationId);
 
-        Long possibleCount = redisTemplate.opsForValue().decrement(reservationId.toString());
+        Long possibleCount =
+                reservationRedisTemplate.opsForValue().decrement(reservationId.toString());
         if (possibleCount == null || possibleCount < 0) {
             safeIncrement(reservationId.toString());
             throw new CustomException(MemberReservationErrorCode.RESERVATION_FAILED);
@@ -233,6 +238,7 @@ public class MemberReservationServiceImpl implements MemberReservationService {
 
         ReservationInfoResponse reservationInfoResponse =
                 managerServiceClient.findReservationById(memberReservation.getReservationId());
+
         String imageByte =
                 createMemberReservationImageString(
                         memberReservation.getId(),
@@ -248,17 +254,26 @@ public class MemberReservationServiceImpl implements MemberReservationService {
                 imageByte,
                 reservationInfoResponse.reservationDate(),
                 reservationInfoResponse.reservationTime());
+
+        createReservationNotification(memberReservation);
     }
 
     @Override
     public void cancelMemberReservation(Long memberReservationId) {
         MemberReservation memberReservation = findMemberReservationById(memberReservationId);
         Long reservationId = memberReservation.getReservationId();
-        memberReservationRepository.delete(memberReservation);
+
         if (reservationId == null)
             throw new CustomException(MemberReservationErrorCode.RESERVATION_NOT_FOUND);
 
+        memberReservationRepository.delete(memberReservation);
         safeIncrement(reservationId.toString());
+
+        String reservationNotificationKey = getReservationNotificationKey(memberReservation);
+
+        notificationRedisTemplate
+                .opsForZSet()
+                .remove("reservation:notifications", reservationNotificationKey);
     }
 
     private MemberReservation findMemberReservationById(Long memberReservationId) {
@@ -294,7 +309,7 @@ public class MemberReservationServiceImpl implements MemberReservationService {
     @CircuitBreaker(name = "redisCircuitBreaker", fallbackMethod = "handleRedisFailure")
     @Retry(name = "redisRetry")
     private void safeIncrement(String key) {
-        redisTemplate.opsForValue().increment(key);
+        reservationRedisTemplate.opsForValue().increment(key);
     }
 
     private void handleRedisFailure(String key, Throwable t) {
@@ -395,5 +410,32 @@ public class MemberReservationServiceImpl implements MemberReservationService {
         }
 
         return reservableDateList;
+    }
+
+    private void createReservationNotification(MemberReservation memberReservation) {
+        try {
+            LocalDate reservationDate = memberReservation.getReservationDate();
+            LocalTime reservationTime = memberReservation.getReservationTime();
+            LocalDateTime reservationDateTime = LocalDateTime.of(reservationDate, reservationTime);
+
+            long epochTime =
+                    reservationDateTime
+                            .minusHours(1)
+                            .atZone(ZoneId.of("Asia/Seoul"))
+                            .toEpochSecond();
+
+            String reservationNotificationKey = getReservationNotificationKey(memberReservation);
+
+            notificationRedisTemplate
+                    .opsForZSet()
+                    .add("reservation:notifications", reservationNotificationKey, epochTime);
+
+        } catch (Exception e) {
+            log.error("예약 알림 등록 오류: {}", e.getMessage(), e);
+        }
+    }
+
+    private String getReservationNotificationKey(MemberReservation memberReservation) {
+        return memberReservation.getId() + "|" + memberReservation.getMemberId();
     }
 }


### PR DESCRIPTION
## 🌱 관련 이슈

- [LCR-300]

---
## 📌 작업 내용 및 특이사항

- Redis 구성을 용도별로 분리했습니다.
  - reservationRedisTemplate(Long)과 notificationRedisTemplate(String)을 별도로 정의하여, 예약 수량 관리와 알림 관리 목적으로 분리했습니다.
- 예약 시 Redis ZSET에 알림 정보를 추가하도록 구현했습니다.
  - ZSET 키는 reservation:notifications이며, 값은 "{memberReservationId|memberId}" 형식이고, score는 예약 시간 기준 1시간 전 시간을 epoch second로 변환하여 사용했습니다.
- 예약 취소 시 Redis ZSET에서 해당 알림 정보를 제거하도록 처리했습니다.
- 기존 테스트 코드에 ZSET 알림 기능 관련 테스트를 추가했습니다.
  - 예약 생성 후 예약 정보 업데이트 시, ZSET에 알림 정보가 정상적으로 추가되는지 검증했습니다.
  - 예약 취소 시, ZSET에서 해당 알림 정보가 정상적으로 삭제되는지 검증했습니다.

---
## 📚 참고사항

- Redis ZSET에서 사용하는 member는 Redis 용어로, ZSET의 value(값)를 의미합니다. 서비스 도메인에서의 회원(Member) 객체와 다르므로 혼동에 주의해 주세요. 이는 고유 식별자로 사용됩니다.
- ZSET score는 reservationDateTime.minusHours(1)을 Asia/Seoul 기준으로 epoch second로 변환한 값입니다.


[LCR-300]: https://lgcns-retail.atlassian.net/browse/LCR-300?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ