### PR TITLE
test: 상품 서비스 단위 테스트 작성

### DIFF
--- a/popi-item-service/src/test/java/com/lgcns/service/integration/ItemServiceIntegrationTest.java
+++ b/popi-item-service/src/test/java/com/lgcns/service/integration/ItemServiceIntegrationTest.java
@@ -1,4 +1,4 @@
-package com.lgcns.service;
+package com.lgcns.service.integration;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
@@ -7,9 +7,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.tomakehurst.wiremock.client.MappingBuilder;
-import com.lgcns.WireMockIntegrationTest;
 import com.lgcns.dto.response.ItemInfoResponse;
 import com.lgcns.response.SliceResponse;
+import com.lgcns.service.ItemService;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -20,7 +20,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 
-public class ItemServiceTest extends WireMockIntegrationTest {
+public class ItemServiceIntegrationTest extends WireMockIntegrationTest {
 
     @Autowired private ItemService itemService;
     @Autowired private ObjectMapper objectMapper;

--- a/popi-item-service/src/test/java/com/lgcns/service/integration/WireMockIntegrationTest.java
+++ b/popi-item-service/src/test/java/com/lgcns/service/integration/WireMockIntegrationTest.java
@@ -1,4 +1,4 @@
-package com.lgcns;
+package com.lgcns.service.integration;
 
 import com.github.tomakehurst.wiremock.WireMockServer;
 import org.junit.jupiter.api.AfterEach;

--- a/popi-item-service/src/test/java/com/lgcns/service/unit/ItemServiceUnitTest.java
+++ b/popi-item-service/src/test/java/com/lgcns/service/unit/ItemServiceUnitTest.java
@@ -1,0 +1,16 @@
+package com.lgcns.service.unit;
+
+import com.lgcns.client.ManagerServiceClient;
+import com.lgcns.service.ItemServiceImpl;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class ItemServiceUnitTest {
+
+    @InjectMocks private ItemServiceImpl itemService;
+
+    @Mock private ManagerServiceClient managerServiceClient;
+}

--- a/popi-item-service/src/test/java/com/lgcns/service/unit/ItemServiceUnitTest.java
+++ b/popi-item-service/src/test/java/com/lgcns/service/unit/ItemServiceUnitTest.java
@@ -1,7 +1,22 @@
 package com.lgcns.service.unit;
 
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.times;
+
 import com.lgcns.client.ManagerServiceClient;
+import com.lgcns.dto.response.ItemInfoResponse;
+import com.lgcns.response.SliceResponse;
 import com.lgcns.service.ItemServiceImpl;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
@@ -13,4 +28,347 @@ public class ItemServiceUnitTest {
     @InjectMocks private ItemServiceImpl itemService;
 
     @Mock private ManagerServiceClient managerServiceClient;
+
+    @Nested
+    class 상품_목록을_조회할_때 {
+
+        @Test
+        void 데이터가_존재하면_상품_목록_조회에_성공한다() {
+            // given
+            given(managerServiceClient.findItemsByName(anyLong(), isNull(), isNull(), anyInt()))
+                    .willReturn(
+                            new SliceResponse<>(
+                                    List.of(
+                                            new ItemInfoResponse(
+                                                    24L,
+                                                    "크룽크 빅쿠션",
+                                                    "https://ygselect.com/web/product/big/shop1_c46529e55a48ad83a68b0f78540465e8.jpg",
+                                                    25000),
+                                            new ItemInfoResponse(
+                                                    23L,
+                                                    "크룽크 미니쿠션",
+                                                    "https://ygselect.com/web/product/big/shop1_6e08c64b2daaf6f2142cbd32c9c7a38a.jpg",
+                                                    18000),
+                                            new ItemInfoResponse(
+                                                    22L,
+                                                    "크룽크 키링",
+                                                    "https://ygselect.com/web/product/big/shop1_d2725a478a33ccaa10b1b7f8697f5c9d.png",
+                                                    14000),
+                                            new ItemInfoResponse(
+                                                    21L,
+                                                    "크룽크 손목인형",
+                                                    "https://ygselect.com/web/product/big/202403/P0000HDL.jpg",
+                                                    7000)),
+                                    false));
+
+            // when
+            SliceResponse<ItemInfoResponse> result = itemService.findItemsByName(1L, null, null, 4);
+
+            // then
+            verify(managerServiceClient, times(1))
+                    .findItemsByName(anyLong(), isNull(), isNull(), anyInt());
+            Assertions.assertAll(
+                    () -> assertThat(result).isNotNull(),
+                    () -> assertThat(result.content()).hasSize(4),
+
+                    // 각 항목의 필드 검증
+                    () -> assertThat(result.content().get(0).itemId()).isEqualTo(24L),
+                    () -> assertThat(result.content().get(1).itemId()).isEqualTo(23L),
+                    () -> assertThat(result.content().get(2).itemId()).isEqualTo(22L),
+                    () -> assertThat(result.content().get(3).itemId()).isEqualTo(21L),
+                    () -> assertThat(result.isLast()).isFalse());
+        }
+
+        @Test
+        void 마지막_상품까지_조회하면_is_last가_true를_반환한다() {
+            // given
+            given(managerServiceClient.findItemsByName(anyLong(), isNull(), anyLong(), anyInt()))
+                    .willReturn(
+                            new SliceResponse<>(
+                                    List.of(
+                                            new ItemInfoResponse(
+                                                    4L,
+                                                    "DAZED 리사",
+                                                    "https://image.aladin.co.kr/product/17920/59/cover500/k142534034_1.jpg",
+                                                    8000),
+                                            new ItemInfoResponse(
+                                                    3L,
+                                                    "DAZED 제니",
+                                                    "https://image.aladin.co.kr/product/28453/14/cover500/k572835617_1.jpg",
+                                                    9500),
+                                            new ItemInfoResponse(
+                                                    2L,
+                                                    "DAZED 로제",
+                                                    "https://ygselect.com/web/product/big/202404/257d66b0a1eca57af67b6c792e68ed75.jpg",
+                                                    15000),
+                                            new ItemInfoResponse(
+                                                    1L,
+                                                    "DAZED 지수",
+                                                    "https://ygselect.com/web/product/big/202402/P0000NMY.jpg",
+                                                    15000)),
+                                    true));
+
+            // when
+            SliceResponse<ItemInfoResponse> result = itemService.findItemsByName(1L, null, 5L, 4);
+
+            // then
+            verify(managerServiceClient, times(1))
+                    .findItemsByName(anyLong(), isNull(), anyLong(), anyInt());
+            Assertions.assertAll(
+                    () -> assertThat(result).isNotNull(),
+                    () -> assertThat(result.content()).hasSize(4),
+
+                    // 각 항목의 필드 검증
+                    () -> assertThat(result.content().get(0).itemId()).isEqualTo(4L),
+                    () -> assertThat(result.content().get(1).itemId()).isEqualTo(3L),
+                    () -> assertThat(result.content().get(2).itemId()).isEqualTo(2L),
+                    () -> assertThat(result.content().get(3).itemId()).isEqualTo(1L),
+                    () -> assertThat(result.isLast()).isTrue());
+        }
+    }
+
+    @Nested
+    class 상품_목록을_검색할_때 {
+
+        @Test
+        void 검색어에_대해_결과가_존재하면_상품_검색에_성공한다() {
+            // given
+            given(managerServiceClient.findItemsByName(anyLong(), anyString(), isNull(), anyInt()))
+                    .willReturn(
+                            new SliceResponse<>(
+                                    List.of(
+                                            new ItemInfoResponse(
+                                                    4L,
+                                                    "DAZED 리사",
+                                                    "https://image.aladin.co.kr/product/17920/59/cover500/k142534034_1.jpg",
+                                                    8000),
+                                            new ItemInfoResponse(
+                                                    3L,
+                                                    "DAZED 제니",
+                                                    "https://image.aladin.co.kr/product/28453/14/cover500/k572835617_1.jpg",
+                                                    9500),
+                                            new ItemInfoResponse(
+                                                    2L,
+                                                    "DAZED 로제",
+                                                    "https://ygselect.com/web/product/big/202404/257d66b0a1eca57af67b6c792e68ed75.jpg",
+                                                    15000),
+                                            new ItemInfoResponse(
+                                                    1L,
+                                                    "DAZED 지수",
+                                                    "https://ygselect.com/web/product/big/202402/P0000NMY.jpg",
+                                                    15000)),
+                                    true));
+
+            // when
+            SliceResponse<ItemInfoResponse> result =
+                    itemService.findItemsByName(1L, "DAZED", null, 4);
+
+            // then
+            verify(managerServiceClient, times(1))
+                    .findItemsByName(anyLong(), anyString(), isNull(), anyInt());
+            Assertions.assertAll(
+                    () -> assertThat(result).isNotNull(),
+                    () -> assertThat(result.content()).hasSize(4),
+                    () -> assertThat(result.isLast()).isTrue(),
+                    () ->
+                            assertThat(result.content())
+                                    .allSatisfy(item -> assertThat(item.name()).contains("DAZED")));
+        }
+
+        @Test
+        void 검색어에_대해_결과가_없으면_빈_리스트를_반환한다() {
+            // given
+            given(managerServiceClient.findItemsByName(anyLong(), anyString(), isNull(), anyInt()))
+                    .willReturn(new SliceResponse<>(List.of(), true));
+
+            // when
+            SliceResponse<ItemInfoResponse> result =
+                    itemService.findItemsByName(1L, "EMPTY", null, 4);
+
+            // then
+            verify(managerServiceClient, times(1))
+                    .findItemsByName(anyLong(), anyString(), isNull(), anyInt());
+            Assertions.assertAll(
+                    () -> assertThat(result).isNotNull(),
+                    () -> assertThat(result.content()).isEmpty(),
+                    () -> assertThat(result.isLast()).isTrue());
+        }
+    }
+
+    @Nested
+    class 기본_상품_목록을_조회할_때 {
+        @Test
+        void 무작위로_선택된_4개의_상품_조회에_성공한다() {
+            // given
+            given(managerServiceClient.findItemsDefault(anyLong()))
+                    .willReturn(
+                            List.of(
+                                    new ItemInfoResponse(
+                                            18L,
+                                            "크룽크 라운드백",
+                                            "https://ygselect.com/web/product/big/shop1_cdf3bd187203a3987f4c262e73061334.png",
+                                            20000),
+                                    new ItemInfoResponse(
+                                            4L,
+                                            "DAZED 리사",
+                                            "https://image.aladin.co.kr/product/17920/59/cover500/k142534034_1.jpg",
+                                            8000),
+                                    new ItemInfoResponse(
+                                            17L,
+                                            "크룽크 미니백",
+                                            "https://ygselect.com/web/product/big/shop1_738be1088b092afab065be5299d5e2a4.png",
+                                            15000),
+                                    new ItemInfoResponse(
+                                            9L,
+                                            "피규어 지수",
+                                            "https://m.ygselect.com/web/product/big/202110/51086d5fd28f00991986031b2ed3f742.jpg",
+                                            84000)));
+
+            // when
+            List<ItemInfoResponse> result = itemService.findItemsDefault(1L);
+
+            // then
+            verify(managerServiceClient, times(1)).findItemsDefault(anyLong());
+            Assertions.assertAll(
+                    () -> assertThat(result).isNotNull(),
+                    () -> assertThat(result).hasSize(4),
+                    () -> assertThat(new HashSet<>(result)).hasSize(result.size()));
+        }
+
+        @Test
+        void 상품_데이터가_4개보다_적으면_전체_데이터_수_만큼_상품이_조회된다() {
+            // given
+            given(managerServiceClient.findItemsDefault(anyLong()))
+                    .willReturn(
+                            List.of(
+                                    new ItemInfoResponse(
+                                            18L,
+                                            "크룽크 라운드백",
+                                            "https://ygselect.com/web/product/big/shop1_cdf3bd187203a3987f4c262e73061334.png",
+                                            20000),
+                                    new ItemInfoResponse(
+                                            4L,
+                                            "DAZED 리사",
+                                            "https://image.aladin.co.kr/product/17920/59/cover500/k142534034_1.jpg",
+                                            8000),
+                                    new ItemInfoResponse(
+                                            9L,
+                                            "피규어 지수",
+                                            "https://m.ygselect.com/web/product/big/202110/51086d5fd28f00991986031b2ed3f742.jpg",
+                                            84000)));
+
+            // when
+            List<ItemInfoResponse> result = itemService.findItemsDefault(1L);
+
+            // then
+            verify(managerServiceClient, times(1)).findItemsDefault(anyLong());
+            Assertions.assertAll(
+                    () -> assertThat(result).isNotNull(),
+                    () -> assertThat(result).hasSize(3),
+                    () -> assertThat(new HashSet<>(result)).hasSize(result.size()));
+        }
+    }
+
+    @Nested
+    class 인기_상품_목록을_조회할_때 {
+        @Test
+        void 집계된_데이터가_3개_이상인_경우_인기_상품_전체_조회에_성공한다() {
+            // given
+            given(managerServiceClient.findItemsPopularity(anyLong()))
+                    .willReturn(
+                            List.of(
+                                    new ItemInfoResponse(
+                                            18L,
+                                            "크룽크 라운드백",
+                                            "https://ygselect.com/web/product/big/shop1_cdf3bd187203a3987f4c262e73061334.png",
+                                            20000),
+                                    new ItemInfoResponse(
+                                            4L,
+                                            "DAZED 리사",
+                                            "https://image.aladin.co.kr/product/17920/59/cover500/k142534034_1.jpg",
+                                            8000),
+                                    new ItemInfoResponse(
+                                            9L,
+                                            "피규어 지수",
+                                            "https://m.ygselect.com/web/product/big/202110/51086d5fd28f00991986031b2ed3f742.jpg",
+                                            84000)));
+
+            // when
+            List<ItemInfoResponse> result = itemService.findItemsPopularity(1L);
+
+            // then
+            verify(managerServiceClient, times(1)).findItemsPopularity(anyLong());
+            Assertions.assertAll(
+                    () -> assertThat(result).isNotNull(),
+                    () -> assertThat(result).hasSize(3),
+                    () ->
+                            assertThat(new HashSet<>(Objects.requireNonNull(result)))
+                                    .hasSize(result.size()));
+        }
+
+        @Test
+        void 집계된_데이터가_2개_경우_인기_상품_2개_조회에_성공한다() {
+            // given
+            given(managerServiceClient.findItemsPopularity(anyLong()))
+                    .willReturn(
+                            List.of(
+                                    new ItemInfoResponse(
+                                            18L,
+                                            "크룽크 라운드백",
+                                            "https://ygselect.com/web/product/big/shop1_cdf3bd187203a3987f4c262e73061334.png",
+                                            20000),
+                                    new ItemInfoResponse(
+                                            4L,
+                                            "DAZED 리사",
+                                            "https://image.aladin.co.kr/product/17920/59/cover500/k142534034_1.jpg",
+                                            8000)));
+
+            // when
+            List<ItemInfoResponse> result = itemService.findItemsPopularity(1L);
+
+            // then
+            verify(managerServiceClient, times(1)).findItemsPopularity(anyLong());
+            Assertions.assertAll(
+                    () -> assertThat(result).isNotNull(),
+                    () -> assertThat(result).hasSize(2),
+                    () ->
+                            assertThat(new HashSet<>(Objects.requireNonNull(result)))
+                                    .hasSize(result.size()));
+        }
+
+        @Test
+        void 집계된_데이터가_1개인_경우_인기_상품_1개_조회에_성공한다() {
+            // given
+            given(managerServiceClient.findItemsPopularity(anyLong()))
+                    .willReturn(
+                            List.of(
+                                    new ItemInfoResponse(
+                                            18L,
+                                            "크룽크 라운드백",
+                                            "https://ygselect.com/web/product/big/shop1_cdf3bd187203a3987f4c262e73061334.png",
+                                            20000)));
+
+            // when
+            List<ItemInfoResponse> result = itemService.findItemsPopularity(1L);
+
+            // then
+            verify(managerServiceClient, times(1)).findItemsPopularity(anyLong());
+            Assertions.assertAll(
+                    () -> assertThat(result).isNotNull(), () -> assertThat(result).hasSize(1));
+        }
+
+        @Test
+        void 집계된_데이터가_없는_경우_빈_리스트를_반환한다() {
+            // given
+            given(managerServiceClient.findItemsPopularity(anyLong())).willReturn(List.of());
+
+            // when
+            List<ItemInfoResponse> result = itemService.findItemsPopularity(1L);
+
+            // then
+            verify(managerServiceClient, times(1)).findItemsPopularity(anyLong());
+            Assertions.assertAll(
+                    () -> assertThat(result).isNotNull(), () -> assertThat(result).isEmpty());
+        }
+    }
 }

--- a/popi-item-service/src/test/java/com/lgcns/service/unit/ItemServiceUnitTest.java
+++ b/popi-item-service/src/test/java/com/lgcns/service/unit/ItemServiceUnitTest.java
@@ -1,6 +1,5 @@
 package com.lgcns.service.unit;
 
-import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.given;


### PR DESCRIPTION
## 🌱 관련 이슈

- [LCR-318]

---
## 📌 작업 내용 및 특이사항

- 기존 통합 테스트(ItemServiceIntegrationTest) 외에 ItemService의 단위 테스트를 추가 작성했습니다.
- ItemServiceImpl은 ```@InjectMocks```로 주입하고, Open Feign 호출을 위한 외부 의존성 ManagerServiceClient는 ```@Mock``` 처리하여 테스트의 독립성과 신뢰성을 확보했습니다.
- given()으로 필요한 mock 응답을 설정해 테스트의 속도와 유지보수성을 높였습니다..
- 메서드 내부에서 외부 서비스 호출이 중요한 테스트에서는 verify(...)를 활용해 호출 여부를 명시적으로 검증했습니다.
- ArgumentMatchers.any() 등 사용: 입력값 자체는 테스트 대상이 아니므로, 반환값 중심의 테스트를 위해 any(), anyString() 등 매처 사용
- ItemService의 모든 단위 테스트는 FeignClient에 의존하지만, 테스트 별로 FeignClient 호출 시 파라미터와 요구하는 응답 내용이 상이하므로 stub 생성을 메서드로 묶지 않았습니다.

---
## 📚 참고사항

-


[LCR-318]: https://lgcns-retail.atlassian.net/browse/LCR-318?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ