### PR TITLE
test: 알림 서비스 단위 테스트 작성

### DIFF
--- a/popi-notification-service/src/main/java/com/lgcns/externalApi/NotificationController.java
+++ b/popi-notification-service/src/main/java/com/lgcns/externalApi/NotificationController.java
@@ -1,11 +1,15 @@
 package com.lgcns.externalApi;
 
+import com.google.api.core.ApiFuture;
 import com.lgcns.dto.request.FcmRequest;
+import com.lgcns.service.FcmService;
 import com.lgcns.service.NotificationService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import java.util.concurrent.ExecutionException;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -13,9 +17,11 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequiredArgsConstructor
 @Tag(name = "알림 서버 API", description = "알림 서버 API 입니다.")
+@Slf4j
 public class NotificationController {
 
     private final NotificationService notificationService;
+    private final FcmService fcmService;
 
     @PostMapping("/fcm/register")
     @Operation(summary = "FCM 토큰 등록", description = "사용자 디바이스의 FCM 토큰을 등록합니다.")
@@ -24,5 +30,17 @@ public class NotificationController {
             @Valid @RequestBody FcmRequest fcmRequest) {
         notificationService.saveFcmToken(memberId, fcmRequest.fcmToken());
         return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+
+    @PostMapping("/test")
+    public ResponseEntity<String> test(@RequestParam(name = "fcmToken") String fcmToken)
+            throws ExecutionException, InterruptedException {
+        try {
+            ApiFuture<String> message = fcmService.sendMessageSync(fcmToken);
+            return ResponseEntity.status(HttpStatus.CREATED).body(message.get());
+        } catch (ExecutionException e) {
+            log.error("ExecutionException 발생: {}", e.getCause().getMessage(), e.getCause());
+            throw e; // 또는 예외 래핑해서 throw
+        }
     }
 }

--- a/popi-notification-service/src/test/java/com/lgcns/batch/NotificationJobTest.java
+++ b/popi-notification-service/src/test/java/com/lgcns/batch/NotificationJobTest.java
@@ -4,9 +4,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.mockito.Mockito.doThrow;
 
-import com.lgcns.NotificationIntegrationTest;
 import com.lgcns.error.exception.CustomException;
 import com.lgcns.exception.NotificationErrorCode;
+import com.lgcns.service.integration.NotificationIntegrationTest;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import org.junit.jupiter.api.BeforeEach;

--- a/popi-notification-service/src/test/java/com/lgcns/service/integration/NotificationIntegrationTest.java
+++ b/popi-notification-service/src/test/java/com/lgcns/service/integration/NotificationIntegrationTest.java
@@ -1,4 +1,4 @@
-package com.lgcns;
+package com.lgcns.service.integration;
 
 import com.lgcns.service.FcmService;
 import org.springframework.boot.test.context.SpringBootTest;

--- a/popi-notification-service/src/test/java/com/lgcns/service/integration/NotificationServiceIntegrationTest.java
+++ b/popi-notification-service/src/test/java/com/lgcns/service/integration/NotificationServiceIntegrationTest.java
@@ -4,7 +4,6 @@ import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
-import com.lgcns.NotificationIntegrationTest;
 import com.lgcns.error.exception.CustomException;
 import com.lgcns.exception.NotificationErrorCode;
 import com.lgcns.service.NotificationService;

--- a/popi-notification-service/src/test/java/com/lgcns/service/integration/NotificationServiceIntegrationTest.java
+++ b/popi-notification-service/src/test/java/com/lgcns/service/integration/NotificationServiceIntegrationTest.java
@@ -1,4 +1,4 @@
-package com.lgcns.service;
+package com.lgcns.service.integration;
 
 import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.*;
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.*;
 import com.lgcns.NotificationIntegrationTest;
 import com.lgcns.error.exception.CustomException;
 import com.lgcns.exception.NotificationErrorCode;
+import com.lgcns.service.NotificationService;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.ArrayList;
@@ -16,7 +17,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.redis.core.RedisTemplate;
 
-public class NotificationServiceTest extends NotificationIntegrationTest {
+public class NotificationServiceIntegrationTest extends NotificationIntegrationTest {
 
     @Autowired private NotificationService notificationService;
     @Autowired private RedisTemplate<String, String> redisTemplate;

--- a/popi-notification-service/src/test/java/com/lgcns/service/unit/NotificationServiceUnitTest.java
+++ b/popi-notification-service/src/test/java/com/lgcns/service/unit/NotificationServiceUnitTest.java
@@ -1,0 +1,237 @@
+package com.lgcns.service.unit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+import com.lgcns.error.exception.CustomException;
+import com.lgcns.exception.NotificationErrorCode;
+import com.lgcns.service.FcmService;
+import com.lgcns.service.NotificationServiceImpl;
+import java.util.*;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataAccessException;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.data.redis.core.ZSetOperations;
+
+@ExtendWith(MockitoExtension.class)
+public class NotificationServiceUnitTest {
+
+    @InjectMocks private NotificationServiceImpl notificationService;
+    @Mock private RedisTemplate<String, String> redisTemplate;
+    @Mock private FcmService fcmService;
+    @Mock private ValueOperations<String, String> redisValueOperations;
+    @Mock private ZSetOperations<String, String> redisZSetOperations;
+
+    private static final String ZSET_KEY = "reservation:notifications";
+
+    @Nested
+    class 알림을_보낼_사용자_ID_리스트를_조회할_때 {
+
+        @Test
+        void 예약이_한_시간_남은_사용자가_존재하면_조회에_성공한다() {
+            // given
+            Long memberId1 = 1L;
+            Long memberId2 = 2L;
+            Long memberReservationId1 = 1L;
+            Long memberReservationId2 = 2L;
+
+            String member1 = memberId1 + "|" + memberReservationId1;
+            String member2 = memberId2 + "|" + memberReservationId2;
+
+            Set<String> mockZSetMembers = new LinkedHashSet<>(List.of(member1, member2));
+
+            given(redisTemplate.opsForZSet()).willReturn(redisZSetOperations);
+            given(redisZSetOperations.rangeByScore(anyString(), anyDouble(), anyDouble()))
+                    .willReturn(mockZSetMembers);
+
+            // when
+            List<Long> result = notificationService.findTargetMemberIds();
+
+            // then
+            verify(redisZSetOperations, times(1))
+                    .rangeByScore(eq(ZSET_KEY), anyDouble(), anyDouble());
+            verify(redisZSetOperations, times(1))
+                    .remove(eq(ZSET_KEY), eq(mockZSetMembers.toArray()));
+            assertAll(
+                    () -> assertThat(result).isNotNull(),
+                    () -> assertThat(result).hasSize(2),
+                    () -> assertThat(result).containsExactly(memberId1, memberId2),
+                    () -> assertThat(redisTemplate.opsForZSet().size(ZSET_KEY)).isEqualTo(0));
+        }
+
+        @Test
+        void 예약이_한_시간_남은_사용자가_없으면_빈_리스트를_반환한다() {
+            // given
+            Set<String> mockZSetMembers = Collections.emptySet();
+
+            given(redisTemplate.opsForZSet()).willReturn(redisZSetOperations);
+            given(redisZSetOperations.rangeByScore(anyString(), anyDouble(), anyDouble()))
+                    .willReturn(mockZSetMembers);
+
+            // when
+            List<Long> result = notificationService.findTargetMemberIds();
+
+            // then
+            verify(redisZSetOperations, times(1))
+                    .rangeByScore(eq(ZSET_KEY), anyDouble(), anyDouble());
+            assertAll(() -> assertThat(result).isNotNull(), () -> assertThat(result).hasSize(0));
+        }
+    }
+
+    @Nested
+    class FCM_토큰을_조회할_때 {
+
+        @Test
+        void Redis에_member_id에_대응하는_FCM_토큰이_존재하면_조회에_성공한다() {
+            // given
+            Long memberId = 1L;
+            String key = memberFcmKey(memberId);
+            String token = "token";
+
+            given(redisTemplate.opsForValue()).willReturn(redisValueOperations);
+            given(redisTemplate.opsForValue().get(key)).willReturn(token);
+
+            // when
+            String result = notificationService.findFcmToken(memberId);
+
+            // then
+            verify(redisValueOperations, times(1)).get(eq(key));
+            assertAll(
+                    () -> assertThat(result).isNotNull(),
+                    () -> assertThat(result).isEqualTo(token));
+        }
+
+        @Test
+        void Redis_접근_중_에러가_발생하면_예외를_반환한다() {
+            // given
+            Long memberId = 1L;
+            String key = memberFcmKey(memberId);
+
+            given(redisTemplate.opsForValue()).willReturn(redisValueOperations);
+            given(redisValueOperations.get(key))
+                    .willThrow(new DataAccessException("Redis error") {});
+
+            // when & then
+            assertThatThrownBy(() -> notificationService.findFcmToken(memberId))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessageContaining(NotificationErrorCode.REDIS_ACCESS_FAILED.getMessage());
+        }
+    }
+
+    @Nested
+    class 사용자에게_알림을_전송할_때 {
+
+        @Test
+        void FCM_토큰이_존재하면_전송에_성공한다() {
+            // given
+            List<String> tokens = List.of("token1", "token2");
+
+            // when
+            notificationService.sendNotification(tokens);
+
+            // then
+            verify(fcmService, times(2)).sendMessageSync(anyString());
+        }
+
+        @Test
+        void FCM_토큰이_없으면_전송하지_않는다() {
+            // given
+            List<String> tokens = new ArrayList<>();
+
+            // when
+            notificationService.sendNotification(tokens);
+
+            // then
+            verify(fcmService, never()).sendMessageSync(anyString());
+        }
+    }
+
+    @Nested
+    class FCM_토큰을_저장할_때 {
+
+        @Test
+        void 유효한_토큰이_포함되고_Redis에_동일한_토큰이_존재하지_않으면_저장에_성공한다() {
+            // given
+            String memberId = "1";
+            String token = "token";
+            String key = "memberId: " + memberId;
+
+            given(redisTemplate.opsForValue()).willReturn(redisValueOperations);
+
+            // when
+            notificationService.saveFcmToken(memberId, token);
+
+            // then
+            verify(redisValueOperations, times(1)).get(eq(key));
+            verify(redisTemplate, never()).delete(eq(key));
+            verify(redisValueOperations, times(1)).set(eq(key), anyString());
+        }
+
+        @Test
+        void Redis에_동일한_토큰이_존재하면_예외를_반환한다() {
+            // given
+            String memberId = "1";
+            String token = "token";
+            String key = "memberId: " + memberId;
+
+            given(redisTemplate.opsForValue()).willReturn(redisValueOperations);
+            given(redisValueOperations.get(eq(key))).willReturn(token);
+
+            // when & then
+            assertThatThrownBy(() -> notificationService.saveFcmToken(memberId, token))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(NotificationErrorCode.FCM_TOKEN_DUPLICATED.getMessage());
+        }
+
+        @Test
+        void 동일한_사용자에_대해_새로운_토큰이_포함되면_토큰을_갱신한다() {
+            // given
+            String memberId = "1";
+            String token1 = "token1";
+            String token2 = "token2";
+            String key = "memberId: " + memberId;
+
+            given(redisTemplate.opsForValue()).willReturn(redisValueOperations);
+            given(redisValueOperations.get(eq(key))).willReturn(token1);
+
+            // when
+            notificationService.saveFcmToken(memberId, token2);
+
+            // then
+            verify(redisValueOperations, times(1)).get(eq(key));
+            verify(redisTemplate, times(1)).delete(eq(key));
+            verify(redisValueOperations, times(1)).set(eq(key), anyString());
+        }
+
+        @Test
+        void Redis_접근_중_에러가_발생하면_예외를_반환한다() {
+            // given
+            String memberId = "1";
+            String key = "memberId: " + memberId;
+            String token = "token";
+
+            given(redisTemplate.opsForValue()).willReturn(redisValueOperations);
+            given(redisValueOperations.get(key))
+                    .willThrow(new DataAccessException("Redis error") {});
+
+            // when & then
+            assertThatThrownBy(() -> notificationService.saveFcmToken(memberId, token))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessageContaining(NotificationErrorCode.REDIS_ACCESS_FAILED.getMessage());
+        }
+    }
+
+    private String memberFcmKey(Long memberId) {
+        return "memberId: " + memberId;
+    }
+}


### PR DESCRIPTION
## 🌱 관련 이슈

- [LCR-341]

---
## 📌 작업 내용 및 특이사항

- 기존 통합 테스트(NotificationServiceIntegrationTest) 외에 NotificationService의 단위 테스트를 추가 작성했습니다.
- NotificationServiceImpl은 ```@InjectMocks```로 주입하고, Redis, FcmService는 ```@Mock``` 처리하여 테스트의 독립성과 신뢰성을 확보했습니다.
- given()으로 필요한 mock 응답을 설정해 테스트의 속도와 유지보수성을 높였습니다..
- 메서드 내부에서 외부 서비스 호출이 중요한 테스트에서는 verify(...)를 활용해 호출 여부를 명시적으로 검증했습니다.
- ArgumentMatchers.any() 등 사용: 입력값 자체는 테스트 대상이 아니므로, 반환값 중심의 테스트를 위해 any(), anyString() 등 매처 사용했습니다.
- 서비스 로직 검증을 위해 Mock처리한 일부 redisTemplate에 대해 given절을 추가하여 테스트를 위한 반환값을 설정했습니다.

---
## 📚 참고사항

-


[LCR-341]: https://lgcns-retail.atlassian.net/browse/LCR-341?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ