### PR TITLE
test: 결제 서비스 단위 테스트 작성

### DIFF
--- a/popi-payment-service/src/test/java/com/lgcns/service/integration/DatabaseCleaner.java
+++ b/popi-payment-service/src/test/java/com/lgcns/service/integration/DatabaseCleaner.java
@@ -1,4 +1,4 @@
-package com.lgcns;
+package com.lgcns.service.integration;
 
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;

--- a/popi-payment-service/src/test/java/com/lgcns/service/integration/PaymentServiceIntegrationTest.java
+++ b/popi-payment-service/src/test/java/com/lgcns/service/integration/PaymentServiceIntegrationTest.java
@@ -1,4 +1,4 @@
-package com.lgcns.service;
+package com.lgcns.service.integration;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
@@ -22,6 +22,7 @@ import com.lgcns.error.exception.CustomException;
 import com.lgcns.exception.PaymentErrorCode;
 import com.lgcns.repository.PaymentRepository;
 import com.lgcns.response.SliceResponse;
+import com.lgcns.service.PaymentService;
 import com.siot.IamportRestClient.IamportClient;
 import com.siot.IamportRestClient.exception.IamportResponseException;
 import com.siot.IamportRestClient.response.IamportResponse;
@@ -40,7 +41,7 @@ import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
-public class PaymentServiceTest extends WireMockIntegrationTest {
+public class PaymentServiceIntegrationTest extends WireMockIntegrationTest {
 
     @Autowired protected DatabaseCleaner databaseCleaner;
 

--- a/popi-payment-service/src/test/java/com/lgcns/service/integration/PaymentServiceIntegrationTest.java
+++ b/popi-payment-service/src/test/java/com/lgcns/service/integration/PaymentServiceIntegrationTest.java
@@ -43,12 +43,12 @@ public class PaymentServiceIntegrationTest extends WireMockIntegrationTest {
 
     @Autowired private DatabaseCleaner databaseCleaner;
 
-    @Autowired PaymentService paymentService;
-    @Autowired PaymentRepository paymentRepository;
+    @Autowired private PaymentService paymentService;
+    @Autowired private PaymentRepository paymentRepository;
 
-    @MockitoBean IamportClient iamportClient;
-    @Mock IamportResponse<com.siot.IamportRestClient.response.Payment> iamportResponse;
-    @Mock com.siot.IamportRestClient.response.Payment iamportPayment;
+    @MockitoBean private IamportClient iamportClient;
+    @Mock private IamportResponse<com.siot.IamportRestClient.response.Payment> iamportResponse;
+    @Mock private com.siot.IamportRestClient.response.Payment iamportPayment;
 
     private static final ObjectMapper objectMapper = new ObjectMapper();
 

--- a/popi-payment-service/src/test/java/com/lgcns/service/integration/PaymentServiceIntegrationTest.java
+++ b/popi-payment-service/src/test/java/com/lgcns/service/integration/PaymentServiceIntegrationTest.java
@@ -8,8 +8,6 @@ import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.lgcns.DatabaseCleaner;
-import com.lgcns.WireMockIntegrationTest;
 import com.lgcns.domain.Payment;
 import com.lgcns.domain.PaymentItem;
 import com.lgcns.domain.PaymentStatus;
@@ -43,7 +41,7 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 public class PaymentServiceIntegrationTest extends WireMockIntegrationTest {
 
-    @Autowired protected DatabaseCleaner databaseCleaner;
+    @Autowired private DatabaseCleaner databaseCleaner;
 
     @Autowired PaymentService paymentService;
     @Autowired PaymentRepository paymentRepository;

--- a/popi-payment-service/src/test/java/com/lgcns/service/integration/PaymentServiceIntegrationTest.java
+++ b/popi-payment-service/src/test/java/com/lgcns/service/integration/PaymentServiceIntegrationTest.java
@@ -4,7 +4,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.when;
+import static org.mockito.BDDMockito.given;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -180,14 +180,7 @@ public class PaymentServiceIntegrationTest extends WireMockIntegrationTest {
         @Test
         void impUid와_결제정보가_일치하면_결제정보를_업데이트한다() throws IOException, IamportResponseException {
             // given
-            when(iamportClient.paymentByImpUid(anyString())).thenReturn(iamportResponse);
-            when(iamportResponse.getResponse()).thenReturn(iamportPayment);
-
-            when(iamportPayment.getMerchantUid()).thenReturn("popup_1_order_test-uuid");
-            when(iamportPayment.getPgProvider()).thenReturn("tosspay");
-            when(iamportPayment.getAmount()).thenReturn(BigDecimal.valueOf(129000));
-            when(iamportPayment.getStatus()).thenReturn("PAID");
-            when(iamportPayment.getPaidAt()).thenReturn(new Date());
+            stubIamportResponse(BigDecimal.valueOf(129000), "PAID");
 
             // when
             paymentService.findPaymentByImpUid("testImpUid");
@@ -204,14 +197,7 @@ public class PaymentServiceIntegrationTest extends WireMockIntegrationTest {
         @Test
         void 결제_금액이_다르면_예외가_발생한다() throws IOException, IamportResponseException {
             // given
-            when(iamportClient.paymentByImpUid(anyString())).thenReturn(iamportResponse);
-            when(iamportResponse.getResponse()).thenReturn(iamportPayment);
-
-            when(iamportPayment.getMerchantUid()).thenReturn("popup_1_order_test-uuid");
-            when(iamportPayment.getPgProvider()).thenReturn("tosspay");
-            when(iamportPayment.getAmount()).thenReturn(BigDecimal.valueOf(1000));
-            when(iamportPayment.getStatus()).thenReturn("PAID");
-            when(iamportPayment.getPaidAt()).thenReturn(new Date());
+            stubIamportResponse(BigDecimal.valueOf(1000), "PAID");
 
             // when & then
             assertThatThrownBy(() -> paymentService.findPaymentByImpUid("testImpUid"))
@@ -222,19 +208,24 @@ public class PaymentServiceIntegrationTest extends WireMockIntegrationTest {
         @Test
         void 결제_상태가_PAID가_아니면_예외가_발생한다() throws IOException, IamportResponseException {
             // given
-            when(iamportClient.paymentByImpUid(anyString())).thenReturn(iamportResponse);
-            when(iamportResponse.getResponse()).thenReturn(iamportPayment);
-
-            when(iamportPayment.getMerchantUid()).thenReturn("popup_1_order_test-uuid");
-            when(iamportPayment.getPgProvider()).thenReturn("tosspay");
-            when(iamportPayment.getAmount()).thenReturn(BigDecimal.valueOf(129000));
-            when(iamportPayment.getStatus()).thenReturn("READY");
-            when(iamportPayment.getPaidAt()).thenReturn(new Date());
+            stubIamportResponse(BigDecimal.valueOf(129000), "READY");
 
             // when & then
             assertThatThrownBy(() -> paymentService.findPaymentByImpUid("testImpUid"))
                     .isInstanceOf(CustomException.class)
                     .hasMessage(PaymentErrorCode.NOT_PAID.getMessage());
+        }
+
+        private void stubIamportResponse(BigDecimal amount, String status)
+                throws IOException, IamportResponseException {
+            given(iamportClient.paymentByImpUid(anyString())).willReturn(iamportResponse);
+            given(iamportResponse.getResponse()).willReturn(iamportPayment);
+
+            given(iamportPayment.getMerchantUid()).willReturn("popup_1_order_test-uuid");
+            given(iamportPayment.getPgProvider()).willReturn("tosspay");
+            given(iamportPayment.getAmount()).willReturn(amount);
+            given(iamportPayment.getStatus()).willReturn(status);
+            given(iamportPayment.getPaidAt()).willReturn(new Date());
         }
     }
 

--- a/popi-payment-service/src/test/java/com/lgcns/service/integration/WireMockIntegrationTest.java
+++ b/popi-payment-service/src/test/java/com/lgcns/service/integration/WireMockIntegrationTest.java
@@ -1,4 +1,4 @@
-package com.lgcns;
+package com.lgcns.service.integration;
 
 import com.github.tomakehurst.wiremock.WireMockServer;
 import org.junit.jupiter.api.AfterEach;

--- a/popi-payment-service/src/test/java/com/lgcns/service/unit/PaymentServiceUnitTest.java
+++ b/popi-payment-service/src/test/java/com/lgcns/service/unit/PaymentServiceUnitTest.java
@@ -54,10 +54,10 @@ public class PaymentServiceUnitTest {
     @Mock private MemberServiceClient memberServiceClient;
     @Mock private ManagerServiceClient managerServiceClient;
 
-    @Mock IamportClient iamportClient;
-    @Mock IamportResponse<com.siot.IamportRestClient.response.Payment> iamportResponse;
-    @Mock com.siot.IamportRestClient.response.Payment iamportPayment;
-    @Mock ItemPurchasedProducer itemPurchasedProducer;
+    @Mock private IamportClient iamportClient;
+    @Mock private IamportResponse<com.siot.IamportRestClient.response.Payment> iamportResponse;
+    @Mock private com.siot.IamportRestClient.response.Payment iamportPayment;
+    @Mock private ItemPurchasedProducer itemPurchasedProducer;
 
     @Nested
     class 결제_준비할_때 {

--- a/popi-payment-service/src/test/java/com/lgcns/service/unit/PaymentServiceUnitTest.java
+++ b/popi-payment-service/src/test/java/com/lgcns/service/unit/PaymentServiceUnitTest.java
@@ -1,0 +1,130 @@
+package com.lgcns.service.unit;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.when;
+
+import com.lgcns.client.managerClient.ManagerServiceClient;
+import com.lgcns.client.managerClient.dto.request.ItemIdsForPaymentRequest;
+import com.lgcns.client.managerClient.dto.response.ItemForPaymentResponse;
+import com.lgcns.client.memberClient.MemberServiceClient;
+import com.lgcns.dto.request.PaymentReadyRequest;
+import com.lgcns.dto.response.*;
+import com.lgcns.enums.MemberAge;
+import com.lgcns.enums.MemberGender;
+import com.lgcns.enums.MemberRole;
+import com.lgcns.enums.MemberStatus;
+import com.lgcns.error.exception.CustomException;
+import com.lgcns.exception.PaymentErrorCode;
+import com.lgcns.repository.PaymentRepository;
+import com.lgcns.service.PaymentServiceImpl;
+import java.util.List;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class PaymentServiceUnitTest {
+
+    @InjectMocks private PaymentServiceImpl paymentService;
+    @Mock private PaymentRepository paymentRepository;
+
+    @Mock private MemberServiceClient memberServiceClient;
+    @Mock private ManagerServiceClient managerServiceClient;
+
+    @Nested
+    class 결제_준비할_때 {
+
+        @Test
+        void 유효한_요청이라면_결제_준비_정보를_응답한다() {
+            // given
+            PaymentReadyRequest request =
+                    new PaymentReadyRequest(
+                            1L,
+                            List.of(
+                                    new PaymentReadyRequest.Item(9L, 1),
+                                    new PaymentReadyRequest.Item(17L, 3)));
+
+            stubMemberInfo();
+            stubItemDetails();
+
+            // when
+            PaymentReadyResponse response = paymentService.preparePayment("1", request);
+
+            // then
+            Assertions.assertAll(
+                    () -> assertThat(response.buyerName()).isEqualTo("현태"),
+                    () -> assertThat(response.name()).isEqualTo("피규어 지수 외 1건"),
+                    () -> assertThat(response.amount()).isEqualTo(129000),
+                    () ->
+                            assertThat(response.merchantUid())
+                                    .matches("^popup_1_order_[0-9a-fA-F\\-]{16}$"));
+        }
+
+        @Test
+        void 존재하지_않는_itemId가_포함되어_있다면_예외가_발생한다() {
+            // given
+            PaymentReadyRequest request =
+                    new PaymentReadyRequest(
+                            1L,
+                            List.of(
+                                    new PaymentReadyRequest.Item(9L, 1),
+                                    new PaymentReadyRequest.Item(999L, 3)));
+
+            stubMemberInfo();
+            stubItemDetails();
+
+            // when & then
+            assertThatThrownBy(() -> paymentService.preparePayment("1", request))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(PaymentErrorCode.ITEM_NOT_FOUND.getMessage());
+        }
+
+        @Test
+        void 재고보다_많은_수량을_요청하면_OUT_OF_STOCK_예외가_발생한다() {
+            // given
+            PaymentReadyRequest request =
+                    new PaymentReadyRequest(
+                            1L,
+                            List.of(
+                                    new PaymentReadyRequest.Item(9L, 1),
+                                    new PaymentReadyRequest.Item(17L, 12)));
+
+            stubMemberInfo();
+            stubItemDetails();
+
+            // when & then
+            assertThatThrownBy(() -> paymentService.preparePayment("1", request))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(PaymentErrorCode.OUT_OF_STOCK.getMessage());
+        }
+
+        private void stubMemberInfo() {
+            when(memberServiceClient.findMemberInfo(anyLong()))
+                    .thenReturn(
+                            new MemberInternalInfoResponse(
+                                    1L,
+                                    "현태",
+                                    MemberAge.TWENTIES,
+                                    MemberGender.MALE,
+                                    MemberRole.USER,
+                                    MemberStatus.NORMAL));
+        }
+
+        private void stubItemDetails() {
+            when(managerServiceClient.findItemsForPayment(
+                            anyLong(), any(ItemIdsForPaymentRequest.class)))
+                    .thenReturn(
+                            List.of(
+                                    new ItemForPaymentResponse(9L, "피규어 지수", 84000, 20),
+                                    new ItemForPaymentResponse(17L, "크룽크 미니백", 15000, 10)));
+        }
+    }
+}

--- a/popi-payment-service/src/test/java/com/lgcns/service/unit/PaymentServiceUnitTest.java
+++ b/popi-payment-service/src/test/java/com/lgcns/service/unit/PaymentServiceUnitTest.java
@@ -1,28 +1,38 @@
 package com.lgcns.service.unit;
 
-import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.when;
 
 import com.lgcns.client.managerClient.ManagerServiceClient;
 import com.lgcns.client.managerClient.dto.request.ItemIdsForPaymentRequest;
 import com.lgcns.client.managerClient.dto.response.ItemForPaymentResponse;
 import com.lgcns.client.memberClient.MemberServiceClient;
+import com.lgcns.domain.Payment;
+import com.lgcns.domain.PaymentStatus;
 import com.lgcns.dto.request.PaymentReadyRequest;
-import com.lgcns.dto.response.*;
+import com.lgcns.dto.response.MemberInternalInfoResponse;
+import com.lgcns.dto.response.PaymentReadyResponse;
 import com.lgcns.enums.MemberAge;
 import com.lgcns.enums.MemberGender;
 import com.lgcns.enums.MemberRole;
 import com.lgcns.enums.MemberStatus;
 import com.lgcns.error.exception.CustomException;
 import com.lgcns.exception.PaymentErrorCode;
+import com.lgcns.kafka.producer.ItemPurchasedProducer;
 import com.lgcns.repository.PaymentRepository;
 import com.lgcns.service.PaymentServiceImpl;
+import com.siot.IamportRestClient.IamportClient;
+import com.siot.IamportRestClient.exception.IamportResponseException;
+import com.siot.IamportRestClient.response.IamportResponse;
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.util.Date;
 import java.util.List;
+import java.util.Optional;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -38,6 +48,11 @@ public class PaymentServiceUnitTest {
 
     @Mock private MemberServiceClient memberServiceClient;
     @Mock private ManagerServiceClient managerServiceClient;
+
+    @Mock IamportClient iamportClient;
+    @Mock IamportResponse<com.siot.IamportRestClient.response.Payment> iamportResponse;
+    @Mock com.siot.IamportRestClient.response.Payment iamportPayment;
+    @Mock ItemPurchasedProducer itemPurchasedProducer;
 
     @Nested
     class 결제_준비할_때 {
@@ -125,6 +140,80 @@ public class PaymentServiceUnitTest {
                             List.of(
                                     new ItemForPaymentResponse(9L, "피규어 지수", 84000, 20),
                                     new ItemForPaymentResponse(17L, "크룽크 미니백", 15000, 10)));
+        }
+    }
+
+    @Nested
+    class 결제_검증할_때 {
+
+        private final String merchantUid = "popup_1_order_test-uuid";
+        private final BigDecimal amount = BigDecimal.valueOf(129000);
+
+        @BeforeEach
+        void setUp() {
+            Payment payment = Payment.createPayment(1L, merchantUid, 129000, 1L);
+            when(paymentRepository.findByMerchantUid(merchantUid)).thenReturn(Optional.of(payment));
+        }
+
+        @Test
+        void impUid와_결제정보가_일치하면_결제정보를_업데이트한다() throws IOException, IamportResponseException {
+            // given
+            when(iamportClient.paymentByImpUid(anyString())).thenReturn(iamportResponse);
+            when(iamportResponse.getResponse()).thenReturn(iamportPayment);
+
+            when(iamportPayment.getMerchantUid()).thenReturn(merchantUid);
+            when(iamportPayment.getPgProvider()).thenReturn("tosspay");
+            when(iamportPayment.getAmount()).thenReturn(amount);
+            when(iamportPayment.getStatus()).thenReturn("PAID");
+            when(iamportPayment.getPaidAt()).thenReturn(new Date());
+
+            // when
+            paymentService.findPaymentByImpUid("testImpUid");
+
+            // then
+            Payment payment =
+                    paymentRepository.findByMerchantUid("popup_1_order_test-uuid").orElseThrow();
+            Assertions.assertAll(
+                    () -> assertThat(payment.getAmount()).isEqualTo(129000),
+                    () -> assertThat(payment.getStatus()).isEqualTo(PaymentStatus.PAID),
+                    () -> assertThat(payment.getMerchantUid()).isEqualTo(merchantUid),
+                    () -> assertThat(payment.getPgProvider()).isEqualTo("tosspay"));
+        }
+
+        @Test
+        void 결제_금액이_다르면_예외가_발생한다() throws IOException, IamportResponseException {
+            // given
+            when(iamportClient.paymentByImpUid(anyString())).thenReturn(iamportResponse);
+            when(iamportResponse.getResponse()).thenReturn(iamportPayment);
+
+            when(iamportPayment.getMerchantUid()).thenReturn(merchantUid);
+            when(iamportPayment.getPgProvider()).thenReturn("tosspay");
+            when(iamportPayment.getAmount()).thenReturn(BigDecimal.valueOf(1000));
+            when(iamportPayment.getStatus()).thenReturn("PAID");
+            when(iamportPayment.getPaidAt()).thenReturn(new Date());
+
+            // when & then
+            assertThatThrownBy(() -> paymentService.findPaymentByImpUid("testImpUid"))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(PaymentErrorCode.INVALID_AMOUNT.getMessage());
+        }
+
+        @Test
+        void 결제_상태가_PAID가_아니면_예외가_발생한다() throws IOException, IamportResponseException {
+            // given
+            when(iamportClient.paymentByImpUid(anyString())).thenReturn(iamportResponse);
+            when(iamportResponse.getResponse()).thenReturn(iamportPayment);
+
+            when(iamportPayment.getMerchantUid()).thenReturn(merchantUid);
+            when(iamportPayment.getPgProvider()).thenReturn("tosspay");
+            when(iamportPayment.getAmount()).thenReturn(amount);
+            when(iamportPayment.getStatus()).thenReturn("READY");
+            when(iamportPayment.getPaidAt()).thenReturn(new Date());
+
+            // when & then
+            assertThatThrownBy(() -> paymentService.findPaymentByImpUid("testImpUid"))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(PaymentErrorCode.NOT_PAID.getMessage());
         }
     }
 }

--- a/popi-payment-service/src/test/java/com/lgcns/service/unit/PaymentServiceUnitTest.java
+++ b/popi-payment-service/src/test/java/com/lgcns/service/unit/PaymentServiceUnitTest.java
@@ -12,6 +12,7 @@ import com.lgcns.client.memberClient.MemberServiceClient;
 import com.lgcns.domain.Payment;
 import com.lgcns.domain.PaymentStatus;
 import com.lgcns.dto.request.PaymentReadyRequest;
+import com.lgcns.dto.response.ItemBuyerCountResponse;
 import com.lgcns.dto.response.MemberInternalInfoResponse;
 import com.lgcns.dto.response.PaymentReadyResponse;
 import com.lgcns.enums.MemberAge;
@@ -214,6 +215,35 @@ public class PaymentServiceUnitTest {
             assertThatThrownBy(() -> paymentService.findPaymentByImpUid("testImpUid"))
                     .isInstanceOf(CustomException.class)
                     .hasMessage(PaymentErrorCode.NOT_PAID.getMessage());
+        }
+    }
+
+    @Nested
+    class 관리자_서비스의_상품별_구매자_수_조회_요청을_처리할_때 {
+
+        @Test
+        void 상품별_구매자_수를_정상적으로_조회한다() {
+            // given
+            Long popupId = 1L;
+
+            when(paymentRepository.countItemBuyerByPopupId(popupId))
+                    .thenReturn(
+                            List.of(
+                                    new ItemBuyerCountResponse(1L, 2),
+                                    new ItemBuyerCountResponse(2L, 1),
+                                    new ItemBuyerCountResponse(3L, 1)));
+
+            // when
+            List<ItemBuyerCountResponse> result = paymentService.countItemBuyerByPopupId(popupId);
+
+            // then
+            Assertions.assertAll(
+                    () -> assertThat(result.get(0).itemId()).isEqualTo(1L),
+                    () -> assertThat(result.get(0).buyerCount()).isEqualTo(2),
+                    () -> assertThat(result.get(1).itemId()).isEqualTo(2L),
+                    () -> assertThat(result.get(1).buyerCount()).isEqualTo(1),
+                    () -> assertThat(result.get(2).itemId()).isEqualTo(3L),
+                    () -> assertThat(result.get(2).buyerCount()).isEqualTo(1));
         }
     }
 }

--- a/popi-payment-service/src/test/java/com/lgcns/service/unit/PaymentServiceUnitTest.java
+++ b/popi-payment-service/src/test/java/com/lgcns/service/unit/PaymentServiceUnitTest.java
@@ -13,10 +13,7 @@ import com.lgcns.domain.Payment;
 import com.lgcns.domain.PaymentStatus;
 import com.lgcns.dto.FlatPaymentItem;
 import com.lgcns.dto.request.PaymentReadyRequest;
-import com.lgcns.dto.response.ItemBuyerCountResponse;
-import com.lgcns.dto.response.MemberInternalInfoResponse;
-import com.lgcns.dto.response.PaymentHistoryResponse;
-import com.lgcns.dto.response.PaymentReadyResponse;
+import com.lgcns.dto.response.*;
 import com.lgcns.enums.MemberAge;
 import com.lgcns.enums.MemberGender;
 import com.lgcns.enums.MemberRole;
@@ -299,6 +296,26 @@ public class PaymentServiceUnitTest {
             assertThat(second.popupId()).isEqualTo(2L);
             assertThat(second.items().get(0).itemName()).isEqualTo("크레용 파란색");
             assertThat(second.items().get(0).price()).isEqualTo(12000);
+        }
+    }
+
+    @Nested
+    class 관리자_서비스의_1인_평균_구매액_조회_요청을_처리할_때 {
+
+        @Test
+        void 평균_구매액을_정상적으로_조회한다() {
+            // given
+            Long popupId = 1L;
+
+            when(paymentRepository.findAverageAmountByPopupId(anyLong()))
+                    .thenReturn(new AverageAmountResponse(31333, 24500));
+
+            // when
+            AverageAmountResponse response = paymentService.findAverageAmount(popupId);
+
+            // then
+            assertThat(response.totalAverageAmount()).isEqualTo(31333);
+            assertThat(response.todayAverageAmount()).isEqualTo(24500);
         }
     }
 }


### PR DESCRIPTION
## 🌱 관련 이슈

- [LCR-313]

---
## 📌 작업 내용 및 특이사항

- 기존 통합 테스트(PaymentServiceIntegrationTest) 외에 PaymentService의 단위 테스트를 추가 작성했습니다.
- PaymentServiceImpl은 ```@InjectMocks```로 주입하고, PaymentRepository, IamportClient, Kafka Producer 등 외부 의존성은 ```@Mock``` 처리하여 테스트의 독립성과 신뢰성을 확보했습니다.
- JPA 기반 객체 저장 없이, given()으로 필요한 mock 응답을 설정해 테스트의 속도와 유지보수성을 높였습니다..
- 내부 상태 확인을 위해 더 이상 repository.findBy...로 다시 조회하지 않고, 스텁 객체 상태를 직접 검증하도록 개선했습니다.
- 메서드 내부에서 외부 서비스 호출이 중요한 테스트에서는 verify(...)를 활용해 호출 여부를 명시적으로 검증했습니다.
- ArgumentMatchers.any() 등 사용: 입력값 자체는 테스트 대상이 아니므로, 반환값 중심의 테스트를 위해 any(), anyString() 등 매처 사용
- Kafka Producer는 실제 메시지 전송 여부는 테스트 범위에 포함하지 않기 때문에 ```@Mock```만 처리하였습니다.
- 중복되는 stub 설정(stubMemberInfo(), stubItemDetails(), stubIamportResponse())을 메서드로 추출해 가독성 개선하였습니다.

---
## 📚 참고사항

- given 블록 stub 세팅 순서와 단위 테스트 작성법은 인증과 회원 서비스 단위 테스트 작성 PR에 각각 있으니 그 부분 참고하시길 바랍니다!

[LCR-313]: https://lgcns-retail.atlassian.net/browse/LCR-313?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ