### PR TITLE
feat: HTTP 요청 & 응답 로깅 필터 도입

### DIFF
--- a/popi-api-gateway/build.gradle
+++ b/popi-api-gateway/build.gradle
@@ -24,4 +24,10 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
+    // Prometheus
+    implementation 'io.micrometer:micrometer-registry-prometheus'
+
+    // Grafana Loki
+    implementation 'com.github.loki4j:loki-logback-appender:1.5.1'
 }

--- a/popi-api-gateway/src/main/java/com/lgcns/logging/dto/HttpRequestLogInfo.java
+++ b/popi-api-gateway/src/main/java/com/lgcns/logging/dto/HttpRequestLogInfo.java
@@ -17,9 +17,11 @@ public record HttpRequestLogInfo(
 
     // WebFlux용 from 메서드
     public static HttpRequestLogInfo from(ServerHttpRequest request) {
+        String queryString = request.getURI().getQuery();
         String traceId = MDC.get("traceId");
         String requestMethod = request.getMethod().toString();
-        String requestUri = request.getURI().toString();
+        String requestUri =
+                request.getURI().getPath() + (queryString == null ? "" : "?" + queryString);
         String xAmznTraceId = request.getHeaders().getFirst("x-amzn-trace-id");
         String userAgent = request.getHeaders().getFirst("user-agent");
 

--- a/popi-api-gateway/src/main/java/com/lgcns/logging/dto/HttpRequestLogInfo.java
+++ b/popi-api-gateway/src/main/java/com/lgcns/logging/dto/HttpRequestLogInfo.java
@@ -15,7 +15,6 @@ public record HttpRequestLogInfo(
         String userAgent) {
     private static final ObjectMapper objectMapper = new ObjectMapper();
 
-    // WebFlux용 from 메서드
     public static HttpRequestLogInfo from(ServerHttpRequest request) {
         String queryString = request.getURI().getQuery();
         String traceId = MDC.get("traceId");

--- a/popi-api-gateway/src/main/java/com/lgcns/logging/dto/HttpRequestLogInfo.java
+++ b/popi-api-gateway/src/main/java/com/lgcns/logging/dto/HttpRequestLogInfo.java
@@ -1,0 +1,42 @@
+package com.lgcns.logging.dto;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.Builder;
+import org.slf4j.MDC;
+import org.springframework.http.server.reactive.ServerHttpRequest;
+
+@Builder
+public record HttpRequestLogInfo(
+        String traceId,
+        String requestMethod,
+        String requestUri,
+        String xAmznTraceId,
+        String userAgent) {
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+
+    // WebFlux용 from 메서드
+    public static HttpRequestLogInfo from(ServerHttpRequest request) {
+        String traceId = MDC.get("traceId");
+        String requestMethod = request.getMethod().toString();
+        String requestUri = request.getURI().toString();
+        String xAmznTraceId = request.getHeaders().getFirst("x-amzn-trace-id");
+        String userAgent = request.getHeaders().getFirst("user-agent");
+
+        return HttpRequestLogInfo.builder()
+                .traceId(traceId)
+                .requestMethod(requestMethod)
+                .requestUri(requestUri)
+                .xAmznTraceId(xAmznTraceId)
+                .userAgent(userAgent)
+                .build();
+    }
+
+    public String toJson() {
+        try {
+            return objectMapper.writeValueAsString(this).replace("\\", "");
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/popi-api-gateway/src/main/java/com/lgcns/logging/dto/HttpRequestLogInfo.java
+++ b/popi-api-gateway/src/main/java/com/lgcns/logging/dto/HttpRequestLogInfo.java
@@ -1,6 +1,5 @@
 package com.lgcns.logging.dto;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.Builder;
 import org.slf4j.MDC;
@@ -31,13 +30,5 @@ public record HttpRequestLogInfo(
                 .xAmznTraceId(xAmznTraceId)
                 .userAgent(userAgent)
                 .build();
-    }
-
-    public String toJson() {
-        try {
-            return objectMapper.writeValueAsString(this).replace("\\", "");
-        } catch (JsonProcessingException e) {
-            throw new RuntimeException(e);
-        }
     }
 }

--- a/popi-api-gateway/src/main/java/com/lgcns/logging/dto/HttpResponseLogInfo.java
+++ b/popi-api-gateway/src/main/java/com/lgcns/logging/dto/HttpResponseLogInfo.java
@@ -1,0 +1,64 @@
+package com.lgcns.logging.dto;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.List;
+import lombok.Builder;
+import org.slf4j.MDC;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.MediaType;
+
+@Builder
+public record HttpResponseLogInfo(String traceId, String responseBody, Integer responseStatus) {
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+
+    public static HttpResponseLogInfo from(
+            byte[] bodyBytes, HttpStatusCode status, String contentType) {
+        String traceId = MDC.get("traceId");
+        String responseBody = getContent(contentType, bodyBytes);
+        return HttpResponseLogInfo.builder()
+                .traceId(traceId)
+                .responseBody(responseBody)
+                .responseStatus(status != null ? status.value() : null)
+                .build();
+    }
+
+    private static String getContent(String contentType, byte[] content) {
+        boolean visible =
+                isVisible(
+                        MediaType.valueOf(contentType == null ? "application/json" : contentType));
+        if (visible) {
+            if (content.length > 0) {
+                return new String(
+                        content, 0, Math.min(content.length, 5120), StandardCharsets.UTF_8);
+            } else {
+                return "";
+            }
+        } else {
+            return "BINARY";
+        }
+    }
+
+    private static boolean isVisible(MediaType mediaType) {
+        final List<MediaType> VISIBLE_TYPES =
+                Arrays.asList(
+                        MediaType.valueOf("text/*"),
+                        MediaType.APPLICATION_FORM_URLENCODED,
+                        MediaType.APPLICATION_JSON,
+                        MediaType.APPLICATION_XML,
+                        MediaType.valueOf("application/*+json"),
+                        MediaType.valueOf("application/*+xml"),
+                        MediaType.MULTIPART_FORM_DATA);
+        return VISIBLE_TYPES.stream().anyMatch(visibleType -> visibleType.includes(mediaType));
+    }
+
+    public String toJson() {
+        try {
+            return objectMapper.writeValueAsString(this).replace("\\", "");
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/popi-api-gateway/src/main/java/com/lgcns/logging/dto/HttpResponseLogInfo.java
+++ b/popi-api-gateway/src/main/java/com/lgcns/logging/dto/HttpResponseLogInfo.java
@@ -30,7 +30,7 @@ public record HttpResponseLogInfo(String traceId, String responseBody, Integer r
                 isVisible(
                         MediaType.valueOf(contentType == null ? "application/json" : contentType));
         if (visible) {
-            if (content.length > 0) {
+            if (content != null && content.length > 0) {
                 return new String(
                         content, 0, Math.min(content.length, 5120), StandardCharsets.UTF_8);
             } else {

--- a/popi-api-gateway/src/main/java/com/lgcns/logging/dto/HttpResponseLogInfo.java
+++ b/popi-api-gateway/src/main/java/com/lgcns/logging/dto/HttpResponseLogInfo.java
@@ -1,7 +1,7 @@
 package com.lgcns.logging.dto;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.List;
@@ -11,13 +11,13 @@ import org.springframework.http.HttpStatusCode;
 import org.springframework.http.MediaType;
 
 @Builder
-public record HttpResponseLogInfo(String traceId, String responseBody, Integer responseStatus) {
+public record HttpResponseLogInfo(String traceId, Object responseBody, Integer responseStatus) {
     private static final ObjectMapper objectMapper = new ObjectMapper();
 
     public static HttpResponseLogInfo from(
             byte[] bodyBytes, HttpStatusCode status, String contentType) {
         String traceId = MDC.get("traceId");
-        String responseBody = getContent(contentType, bodyBytes);
+        Object responseBody = getContent(contentType, bodyBytes);
         return HttpResponseLogInfo.builder()
                 .traceId(traceId)
                 .responseBody(responseBody)
@@ -25,14 +25,17 @@ public record HttpResponseLogInfo(String traceId, String responseBody, Integer r
                 .build();
     }
 
-    private static String getContent(String contentType, byte[] content) {
+    private static Object getContent(String contentType, byte[] content) {
         boolean visible =
                 isVisible(
                         MediaType.valueOf(contentType == null ? "application/json" : contentType));
         if (visible) {
             if (content != null && content.length > 0) {
-                return new String(
-                        content, 0, Math.min(content.length, 5120), StandardCharsets.UTF_8);
+                try {
+                    return new ObjectMapper().readValue(content, Object.class);
+                } catch (IOException e) {
+                    return new String(content, StandardCharsets.UTF_8);
+                }
             } else {
                 return "";
             }
@@ -52,13 +55,5 @@ public record HttpResponseLogInfo(String traceId, String responseBody, Integer r
                         MediaType.valueOf("application/*+xml"),
                         MediaType.MULTIPART_FORM_DATA);
         return VISIBLE_TYPES.stream().anyMatch(visibleType -> visibleType.includes(mediaType));
-    }
-
-    public String toJson() {
-        try {
-            return objectMapper.writeValueAsString(this).replace("\\", "");
-        } catch (JsonProcessingException e) {
-            throw new RuntimeException(e);
-        }
     }
 }

--- a/popi-api-gateway/src/main/java/com/lgcns/logging/filter/HttpLoggingFilter.java
+++ b/popi-api-gateway/src/main/java/com/lgcns/logging/filter/HttpLoggingFilter.java
@@ -31,6 +31,8 @@ public class HttpLoggingFilter implements GlobalFilter, Ordered {
 
         logRequest(exchange);
 
+        ServerHttpRequest request = exchange.getRequest();
+        String path = request.getPath().value();
         ServerHttpResponse originalResponse = exchange.getResponse();
 
         // 응답 바디를 가로채기 위해 응답 객체를 데코레이터로 감쌈
@@ -39,6 +41,11 @@ public class HttpLoggingFilter implements GlobalFilter, Ordered {
 
                     @Override
                     public Mono<Void> writeWith(Publisher<? extends DataBuffer> body) {
+                        if (path.startsWith("/auth")) {
+                            logResponse(null, originalResponse);
+                            return super.writeWith(body);
+                        }
+
                         if (body instanceof Flux<? extends DataBuffer> fluxBody) {
                             return super.writeWith(
                                     fluxBody.buffer()

--- a/popi-api-gateway/src/main/java/com/lgcns/logging/filter/HttpLoggingFilter.java
+++ b/popi-api-gateway/src/main/java/com/lgcns/logging/filter/HttpLoggingFilter.java
@@ -1,0 +1,141 @@
+package com.lgcns.logging.filter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.lgcns.logging.dto.HttpRequestLogInfo;
+import com.lgcns.logging.dto.HttpResponseLogInfo;
+import java.nio.charset.StandardCharsets;
+import java.util.UUID;
+import lombok.extern.slf4j.Slf4j;
+import org.reactivestreams.Publisher;
+import org.slf4j.MDC;
+import org.springframework.cloud.gateway.filter.GatewayFilterChain;
+import org.springframework.cloud.gateway.filter.GlobalFilter;
+import org.springframework.core.Ordered;
+import org.springframework.core.io.buffer.*;
+import org.springframework.http.server.reactive.ServerHttpRequest;
+import org.springframework.http.server.reactive.ServerHttpRequestDecorator;
+import org.springframework.http.server.reactive.ServerHttpResponse;
+import org.springframework.http.server.reactive.ServerHttpResponseDecorator;
+import org.springframework.stereotype.Component;
+import org.springframework.web.server.ServerWebExchange;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+@Slf4j
+@Component
+public class HttpLoggingFilter implements GlobalFilter, Ordered {
+
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Override
+    public Mono<Void> filter(ServerWebExchange exchange, GatewayFilterChain chain) {
+        String traceId = UUID.randomUUID().toString();
+        MDC.put("traceId", traceId);
+
+        ServerHttpRequest request = exchange.getRequest();
+
+        /*log.info(
+        "[REQ] traceId={}, method={}, uri={}, headers={}",
+        traceId,
+        request.getMethod(),
+        request.getURI(),
+        request.getHeaders());*/
+        log.info("[REQ] {}", HttpRequestLogInfo.from(request).toJson());
+
+        // WebFlux에서는 body가 DataBuffer 형태의 stream -> join 필요
+        return DataBufferUtils.join(request.getBody())
+                .defaultIfEmpty(new DefaultDataBufferFactory().wrap(new byte[0])) // body 없을 경우 대비
+                .flatMap(
+                        dataBuffer -> {
+                            byte[] reqBodyBytes = new byte[dataBuffer.readableByteCount()];
+                            dataBuffer.read(reqBodyBytes);
+                            DataBufferUtils.release(dataBuffer); // 메모리 누수 방지
+
+                            String requestBody = new String(reqBodyBytes, StandardCharsets.UTF_8);
+
+                            log.info("[REQ BODY] traceId={}, body={}", traceId, requestBody);
+
+                            // 읽은 바디를 다시 request에 주입하려면 request를 감싸는 decorator 필요
+                            ServerHttpRequest mutatedRequest = request.mutate().build();
+                            mutatedRequest =
+                                    new ServerHttpRequestDecorator(mutatedRequest) {
+                                        @Override
+                                        public Flux<DataBuffer> getBody() {
+                                            return Flux.just(
+                                                    new DefaultDataBufferFactory()
+                                                            .wrap(reqBodyBytes));
+                                        }
+                                    };
+
+                            ServerHttpResponse originalResponse = exchange.getResponse();
+                            DataBufferFactory bufferFactory = originalResponse.bufferFactory();
+
+                            // 응답을 감싸는 decorator 생성 → writeWith() 오버라이드해서 body 로깅
+                            ServerHttpResponseDecorator decoratedResponse =
+                                    new ServerHttpResponseDecorator(originalResponse) {
+                                        @Override
+                                        public Mono<Void> writeWith(
+                                                Publisher<? extends DataBuffer> body) {
+                                            // 응답 바디가 Flux일 경우에만 처리
+                                            if (body
+                                                    instanceof
+                                                    Flux<? extends DataBuffer>
+                                                    fluxBody) {
+                                                return super.writeWith(
+                                                        fluxBody.buffer()
+                                                                .map(
+                                                                        dataBuffers -> {
+                                                                            DataBuffer joined =
+                                                                                    new DefaultDataBufferFactory()
+                                                                                            .join(
+                                                                                                    dataBuffers);
+
+                                                                            byte[] content =
+                                                                                    new byte
+                                                                                            [joined
+                                                                                                    .readableByteCount()];
+                                                                            joined.read(content);
+
+                                                                            String contentType =
+                                                                                    originalResponse
+                                                                                            .getHeaders()
+                                                                                            .getFirst(
+                                                                                                    "Content-Type");
+                                                                            HttpResponseLogInfo
+                                                                                    responseLog =
+                                                                                            HttpResponseLogInfo
+                                                                                                    .from(
+                                                                                                            content,
+                                                                                                            originalResponse
+                                                                                                                    .getStatusCode(),
+                                                                                                            contentType);
+                                                                            log.info(
+                                                                                    "[RES] {}",
+                                                                                    responseLog
+                                                                                            .toJson());
+
+                                                                            // 응답 바디 다시 감싸서 반환
+                                                                            return bufferFactory
+                                                                                    .wrap(content);
+                                                                        }));
+                                            }
+                                            // Flux가 아닌 다른 타입이면 그대로 통과
+                                            return super.writeWith(body);
+                                        }
+                                    };
+
+                            // 필터 체인을 이어서 실행하되, 변경된 요청(request) + 응답 데코레이터(response) 사용
+                            return chain.filter(
+                                            exchange.mutate()
+                                                    .request(mutatedRequest)
+                                                    .response(decoratedResponse)
+                                                    .build())
+                                    .doFinally(signal -> MDC.clear());
+                        });
+    }
+
+    @Override
+    public int getOrder() {
+        return -1;
+    }
+}

--- a/popi-api-gateway/src/main/java/com/lgcns/logging/filter/HttpLoggingFilter.java
+++ b/popi-api-gateway/src/main/java/com/lgcns/logging/filter/HttpLoggingFilter.java
@@ -9,6 +9,7 @@ import org.slf4j.MDC;
 import org.springframework.cloud.gateway.filter.GatewayFilterChain;
 import org.springframework.cloud.gateway.filter.GlobalFilter;
 import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
 import org.springframework.core.io.buffer.*;
 import org.springframework.http.server.reactive.ServerHttpRequest;
 import org.springframework.http.server.reactive.ServerHttpResponse;
@@ -20,7 +21,8 @@ import reactor.core.publisher.Mono;
 
 @Slf4j
 @Component
-public class HttpLoggingFilter implements GlobalFilter, Ordered {
+@Order(Ordered.HIGHEST_PRECEDENCE)
+public class HttpLoggingFilter implements GlobalFilter {
 
     private static final DataBufferFactory bufferFactory = new DefaultDataBufferFactory();
 
@@ -75,12 +77,6 @@ public class HttpLoggingFilter implements GlobalFilter, Ordered {
         // 응답 객체만 데코레이터로 변환 + 체인 필터 실행
         return chain.filter(exchange.mutate().response(decoratedResponse).build())
                 .doFinally(signal -> MDC.clear());
-    }
-
-    // 필터 우선순위 설정 - 가장 먼저 실행
-    @Override
-    public int getOrder() {
-        return -1;
     }
 
     private static void logRequest(ServerWebExchange exchange) {

--- a/popi-api-gateway/src/main/java/com/lgcns/logging/filter/HttpLoggingFilter.java
+++ b/popi-api-gateway/src/main/java/com/lgcns/logging/filter/HttpLoggingFilter.java
@@ -81,7 +81,7 @@ public class HttpLoggingFilter implements GlobalFilter {
 
     private static void logRequest(ServerWebExchange exchange) {
         ServerHttpRequest request = exchange.getRequest();
-        log.info(HttpRequestLogInfo.from(request).toJson());
+        log.info("{}", HttpRequestLogInfo.from(request));
     }
 
     private static void logResponse(byte[] content, ServerHttpResponse originalResponse) {
@@ -90,6 +90,6 @@ public class HttpLoggingFilter implements GlobalFilter {
         HttpResponseLogInfo responseLog =
                 HttpResponseLogInfo.from(content, originalResponse.getStatusCode(), contentType);
 
-        log.info(responseLog.toJson());
+        log.info("{}", responseLog);
     }
 }

--- a/popi-api-gateway/src/main/java/com/lgcns/logging/filter/HttpLoggingFilter.java
+++ b/popi-api-gateway/src/main/java/com/lgcns/logging/filter/HttpLoggingFilter.java
@@ -1,9 +1,7 @@
 package com.lgcns.logging.filter;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.lgcns.logging.dto.HttpRequestLogInfo;
 import com.lgcns.logging.dto.HttpResponseLogInfo;
-import java.nio.charset.StandardCharsets;
 import java.util.UUID;
 import lombok.extern.slf4j.Slf4j;
 import org.reactivestreams.Publisher;
@@ -13,7 +11,6 @@ import org.springframework.cloud.gateway.filter.GlobalFilter;
 import org.springframework.core.Ordered;
 import org.springframework.core.io.buffer.*;
 import org.springframework.http.server.reactive.ServerHttpRequest;
-import org.springframework.http.server.reactive.ServerHttpRequestDecorator;
 import org.springframework.http.server.reactive.ServerHttpResponse;
 import org.springframework.http.server.reactive.ServerHttpResponseDecorator;
 import org.springframework.stereotype.Component;
@@ -25,7 +22,7 @@ import reactor.core.publisher.Mono;
 @Component
 public class HttpLoggingFilter implements GlobalFilter, Ordered {
 
-    private static final ObjectMapper objectMapper = new ObjectMapper();
+    private static final DataBufferFactory bufferFactory = new DefaultDataBufferFactory();
 
     @Override
     public Mono<Void> filter(ServerWebExchange exchange, GatewayFilterChain chain) {
@@ -34,106 +31,60 @@ public class HttpLoggingFilter implements GlobalFilter, Ordered {
 
         ServerHttpRequest request = exchange.getRequest();
 
-        /*log.info(
-        "[REQ] traceId={}, method={}, uri={}, headers={}",
-        traceId,
-        request.getMethod(),
-        request.getURI(),
-        request.getHeaders());*/
-        log.info("[REQ] {}", HttpRequestLogInfo.from(request).toJson());
+        log.info(HttpRequestLogInfo.from(request).toJson());
 
-        // WebFlux에서는 body가 DataBuffer 형태의 stream -> join 필요
-        return DataBufferUtils.join(request.getBody())
-                .defaultIfEmpty(new DefaultDataBufferFactory().wrap(new byte[0])) // body 없을 경우 대비
-                .flatMap(
-                        dataBuffer -> {
-                            byte[] reqBodyBytes = new byte[dataBuffer.readableByteCount()];
-                            dataBuffer.read(reqBodyBytes);
-                            DataBufferUtils.release(dataBuffer); // 메모리 누수 방지
+        ServerHttpResponse originalResponse = exchange.getResponse();
 
-                            String requestBody = new String(reqBodyBytes, StandardCharsets.UTF_8);
+        // 응답 바디를 가로채기 위해 응답 객체를 데코레이터로 감쌈
+        ServerHttpResponseDecorator decoratedResponse =
+                new ServerHttpResponseDecorator(originalResponse) {
 
-                            log.info("[REQ BODY] traceId={}, body={}", traceId, requestBody);
+                    @Override
+                    public Mono<Void> writeWith(Publisher<? extends DataBuffer> body) {
+                        if (body instanceof Flux<? extends DataBuffer> fluxBody) {
+                            return super.writeWith(
+                                    fluxBody.buffer()
+                                            .map(
+                                                    dataBuffers -> {
+                                                        DataBuffer joined =
+                                                                bufferFactory.join(dataBuffers);
+                                                        byte[] content =
+                                                                new byte
+                                                                        [joined
+                                                                                .readableByteCount()];
+                                                        joined.read(content);
 
-                            // 읽은 바디를 다시 request에 주입하려면 request를 감싸는 decorator 필요
-                            ServerHttpRequest mutatedRequest = request.mutate().build();
-                            mutatedRequest =
-                                    new ServerHttpRequestDecorator(mutatedRequest) {
-                                        @Override
-                                        public Flux<DataBuffer> getBody() {
-                                            return Flux.just(
-                                                    new DefaultDataBufferFactory()
-                                                            .wrap(reqBodyBytes));
-                                        }
-                                    };
+                                                        String contentType =
+                                                                originalResponse
+                                                                        .getHeaders()
+                                                                        .getFirst("Content-Type");
 
-                            ServerHttpResponse originalResponse = exchange.getResponse();
-                            DataBufferFactory bufferFactory = originalResponse.bufferFactory();
+                                                        HttpResponseLogInfo responseLog =
+                                                                HttpResponseLogInfo.from(
+                                                                        content,
+                                                                        originalResponse
+                                                                                .getStatusCode(),
+                                                                        contentType);
 
-                            // 응답을 감싸는 decorator 생성 → writeWith() 오버라이드해서 body 로깅
-                            ServerHttpResponseDecorator decoratedResponse =
-                                    new ServerHttpResponseDecorator(originalResponse) {
-                                        @Override
-                                        public Mono<Void> writeWith(
-                                                Publisher<? extends DataBuffer> body) {
-                                            // 응답 바디가 Flux일 경우에만 처리
-                                            if (body
-                                                    instanceof
-                                                    Flux<? extends DataBuffer>
-                                                    fluxBody) {
-                                                return super.writeWith(
-                                                        fluxBody.buffer()
-                                                                .map(
-                                                                        dataBuffers -> {
-                                                                            DataBuffer joined =
-                                                                                    new DefaultDataBufferFactory()
-                                                                                            .join(
-                                                                                                    dataBuffers);
+                                                        log.info(responseLog.toJson());
 
-                                                                            byte[] content =
-                                                                                    new byte
-                                                                                            [joined
-                                                                                                    .readableByteCount()];
-                                                                            joined.read(content);
+                                                        // 읽은 응답 바디를 클라이언트에게 다시 전달 (body는 한 번만 소비
+                                                        // 가능하므로 wrap 필요)
+                                                        return bufferFactory.wrap(content);
+                                                    }));
+                        }
 
-                                                                            String contentType =
-                                                                                    originalResponse
-                                                                                            .getHeaders()
-                                                                                            .getFirst(
-                                                                                                    "Content-Type");
-                                                                            HttpResponseLogInfo
-                                                                                    responseLog =
-                                                                                            HttpResponseLogInfo
-                                                                                                    .from(
-                                                                                                            content,
-                                                                                                            originalResponse
-                                                                                                                    .getStatusCode(),
-                                                                                                            contentType);
-                                                                            log.info(
-                                                                                    "[RES] {}",
-                                                                                    responseLog
-                                                                                            .toJson());
+                        // Flux가 아닌 body 타입이면 그대로 처리 (예외적인 경우)
+                        return super.writeWith(body);
+                    }
+                };
 
-                                                                            // 응답 바디 다시 감싸서 반환
-                                                                            return bufferFactory
-                                                                                    .wrap(content);
-                                                                        }));
-                                            }
-                                            // Flux가 아닌 다른 타입이면 그대로 통과
-                                            return super.writeWith(body);
-                                        }
-                                    };
-
-                            // 필터 체인을 이어서 실행하되, 변경된 요청(request) + 응답 데코레이터(response) 사용
-                            return chain.filter(
-                                            exchange.mutate()
-                                                    .request(mutatedRequest)
-                                                    .response(decoratedResponse)
-                                                    .build())
-                                    .doFinally(signal -> MDC.clear());
-                        });
+        // 응답 객체만 데코레이터로 변환 + 체인 필터 실행
+        return chain.filter(exchange.mutate().response(decoratedResponse).build())
+                .doFinally(signal -> MDC.clear());
     }
 
+    // 필터 우선순위 설정 - 가장 먼저 실행
     @Override
     public int getOrder() {
         return -1;

--- a/popi-api-gateway/src/main/resources/logback-spring.xml
+++ b/popi-api-gateway/src/main/resources/logback-spring.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
+
+    <springProfile name="local">
+        <property name="LOKI_URL" value="http://localhost:3100/loki/api/v1/push"/>
+    </springProfile>
+    <springProfile name="dev">
+        <property name="LOKI_URL" value="http://loki.monitoring.svc:3100/loki/api/v1/push"/>
+    </springProfile>
+
+    <appender name="LOKI" class="com.github.loki4j.logback.Loki4jAppender">
+        <http>
+            <url>${LOKI_URL}</url>
+        </http>
+        <format>
+            <label>
+                <pattern>app=popi,service=user-service,level=%level</pattern>
+            </label>
+            <message class="com.github.loki4j.logback.JsonLayout"/>
+        </format>
+    </appender>
+
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>${CONSOLE_LOG_PATTERN}</pattern>
+        </encoder>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="LOKI"/>
+        <appender-ref ref="CONSOLE"/>
+    </root>
+</configuration>

--- a/popi-api-gateway/src/test/resources/logback-test.xml
+++ b/popi-api-gateway/src/test/resources/logback-test.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <include resource="org/springframework/boot/logging/logback/base.xml"/>
+    <logger name="org.springframework.core " level="error"/>
+    <logger name="org.springframework.beans" level="error"/>
+    <logger name="org.springframework.context" level="error"/>
+    <logger name="org.springframework.transaction" level="error"/>
+    <logger name="org.springframework.web" level="error"/>
+    <logger name="org.springframework.test" level="error"/>
+    <logger name="org.hibernate" level="error"/>
+</configuration>

--- a/popi-common/build.gradle
+++ b/popi-common/build.gradle
@@ -19,4 +19,10 @@ dependencies {
 
     // Slice & Pageable
     implementation 'org.springframework.data:spring-data-commons'
+
+    // Prometheus
+    api 'io.micrometer:micrometer-registry-prometheus'
+
+    // Grafana Loki
+    api 'com.github.loki4j:loki-logback-appender:1.5.1'
 }

--- a/popi-reservation-service/src/main/java/com/lgcns/service/MemberReservationServiceImpl.java
+++ b/popi-reservation-service/src/main/java/com/lgcns/service/MemberReservationServiceImpl.java
@@ -30,6 +30,7 @@ import java.awt.image.BufferedImage;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.time.*;
+import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 import java.util.*;
 import java.util.stream.Collectors;
@@ -358,7 +359,8 @@ public class MemberReservationServiceImpl implements MemberReservationService {
             data.put("age", age);
             data.put("gender", gender);
             data.put("reservationDate", reservationDate.toString());
-            data.put("reservationTime", reservationTime.toString());
+            DateTimeFormatter timeFormatter = DateTimeFormatter.ofPattern("HH:mm:ss");
+            data.put("reservationTime", reservationTime.format(timeFormatter));
 
             ObjectMapper objectMapper = new ObjectMapper();
             String json = objectMapper.writeValueAsString(data);


### PR DESCRIPTION
## 🌱 관련 이슈

- [LCR-355]

---
## 📌 작업 내용 및 특이사항

###  `HttpRequestLogInfo`
- 요청 메타데이터를 일관된 JSON 포맷으로 로깅하기 위해 구현했습니다.
- **필드 설명**
  - `traceId` — 요청 단위 고유 ID로 MDC에 저장된 UUID (모든 로그에 공통 사용)
  - `requestMethod` — HTTP 메서드 (GET, POST 등)
  - `requestUri` — base URL 제외 경로 (예: `/members/me`)
  - `xAmznTraceId` — AWS X-Ray 헤더 (`x-amzn-trace-id`), 분산 트레이싱용 (nullable)
  - `userAgent` — 클라이언트 브라우저 또는 앱 정보
- **`toJson()`**
  - `ObjectMapper.writeValueAsString(this)`로 직렬화 후 `.replace("\\", "")` 처리해 로그 가독성 향상

</br>

###  `HttpResponseLogInfo`
- 응답 바디 및 상태 정보를 JSON 형태로 로깅하기 위해 구현했습니다.
- **필드 설명**
  - `traceId` — 요청과 매칭되는 MDC의 UUID
  - `responseBody` — 응답 본문 중 가시성 높은 content-type(JSON, TEXT 등)은 최대 5KB까지만 로깅. 바이너리 응답은 `"BINARY"`로 대체
  - `responseStatus` — HTTP 응답 상태 코드 (예: 200, 401, 500 등)
- **`toJson()`**
  - 요청과 동일하게 JSON 직렬화 후 슬래시 제거 처리

</br>

###  `HttpLoggingFilter`
- Spring Cloud Gateway 환경에서 모든 요청/응답을 로깅하기 위해 `GlobalFilter`를 구현했습니다.

####  요청 흐름
1. `traceId` 생성 후 `MDC.put(...)`으로 로그와 연동
2. `logRequest()` 호출 → `HttpRequestLogInfo.from(request)`로 요청 로그 기록

####  응답 흐름
3. `ServerHttpResponseDecorator`로 응답 객체 감싸기
4. `/auth` 경로는 응답 바디를 읽지 않고 상태 코드만 로깅
5. 기타 경로는 응답 바디를 `DataBuffer`로 읽은 뒤 byte[] 변환 → `HttpResponseLogInfo.from(...)`로 로깅
6. 응답 바디는 재사용 불가하므로 `wrap()`을 통해 복원
7. `MDC.clear()`로 요청 종료 후 traceId 정리

</br>

### `Logback` 
- 작성한 로그를 Loki에 전송하기 위해 의존성을 추가하고 logback-spring.xml을 추가했습니다.
- 로그 전송 과정에서 JSON 파싱에 일부 오류가 발생하여 HttpLoggingFilter를 수정했습니다.
- 테스트 환경을 위해 logback-test.xml을 추가했습니다.

---
## 📚 참고사항

-


[LCR-355]: https://lgcns-retail.atlassian.net/browse/LCR-355?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ