### PR TITLE
feat: 인기 상품 리스트 조회 기능 구현

### DIFF
--- a/popi-item-service/src/main/java/com/lgcns/client/ManagerServiceClient.java
+++ b/popi-item-service/src/main/java/com/lgcns/client/ManagerServiceClient.java
@@ -24,4 +24,7 @@ public interface ManagerServiceClient {
 
     @GetMapping("/internal/popups/{popupId}/items/default")
     List<ItemInfoResponse> findItemsDefault(@PathVariable(name = "popupId") Long popupId);
+
+    @GetMapping("/internal/popups/{popupId}/items/popularity")
+    List<ItemInfoResponse> findItemsPopularity(@PathVariable(name = "popupId") Long popupId);
 }

--- a/popi-item-service/src/main/java/com/lgcns/externalApi/ItemController.java
+++ b/popi-item-service/src/main/java/com/lgcns/externalApi/ItemController.java
@@ -46,4 +46,12 @@ public class ItemController {
                     Long popupId) {
         return itemService.findItemsDefault(popupId);
     }
+
+    @GetMapping("/popularity")
+    @Operation(summary = "인기 상품 목록 조회", description = "카메라 점수 및 실구매율 기반 인기 상품 3개를 조회합니다.")
+    public List<ItemInfoResponse> itemFindPopularity(
+            @Parameter(description = "팝업 ID", example = "1") @PathVariable(name = "popupId")
+                    Long popupId) {
+        return itemService.findItemsPopularity(popupId);
+    }
 }

--- a/popi-item-service/src/main/java/com/lgcns/service/ItemService.java
+++ b/popi-item-service/src/main/java/com/lgcns/service/ItemService.java
@@ -9,4 +9,6 @@ public interface ItemService {
             Long popupId, String keyword, Long lastItemId, int size);
 
     List<ItemInfoResponse> findItemsDefault(Long popupId);
+
+    List<ItemInfoResponse> findItemsPopularity(Long popupId);
 }

--- a/popi-item-service/src/main/java/com/lgcns/service/ItemServiceImpl.java
+++ b/popi-item-service/src/main/java/com/lgcns/service/ItemServiceImpl.java
@@ -23,4 +23,9 @@ public class ItemServiceImpl implements ItemService {
     public List<ItemInfoResponse> findItemsDefault(Long popupId) {
         return managerServiceClient.findItemsDefault(popupId);
     }
+
+    @Override
+    public List<ItemInfoResponse> findItemsPopularity(Long popupId) {
+        return managerServiceClient.findItemsPopularity(popupId);
+    }
 }


### PR DESCRIPTION
## 🌱 관련 이슈

- [LCR-229]

---
## 📌 작업 내용 및 특이사항

- 인기 상품 목록 조회 기능을 구현했습니다.
  - 카메라 기반 인기 점수와 판매량 기반 점수를 합산하여 상위 3개의 상품을 선정하므로, 집계된 데이터가 부족한 경우엔 3개 미만의 인기 상품이 반환될 수 있습니다.
  - 운영자 서버의 대시보드에 사용되는 '인기 상품 분석' 로직을 사용할 예정입니다.
- 팝업이 오픈 초기 등의 이슈로 인해 집계 데이터가 없는 경우를 고려하여, 빈 리스트를 포함해 어떤 경우에도 예외는 발생하지 않도록 처리했습니다.

---
## 📚 참고사항


[LCR-229]: https://lgcns-retail.atlassian.net/browse/LCR-229?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ