### PR TITLE
chore: AOP 로깅 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,7 +39,9 @@ def jacocoExcludePatterns = [
         "**/*Token*",
         "**/*Util*",
         "**/*Constants*",
-        "**/*Role*"
+        "**/*Role*",
+        "**/aop/**",
+        "**/async/**"
 ]
 
 sonar {

--- a/popi-api-gateway/build.gradle
+++ b/popi-api-gateway/build.gradle
@@ -25,9 +25,6 @@ dependencies {
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 
-    // Prometheus
+    // prometheus
     implementation 'io.micrometer:micrometer-registry-prometheus'
-
-    // Grafana Loki
-    implementation 'com.github.loki4j:loki-logback-appender:1.5.1'
 }

--- a/popi-api-gateway/src/main/java/com/lgcns/logging/filter/HttpLoggingFilter.java
+++ b/popi-api-gateway/src/main/java/com/lgcns/logging/filter/HttpLoggingFilter.java
@@ -3,6 +3,7 @@ package com.lgcns.logging.filter;
 import com.lgcns.logging.dto.HttpRequestLogInfo;
 import com.lgcns.logging.dto.HttpResponseLogInfo;
 import java.util.UUID;
+import java.util.regex.Pattern;
 import lombok.extern.slf4j.Slf4j;
 import org.reactivestreams.Publisher;
 import org.slf4j.MDC;
@@ -26,15 +27,25 @@ public class HttpLoggingFilter implements GlobalFilter {
 
     private static final DataBufferFactory bufferFactory = new DefaultDataBufferFactory();
 
+    private static final Pattern EXCLUDED_PATH_PATTERN =
+            Pattern.compile("^/[^/]+/(v3/api-docs|actuator|prometheus)(/.*)?$");
+
     @Override
     public Mono<Void> filter(ServerWebExchange exchange, GatewayFilterChain chain) {
+        String path = exchange.getRequest().getURI().getPath();
+
+        if (EXCLUDED_PATH_PATTERN.matcher(path).matches()) {
+            return chain.filter(exchange);
+        }
+
         String traceId = UUID.randomUUID().toString();
         MDC.put("traceId", traceId);
 
-        logRequest(exchange);
+        ServerHttpRequest mutatedRequest =
+                exchange.getRequest().mutate().header("trace-id", traceId).build();
 
-        ServerHttpRequest request = exchange.getRequest();
-        String path = request.getPath().value();
+        logRequest(mutatedRequest);
+
         ServerHttpResponse originalResponse = exchange.getResponse();
 
         // 응답 바디를 가로채기 위해 응답 객체를 데코레이터로 감쌈
@@ -75,12 +86,15 @@ public class HttpLoggingFilter implements GlobalFilter {
                 };
 
         // 응답 객체만 데코레이터로 변환 + 체인 필터 실행
-        return chain.filter(exchange.mutate().response(decoratedResponse).build())
+        return chain.filter(
+                        exchange.mutate()
+                                .request(mutatedRequest)
+                                .response(decoratedResponse)
+                                .build())
                 .doFinally(signal -> MDC.clear());
     }
 
-    private static void logRequest(ServerWebExchange exchange) {
-        ServerHttpRequest request = exchange.getRequest();
+    private static void logRequest(ServerHttpRequest request) {
         log.info("{}", HttpRequestLogInfo.from(request));
     }
 

--- a/popi-api-gateway/src/main/java/com/lgcns/logging/filter/HttpLoggingFilter.java
+++ b/popi-api-gateway/src/main/java/com/lgcns/logging/filter/HttpLoggingFilter.java
@@ -91,6 +91,10 @@ public class HttpLoggingFilter implements GlobalFilter {
                                 .request(mutatedRequest)
                                 .response(decoratedResponse)
                                 .build())
+                .doOnError(
+                        throwable -> {
+                            logResponse(null, originalResponse);
+                        })
                 .doFinally(signal -> MDC.clear());
     }
 

--- a/popi-api-gateway/src/main/resources/logback-spring.xml
+++ b/popi-api-gateway/src/main/resources/logback-spring.xml
@@ -1,34 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
+
     <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
 
-    <springProfile name="local">
-        <property name="LOKI_URL" value="http://localhost:3100/loki/api/v1/push"/>
-    </springProfile>
-    <springProfile name="dev">
-        <property name="LOKI_URL" value="http://loki.monitoring.svc:3100/loki/api/v1/push"/>
-    </springProfile>
-
-    <appender name="LOKI" class="com.github.loki4j.logback.Loki4jAppender">
-        <http>
-            <url>${LOKI_URL}</url>
-        </http>
-        <format>
-            <label>
-                <pattern>app=popi,service=user-service,level=%level</pattern>
-            </label>
-            <message class="com.github.loki4j.logback.JsonLayout"/>
-        </format>
-    </appender>
+    <property name="APP_NAME" value="popi-api-gateway"/>
 
     <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>${CONSOLE_LOG_PATTERN}</pattern>
+            <pattern>
+                {"timestamp":"%d{yyyy-MM-dd'T'HH:mm:ss.SSS}","level":"%p","thread":"%thread","app_name":"${APP_NAME}","logger":"%logger{1}","traceId":"%X{traceId:-}","memberId":"%X{memberId:-}","message":"%replace(%msg){'\"','\\\"'}"}%n
+            </pattern>
         </encoder>
     </appender>
 
+    <logger name="org.springframework" level="WARN"/>
+    <logger name="reactor.netty" level="WARN"/>
+    <logger name="org.springframework.web.reactive" level="INFO"/>
+
     <root level="INFO">
-        <appender-ref ref="LOKI"/>
         <appender-ref ref="CONSOLE"/>
     </root>
+
 </configuration>

--- a/popi-api-gateway/src/main/resources/logback-spring.xml
+++ b/popi-api-gateway/src/main/resources/logback-spring.xml
@@ -3,7 +3,7 @@
 
     <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
 
-    <property name="APP_NAME" value="popi-api-gateway"/>
+    <property name="APP_NAME" value="api-gateway"/>
 
     <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>

--- a/popi-auth-service/build.gradle
+++ b/popi-auth-service/build.gradle
@@ -36,4 +36,7 @@ dependencies {
     implementation "io.grpc:grpc-netty-shaded:${grpcVersion}"
     implementation "io.grpc:grpc-stub:${grpcVersion}"
     implementation "io.grpc:grpc-inprocess:${grpcVersion}"
+
+    // prometheus
+    implementation 'io.micrometer:micrometer-registry-prometheus'
 }

--- a/popi-auth-service/src/main/resources/logback-spring.xml
+++ b/popi-auth-service/src/main/resources/logback-spring.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
+
+    <property name="APP_NAME" value="popi-auth-service"/>
+
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>{"timestamp":"%d{yyyy-MM-dd'T'HH:mm:ss.SSS}","level":"%p","thread":"%thread","app_name":"${APP_NAME}","logger":"%logger{1}","traceId":"%X{traceId:-}","memberId":"%X{memberId:-}","message":"%replace(%msg){'\"','\\\"'}"}%n</pattern>
+        </encoder>
+    </appender>
+
+    <logger name="org.springframework" level="WARN"/>
+    <logger name="org.hibernate" level="WARN"/>
+    <logger name="com.zaxxer.hikari" level="WARN"/>
+
+    <root level="INFO">
+        <appender-ref ref="CONSOLE"/>
+    </root>
+
+</configuration>

--- a/popi-auth-service/src/main/resources/logback-spring.xml
+++ b/popi-auth-service/src/main/resources/logback-spring.xml
@@ -2,7 +2,7 @@
 <configuration>
     <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
 
-    <property name="APP_NAME" value="popi-auth-service"/>
+    <property name="APP_NAME" value="auth-service"/>
 
     <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>

--- a/popi-auth-service/src/main/resources/logback-spring.xml
+++ b/popi-auth-service/src/main/resources/logback-spring.xml
@@ -6,7 +6,9 @@
 
     <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>{"timestamp":"%d{yyyy-MM-dd'T'HH:mm:ss.SSS}","level":"%p","thread":"%thread","app_name":"${APP_NAME}","logger":"%logger{1}","traceId":"%X{traceId:-}","memberId":"%X{memberId:-}","message":"%replace(%msg){'\"','\\\"'}"}%n</pattern>
+            <pattern>
+                {"timestamp":"%d{yyyy-MM-dd'T'HH:mm:ss.SSS}","level":"%p","thread":"%thread","app_name":"${APP_NAME}","logger":"%logger{1}","traceId":"%X{traceId:-}","memberId":"%X{memberId:-}","message":"%replace(%msg){'\"','\\\"'}"}%n
+            </pattern>
         </encoder>
     </appender>
 

--- a/popi-common/build.gradle
+++ b/popi-common/build.gradle
@@ -45,12 +45,6 @@ dependencies {
     // logback
     api 'net.logstash.logback:logstash-logback-encoder:8.1'
 
-    // Prometheus
-    api 'io.micrometer:micrometer-registry-prometheus'
-
-    // Grafana Loki
-    api 'com.github.loki4j:loki-logback-appender:1.5.1'
-
     // Protobuf serialization/deserialization
     implementation "com.google.protobuf:protobuf-java:${protobufVersion}"
     implementation "com.google.protobuf:protobuf-java-util:${protobufVersion}"

--- a/popi-common/build.gradle
+++ b/popi-common/build.gradle
@@ -39,6 +39,12 @@ dependencies {
     // Slice & Pageable
     implementation 'org.springframework.data:spring-data-commons'
 
+    // AOP
+    implementation 'org.springframework.boot:spring-boot-starter-aop'
+
+    // logback
+    api 'net.logstash.logback:logstash-logback-encoder:8.1'
+
     // Prometheus
     api 'io.micrometer:micrometer-registry-prometheus'
 

--- a/popi-common/src/main/java/com/lgcns/aop/aspect/EventLoggingAspect.java
+++ b/popi-common/src/main/java/com/lgcns/aop/aspect/EventLoggingAspect.java
@@ -1,0 +1,69 @@
+package com.lgcns.aop.aspect;
+
+import static com.lgcns.aop.util.LoggingUtil.calculateDuration;
+import static com.lgcns.aop.util.LoggingUtil.getShortErrorMessage;
+
+import com.lgcns.aop.util.LoggingUtil;
+import java.lang.reflect.Method;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Pointcut;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.springframework.stereotype.Component;
+
+@Aspect
+@Component
+@Slf4j
+public class EventLoggingAspect {
+
+    @Pointcut(
+            "execution(public * org.springframework.context.ApplicationEventPublisher+.publishEvent(..))")
+    public void allPublishEvent() {}
+
+    @Pointcut("execution(public * com.lgcns..event..*.*(..))")
+    public void allEventHandlers() {}
+
+    @Around("allPublishEvent()")
+    public Object logEventPublishing(ProceedingJoinPoint joinPoint) throws Throwable {
+        MethodSignature signature = (MethodSignature) joinPoint.getSignature();
+        Method method = signature.getMethod();
+        String methodName = LoggingUtil.getMethodSignature(method);
+
+        long start = System.currentTimeMillis();
+
+        try {
+            return joinPoint.proceed();
+        } catch (Exception e) {
+            log.error(
+                    "[EVENT-PUBLISH-ERROR] Method: {}, Exception: {}, Message: {}, Duration: {}ms",
+                    methodName,
+                    e.getClass().getSimpleName(),
+                    getShortErrorMessage(e.getMessage()),
+                    calculateDuration(start));
+            throw e;
+        }
+    }
+
+    @Around("allEventHandlers()")
+    public Object logEventHandlers(ProceedingJoinPoint joinPoint) throws Throwable {
+        MethodSignature signature = (MethodSignature) joinPoint.getSignature();
+        Method method = signature.getMethod();
+        String methodName = LoggingUtil.getMethodSignature(method);
+
+        long start = System.currentTimeMillis();
+
+        try {
+            return joinPoint.proceed();
+        } catch (Exception e) {
+            log.error(
+                    "[EVENT-LISTENER-ERROR] Method: {}, Exception: {}, Message: {}, Duration: {}ms",
+                    methodName,
+                    e.getClass().getSimpleName(),
+                    getShortErrorMessage(e.getMessage()),
+                    calculateDuration(start));
+            throw e;
+        }
+    }
+}

--- a/popi-common/src/main/java/com/lgcns/aop/aspect/FeignLoggingAspect.java
+++ b/popi-common/src/main/java/com/lgcns/aop/aspect/FeignLoggingAspect.java
@@ -1,0 +1,55 @@
+package com.lgcns.aop.aspect;
+
+import static com.lgcns.aop.util.LoggingUtil.calculateDuration;
+import static com.lgcns.aop.util.LoggingUtil.getShortErrorMessage;
+
+import com.lgcns.aop.util.LoggingUtil;
+import com.lgcns.error.exception.CustomException;
+import java.lang.reflect.Method;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Pointcut;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.springframework.stereotype.Component;
+
+@Aspect
+@Component
+@Slf4j
+public class FeignLoggingAspect {
+
+    @Pointcut("execution(* com.lgcns..client..*.*(..))")
+    public void allFeignClient() {}
+
+    @Around("allFeignClient()")
+    public Object logFeign(ProceedingJoinPoint joinPoint) throws Throwable {
+        MethodSignature signature = (MethodSignature) joinPoint.getSignature();
+        Method method = signature.getMethod();
+        String methodName = LoggingUtil.getMethodSignature(method);
+
+        long start = System.currentTimeMillis();
+
+        try {
+            return joinPoint.proceed();
+
+        } catch (CustomException ce) {
+            log.warn(
+                    "[FEIGN-CUSTOM] Method: {}, Code: {}, Message: {}, Duration: {}ms",
+                    methodName,
+                    ce.getErrorCode(),
+                    ce.getMessage(),
+                    calculateDuration(start));
+            throw ce;
+
+        } catch (Exception e) {
+            log.error(
+                    "[FEIGN-ERROR] Method: {}, Exception: {}, Message: {}, Duration: {}ms",
+                    methodName,
+                    e.getClass().getSimpleName(),
+                    getShortErrorMessage(e.getMessage()),
+                    calculateDuration(start));
+            throw e;
+        }
+    }
+}

--- a/popi-common/src/main/java/com/lgcns/aop/aspect/KafkaProducerLoggingAspect.java
+++ b/popi-common/src/main/java/com/lgcns/aop/aspect/KafkaProducerLoggingAspect.java
@@ -1,0 +1,44 @@
+package com.lgcns.aop.aspect;
+
+import static com.lgcns.aop.util.LoggingUtil.calculateDuration;
+import static com.lgcns.aop.util.LoggingUtil.getShortErrorMessage;
+
+import com.lgcns.aop.util.LoggingUtil;
+import java.lang.reflect.Method;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Pointcut;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.springframework.stereotype.Component;
+
+@Aspect
+@Component
+@Slf4j
+public class KafkaProducerLoggingAspect {
+
+    @Pointcut("execution(* com.lgcns..producer..*Producer.sendMessage(..))")
+    public void allKafkaProducer() {}
+
+    @Around("allKafkaProducer()")
+    public Object logKafkaProducer(ProceedingJoinPoint joinPoint) throws Throwable {
+        MethodSignature signature = (MethodSignature) joinPoint.getSignature();
+        Method method = signature.getMethod();
+        String methodName = LoggingUtil.getMethodSignature(method);
+
+        long start = System.currentTimeMillis();
+
+        try {
+            return joinPoint.proceed();
+        } catch (Exception e) {
+            log.error(
+                    "[KAFKA-ERROR] Method: {}, Exception: {}, Message: {}, Duration: {}ms",
+                    methodName,
+                    e.getClass().getSimpleName(),
+                    getShortErrorMessage(e.getMessage()),
+                    calculateDuration(start));
+            throw e;
+        }
+    }
+}

--- a/popi-common/src/main/java/com/lgcns/aop/aspect/RepositoryLoggingAspect.java
+++ b/popi-common/src/main/java/com/lgcns/aop/aspect/RepositoryLoggingAspect.java
@@ -1,0 +1,55 @@
+package com.lgcns.aop.aspect;
+
+import static com.lgcns.aop.util.LoggingUtil.calculateDuration;
+import static com.lgcns.aop.util.LoggingUtil.getShortErrorMessage;
+
+import com.lgcns.aop.util.LoggingUtil;
+import com.lgcns.error.exception.CustomException;
+import java.lang.reflect.Method;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Pointcut;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.springframework.stereotype.Component;
+
+@Aspect
+@Component
+@Slf4j
+public class RepositoryLoggingAspect {
+
+    @Pointcut("execution(public * com.lgcns..repository..*.*(..))")
+    public void allRepository() {}
+
+    @Around("allRepository()")
+    public Object logRepository(ProceedingJoinPoint joinPoint) throws Throwable {
+        MethodSignature signature = (MethodSignature) joinPoint.getSignature();
+        Method method = signature.getMethod();
+        String methodName = LoggingUtil.getMethodSignature(method);
+
+        long start = System.currentTimeMillis();
+
+        try {
+            return joinPoint.proceed();
+
+        } catch (CustomException ce) {
+            log.warn(
+                    "[REPOSITORY-CUSTOM] Method: {}, Code: {}, Message: {}, Duration: {}ms",
+                    methodName,
+                    ce.getErrorCode(),
+                    ce.getMessage(),
+                    calculateDuration(start));
+            throw ce;
+
+        } catch (Exception e) {
+            log.error(
+                    "[REPOSITORY-ERROR] Method: {}, Exception: {}, Message: {}, Duration: {}ms",
+                    methodName,
+                    e.getClass().getSimpleName(),
+                    getShortErrorMessage(e.getMessage()),
+                    calculateDuration(start));
+            throw e;
+        }
+    }
+}

--- a/popi-common/src/main/java/com/lgcns/aop/aspect/SchedulerLoggingAspect.java
+++ b/popi-common/src/main/java/com/lgcns/aop/aspect/SchedulerLoggingAspect.java
@@ -1,0 +1,61 @@
+package com.lgcns.aop.aspect;
+
+import static com.lgcns.aop.util.LoggingUtil.calculateDuration;
+import static com.lgcns.aop.util.LoggingUtil.getShortErrorMessage;
+
+import com.lgcns.aop.util.LoggingUtil;
+import com.lgcns.error.exception.CustomException;
+import java.lang.reflect.Method;
+import java.util.UUID;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Pointcut;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.springframework.stereotype.Component;
+
+@Aspect
+@Component
+@Slf4j
+public class SchedulerLoggingAspect {
+
+    @Pointcut("@annotation(org.springframework.scheduling.annotation.Scheduled)")
+    public void allScheduledJobs() {}
+
+    @Around("allScheduledJobs()")
+    public Object logScheduler(ProceedingJoinPoint joinPoint) throws Throwable {
+        MethodSignature signature = (MethodSignature) joinPoint.getSignature();
+        Method method = signature.getMethod();
+        String methodName = LoggingUtil.getMethodSignature(method);
+
+        String traceId = UUID.randomUUID().toString();
+        LoggingUtil.setTraceId(traceId);
+
+        long start = System.currentTimeMillis();
+
+        try {
+            return joinPoint.proceed();
+
+        } catch (CustomException ce) {
+            log.warn(
+                    "[SCHEDULER-CUSTOM] Method: {}, Code: {}, Message: {}, Duration: {}ms",
+                    methodName,
+                    ce.getErrorCode(),
+                    ce.getMessage(),
+                    calculateDuration(start));
+            throw ce;
+
+        } catch (Exception e) {
+            log.error(
+                    "[SCHEDULER-ERROR] Method: {}, Exception: {}, Message: {}, Duration: {}ms",
+                    methodName,
+                    e.getClass().getSimpleName(),
+                    getShortErrorMessage(e.getMessage()),
+                    calculateDuration(start));
+            throw e;
+        } finally {
+            LoggingUtil.clearMDC();
+        }
+    }
+}

--- a/popi-common/src/main/java/com/lgcns/aop/aspect/ServiceLoggingAspect.java
+++ b/popi-common/src/main/java/com/lgcns/aop/aspect/ServiceLoggingAspect.java
@@ -1,0 +1,60 @@
+package com.lgcns.aop.aspect;
+
+import static com.lgcns.aop.util.LoggingUtil.calculateDuration;
+import static com.lgcns.aop.util.LoggingUtil.getShortErrorMessage;
+
+import com.lgcns.aop.util.LoggingUtil;
+import com.lgcns.error.exception.CustomException;
+import com.lgcns.error.exception.ErrorCode;
+import java.lang.reflect.Method;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Pointcut;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.springframework.stereotype.Component;
+
+@Aspect
+@Component
+@Slf4j
+public class ServiceLoggingAspect {
+
+    @Pointcut("execution(public * com.lgcns..service..*.*(..))")
+    public void allService() {}
+
+    @Around("allService()")
+    public Object logService(ProceedingJoinPoint joinPoint) throws Throwable {
+        MethodSignature signature = (MethodSignature) joinPoint.getSignature();
+        Method method = signature.getMethod();
+        String methodName = LoggingUtil.getMethodSignature(method);
+
+        long start = System.currentTimeMillis();
+
+        log.info("[SERVICE] Method: {}", methodName);
+
+        try {
+            Object result = joinPoint.proceed();
+            log.info("[SERVICE] Method: {}, Duration: {}ms", methodName, calculateDuration(start));
+            return result;
+        } catch (CustomException customException) {
+            ErrorCode errorCode = customException.getErrorCode();
+            log.info(
+                    "[CustomException] Method: {}, Code: {}, Message: {}, Duration: {}ms",
+                    methodName,
+                    errorCode,
+                    customException.getMessage(),
+                    calculateDuration(start));
+
+            throw customException;
+        } catch (Exception e) {
+            log.error(
+                    "[UnhandledException] Method: {}, Exception: {}, Message: {}, Duration: {}ms",
+                    methodName,
+                    e.getClass().getSimpleName(),
+                    getShortErrorMessage(e.getMessage()),
+                    calculateDuration(start));
+            throw e;
+        }
+    }
+}

--- a/popi-common/src/main/java/com/lgcns/aop/filter/LoggingContextInjectionFilter.java
+++ b/popi-common/src/main/java/com/lgcns/aop/filter/LoggingContextInjectionFilter.java
@@ -1,0 +1,31 @@
+package com.lgcns.aop.filter;
+
+import com.lgcns.aop.util.LoggingUtil;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Component
+public class LoggingContextInjectionFilter extends OncePerRequestFilter {
+
+    @Override
+    protected void doFilterInternal(
+            HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+        try {
+            String traceId = request.getHeader("trace-id");
+            String memberId = request.getHeader("member-id");
+
+            LoggingUtil.setTraceId(traceId);
+            LoggingUtil.setMemberId(memberId);
+
+            filterChain.doFilter(request, response);
+        } finally {
+            LoggingUtil.clearMDC();
+        }
+    }
+}

--- a/popi-common/src/main/java/com/lgcns/aop/util/LoggingUtil.java
+++ b/popi-common/src/main/java/com/lgcns/aop/util/LoggingUtil.java
@@ -1,0 +1,80 @@
+package com.lgcns.aop.util;
+
+import jakarta.servlet.http.HttpServletRequest;
+import java.lang.reflect.Method;
+import java.lang.reflect.Parameter;
+import java.util.HashMap;
+import java.util.Map;
+import org.slf4j.MDC;
+import org.springframework.web.context.request.RequestAttributes;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+public class LoggingUtil {
+
+    public static final String TRACE_ID = "traceId";
+    public static final String MEMBER_ID = "memberId";
+
+    public static void setTraceId(String traceId) {
+        if (isNotEmpty(traceId)) MDC.put(TRACE_ID, traceId);
+    }
+
+    public static String getTraceId() {
+        return MDC.get(TRACE_ID);
+    }
+
+    public static void setMemberId(String memberId) {
+        if (isNotEmpty(memberId)) MDC.put(MEMBER_ID, memberId);
+    }
+
+    public static String getMemberId() {
+        return MDC.get(MEMBER_ID);
+    }
+
+    public static void clearMDC() {
+        MDC.clear();
+    }
+
+    private static boolean isNotEmpty(String value) {
+        return value != null && !value.isEmpty();
+    }
+
+    public static HttpServletRequest getCurrentHttpRequest() {
+        RequestAttributes attributes = RequestContextHolder.getRequestAttributes();
+        if (attributes instanceof ServletRequestAttributes servletRequestAttributes) {
+            return servletRequestAttributes.getRequest();
+        }
+        return null;
+    }
+
+    public static String getRequestUriWithQuery(HttpServletRequest request) {
+        if (request == null) return null;
+        String query = request.getQueryString();
+        return request.getRequestURI() + (query == null ? "" : "?" + query);
+    }
+
+    public static String getMethodSignature(Method method) {
+        return method.getDeclaringClass().getSimpleName() + "." + method.getName();
+    }
+
+    public static Map<String, Object> extractParams(Method method, Object[] args) {
+        Map<String, Object> paramMap = new HashMap<>();
+        if (args == null || args.length == 0) return paramMap;
+
+        Parameter[] parameters = method.getParameters();
+        for (int i = 0; i < parameters.length; i++) {
+            paramMap.put(parameters[i].getName(), args[i]);
+        }
+        return paramMap;
+    }
+
+    public static long calculateDuration(long startTime) {
+        return System.currentTimeMillis() - startTime;
+    }
+
+    public static String getShortErrorMessage(String errorMessage) {
+        return errorMessage != null && errorMessage.contains(":")
+                ? errorMessage.substring(errorMessage.lastIndexOf(":") + 1).trim()
+                : errorMessage;
+    }
+}

--- a/popi-common/src/main/java/com/lgcns/async/MdcTaskDecorator.java
+++ b/popi-common/src/main/java/com/lgcns/async/MdcTaskDecorator.java
@@ -1,0 +1,25 @@
+package com.lgcns.async;
+
+import java.util.Map;
+import org.slf4j.MDC;
+import org.springframework.core.task.TaskDecorator;
+
+public class MdcTaskDecorator implements TaskDecorator {
+
+    @Override
+    public Runnable decorate(Runnable runnable) {
+
+        Map<String, String> contextMap = MDC.getCopyOfContextMap();
+
+        return () -> {
+            try {
+                if (contextMap != null) {
+                    MDC.setContextMap(contextMap);
+                }
+                runnable.run();
+            } finally {
+                MDC.clear();
+            }
+        };
+    }
+}

--- a/popi-common/src/main/java/com/lgcns/config/AsyncConfig.java
+++ b/popi-common/src/main/java/com/lgcns/config/AsyncConfig.java
@@ -1,0 +1,24 @@
+package com.lgcns.config;
+
+import com.lgcns.async.MdcTaskDecorator;
+import java.util.concurrent.Executor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+@Configuration
+@EnableAsync
+public class AsyncConfig {
+
+    @Bean(name = "asyncTaskExecutor")
+    public Executor asyncTaskExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(5);
+        executor.setMaxPoolSize(10);
+        executor.setQueueCapacity(100);
+        executor.setTaskDecorator(new MdcTaskDecorator());
+        executor.initialize();
+        return executor;
+    }
+}

--- a/popi-common/src/main/java/com/lgcns/config/FeignConfig.java
+++ b/popi-common/src/main/java/com/lgcns/config/FeignConfig.java
@@ -1,6 +1,8 @@
 package com.lgcns.config;
 
+import com.lgcns.aop.util.LoggingUtil;
 import com.lgcns.error.feign.FeignErrorDecoder;
+import feign.RequestInterceptor;
 import feign.codec.ErrorDecoder;
 import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.context.annotation.Bean;
@@ -13,5 +15,16 @@ public class FeignConfig {
     @Bean
     public ErrorDecoder errorDecoder() {
         return new FeignErrorDecoder();
+    }
+
+    @Bean
+    public RequestInterceptor feignRequestInterceptor() {
+        return template -> {
+            String traceId = LoggingUtil.getTraceId();
+            String memberId = LoggingUtil.getMemberId();
+
+            if (traceId != null) template.header("trace-id", traceId);
+            if (memberId != null) template.header("member-id", memberId);
+        };
     }
 }

--- a/popi-common/src/main/java/com/lgcns/error/feign/FeignErrorDecoder.java
+++ b/popi-common/src/main/java/com/lgcns/error/feign/FeignErrorDecoder.java
@@ -10,11 +10,11 @@ import java.io.InputStream;
 public class FeignErrorDecoder implements ErrorDecoder {
 
     private final ErrorDecoder defaultDecoder = new Default();
+    private final ObjectMapper objectMapper = new ObjectMapper();
 
     @Override
     public Exception decode(String methodKey, Response response) {
         try (InputStream body = response.body().asInputStream()) {
-            ObjectMapper objectMapper = new ObjectMapper();
             JsonNode errorBody = objectMapper.readTree(body);
 
             String errorClassName =

--- a/popi-item-service/build.gradle
+++ b/popi-item-service/build.gradle
@@ -31,4 +31,7 @@ dependencies {
 
     // JPA
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+
+    // prometheus
+    implementation 'io.micrometer:micrometer-registry-prometheus'
 }

--- a/popi-item-service/src/main/resources/logback-spring.xml
+++ b/popi-item-service/src/main/resources/logback-spring.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
+
+    <property name="APP_NAME" value="popi-item-service"/>
+
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>{"timestamp":"%d{yyyy-MM-dd'T'HH:mm:ss.SSS}","level":"%p","thread":"%thread","logger":"%logger{1}","traceId":"%X{traceId:-}","memberId":"%X{memberId:-}","message":"%replace(%msg){'\"','\\\"'}"}%n</pattern>
+        </encoder>
+    </appender>
+
+    <logger name="org.springframework" level="WARN"/>
+    <logger name="org.hibernate" level="WARN"/>
+    <logger name="com.zaxxer.hikari" level="WARN"/>
+
+    <root level="INFO">
+        <appender-ref ref="CONSOLE"/>
+    </root>
+
+</configuration>

--- a/popi-item-service/src/main/resources/logback-spring.xml
+++ b/popi-item-service/src/main/resources/logback-spring.xml
@@ -6,7 +6,9 @@
 
     <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>{"timestamp":"%d{yyyy-MM-dd'T'HH:mm:ss.SSS}","level":"%p","thread":"%thread","logger":"%logger{1}","traceId":"%X{traceId:-}","memberId":"%X{memberId:-}","message":"%replace(%msg){'\"','\\\"'}"}%n</pattern>
+            <pattern>
+                {"timestamp":"%d{yyyy-MM-dd'T'HH:mm:ss.SSS}","level":"%p","thread":"%thread","app_name":"${APP_NAME}","logger":"%logger{1}","traceId":"%X{traceId:-}","memberId":"%X{memberId:-}","message":"%replace(%msg){'\"','\\\"'}"}%n
+            </pattern>
         </encoder>
     </appender>
 

--- a/popi-item-service/src/main/resources/logback-spring.xml
+++ b/popi-item-service/src/main/resources/logback-spring.xml
@@ -2,7 +2,7 @@
 <configuration>
     <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
 
-    <property name="APP_NAME" value="popi-item-service"/>
+    <property name="APP_NAME" value="item-service"/>
 
     <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>

--- a/popi-member-service/build.gradle
+++ b/popi-member-service/build.gradle
@@ -37,4 +37,7 @@ dependencies {
     implementation "io.grpc:grpc-netty-shaded:${grpcVersion}"
     implementation "io.grpc:grpc-stub:${grpcVersion}"
     implementation "io.grpc:grpc-inprocess:${grpcVersion}"
+
+    // prometheus
+    implementation 'io.micrometer:micrometer-registry-prometheus'
 }

--- a/popi-member-service/src/main/resources/logback-spring.xml
+++ b/popi-member-service/src/main/resources/logback-spring.xml
@@ -2,7 +2,7 @@
 <configuration>
     <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
 
-    <property name="APP_NAME" value="popi-member-service"/>
+    <property name="APP_NAME" value="member-service"/>
 
     <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>

--- a/popi-member-service/src/main/resources/logback-spring.xml
+++ b/popi-member-service/src/main/resources/logback-spring.xml
@@ -6,7 +6,9 @@
 
     <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>{"timestamp":"%d{yyyy-MM-dd'T'HH:mm:ss.SSS}","level":"%p","thread":"%thread","logger":"%logger{1}","traceId":"%X{traceId:-}","memberId":"%X{memberId:-}","message":"%replace(%msg){'\"','\\\"'}"}%n</pattern>
+            <pattern>
+                {"timestamp":"%d{yyyy-MM-dd'T'HH:mm:ss.SSS}","level":"%p","thread":"%thread","app_name":"${APP_NAME}","logger":"%logger{1}","traceId":"%X{traceId:-}","memberId":"%X{memberId:-}","message":"%replace(%msg){'\"','\\\"'}"}%n
+            </pattern>
         </encoder>
     </appender>
 

--- a/popi-member-service/src/main/resources/logback-spring.xml
+++ b/popi-member-service/src/main/resources/logback-spring.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
+
+    <property name="APP_NAME" value="popi-member-service"/>
+
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>{"timestamp":"%d{yyyy-MM-dd'T'HH:mm:ss.SSS}","level":"%p","thread":"%thread","logger":"%logger{1}","traceId":"%X{traceId:-}","memberId":"%X{memberId:-}","message":"%replace(%msg){'\"','\\\"'}"}%n</pattern>
+        </encoder>
+    </appender>
+
+    <logger name="org.springframework" level="WARN"/>
+    <logger name="org.hibernate" level="WARN"/>
+    <logger name="com.zaxxer.hikari" level="WARN"/>
+
+    <root level="INFO">
+        <appender-ref ref="CONSOLE"/>
+    </root>
+
+</configuration>

--- a/popi-notification-service/build.gradle
+++ b/popi-notification-service/build.gradle
@@ -44,4 +44,7 @@ dependencies {
 	// Batch
 	implementation 'org.springframework.boot:spring-boot-starter-batch'
 	testImplementation 'org.springframework.batch:spring-batch-test'
+
+	// prometheus
+	implementation 'io.micrometer:micrometer-registry-prometheus'
 }

--- a/popi-notification-service/src/main/resources/logback-spring.xml
+++ b/popi-notification-service/src/main/resources/logback-spring.xml
@@ -6,7 +6,9 @@
 
     <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>{"timestamp":"%d{yyyy-MM-dd'T'HH:mm:ss.SSS}","level":"%p","thread":"%thread","logger":"%logger{1}","traceId":"%X{traceId:-}","memberId":"%X{memberId:-}","message":"%replace(%msg){'\"','\\\"'}"}%n</pattern>
+            <pattern>
+                {"timestamp":"%d{yyyy-MM-dd'T'HH:mm:ss.SSS}","level":"%p","thread":"%thread","app_name":"${APP_NAME}","logger":"%logger{1}","traceId":"%X{traceId:-}","memberId":"%X{memberId:-}","message":"%replace(%msg){'\"','\\\"'}"}%n
+            </pattern>
         </encoder>
     </appender>
 

--- a/popi-notification-service/src/main/resources/logback-spring.xml
+++ b/popi-notification-service/src/main/resources/logback-spring.xml
@@ -2,7 +2,7 @@
 <configuration>
     <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
 
-    <property name="APP_NAME" value="popi-notification-service"/>
+    <property name="APP_NAME" value="notification-service"/>
 
     <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>

--- a/popi-notification-service/src/main/resources/logback-spring.xml
+++ b/popi-notification-service/src/main/resources/logback-spring.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
+
+    <property name="APP_NAME" value="popi-notification-service"/>
+
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>{"timestamp":"%d{yyyy-MM-dd'T'HH:mm:ss.SSS}","level":"%p","thread":"%thread","logger":"%logger{1}","traceId":"%X{traceId:-}","memberId":"%X{memberId:-}","message":"%replace(%msg){'\"','\\\"'}"}%n</pattern>
+        </encoder>
+    </appender>
+
+    <logger name="org.springframework" level="WARN"/>
+    <logger name="org.hibernate" level="WARN"/>
+    <logger name="com.zaxxer.hikari" level="WARN"/>
+
+    <root level="INFO">
+        <appender-ref ref="CONSOLE"/>
+    </root>
+
+</configuration>

--- a/popi-payment-service/build.gradle
+++ b/popi-payment-service/build.gradle
@@ -49,4 +49,7 @@ dependencies {
     annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
     annotationProcessor "jakarta.annotation:jakarta.annotation-api"
     annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+
+    // prometheus
+    implementation 'io.micrometer:micrometer-registry-prometheus'
 }

--- a/popi-payment-service/src/main/resources/logback-spring.xml
+++ b/popi-payment-service/src/main/resources/logback-spring.xml
@@ -2,7 +2,7 @@
 <configuration>
     <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
 
-    <property name="APP_NAME" value="popi-payment-service"/>
+    <property name="APP_NAME" value="payment-service"/>
 
     <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>

--- a/popi-payment-service/src/main/resources/logback-spring.xml
+++ b/popi-payment-service/src/main/resources/logback-spring.xml
@@ -6,7 +6,9 @@
 
     <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>{"timestamp":"%d{yyyy-MM-dd'T'HH:mm:ss.SSS}","level":"%p","thread":"%thread","logger":"%logger{1}","traceId":"%X{traceId:-}","memberId":"%X{memberId:-}","message":"%replace(%msg){'\"','\\\"'}"}%n</pattern>
+            <pattern>
+                {"timestamp":"%d{yyyy-MM-dd'T'HH:mm:ss.SSS}","level":"%p","thread":"%thread","app_name":"${APP_NAME}","logger":"%logger{1}","traceId":"%X{traceId:-}","memberId":"%X{memberId:-}","message":"%replace(%msg){'\"','\\\"'}"}%n
+            </pattern>
         </encoder>
     </appender>
 

--- a/popi-payment-service/src/main/resources/logback-spring.xml
+++ b/popi-payment-service/src/main/resources/logback-spring.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
+
+    <property name="APP_NAME" value="popi-payment-service"/>
+
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>{"timestamp":"%d{yyyy-MM-dd'T'HH:mm:ss.SSS}","level":"%p","thread":"%thread","logger":"%logger{1}","traceId":"%X{traceId:-}","memberId":"%X{memberId:-}","message":"%replace(%msg){'\"','\\\"'}"}%n</pattern>
+        </encoder>
+    </appender>
+
+    <logger name="org.springframework" level="WARN"/>
+    <logger name="org.hibernate" level="WARN"/>
+    <logger name="com.zaxxer.hikari" level="WARN"/>
+
+    <root level="INFO">
+        <appender-ref ref="CONSOLE"/>
+    </root>
+
+</configuration>

--- a/popi-popup-service/build.gradle
+++ b/popi-popup-service/build.gradle
@@ -18,4 +18,7 @@ dependencies {
 
     // WireMock
     testImplementation 'org.springframework.cloud:spring-cloud-contract-wiremock:4.2.1'
+
+    // prometheus
+    implementation 'io.micrometer:micrometer-registry-prometheus'
 }

--- a/popi-popup-service/src/main/resources/logback-spring.xml
+++ b/popi-popup-service/src/main/resources/logback-spring.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
+
+    <property name="APP_NAME" value="popi-popup-service"/>
+
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>{"timestamp":"%d{yyyy-MM-dd'T'HH:mm:ss.SSS}","level":"%p","thread":"%thread","logger":"%logger{1}","traceId":"%X{traceId:-}","memberId":"%X{memberId:-}","message":"%replace(%msg){'\"','\\\"'}"}%n</pattern>
+        </encoder>
+    </appender>
+
+    <logger name="org.springframework" level="WARN"/>
+    <logger name="org.hibernate" level="WARN"/>
+    <logger name="com.zaxxer.hikari" level="WARN"/>
+
+    <root level="INFO">
+        <appender-ref ref="CONSOLE"/>
+    </root>
+
+</configuration>

--- a/popi-popup-service/src/main/resources/logback-spring.xml
+++ b/popi-popup-service/src/main/resources/logback-spring.xml
@@ -2,7 +2,7 @@
 <configuration>
     <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
 
-    <property name="APP_NAME" value="popi-popup-service"/>
+    <property name="APP_NAME" value="popup-service"/>
 
     <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>

--- a/popi-popup-service/src/main/resources/logback-spring.xml
+++ b/popi-popup-service/src/main/resources/logback-spring.xml
@@ -6,7 +6,9 @@
 
     <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>{"timestamp":"%d{yyyy-MM-dd'T'HH:mm:ss.SSS}","level":"%p","thread":"%thread","logger":"%logger{1}","traceId":"%X{traceId:-}","memberId":"%X{memberId:-}","message":"%replace(%msg){'\"','\\\"'}"}%n</pattern>
+            <pattern>
+                {"timestamp":"%d{yyyy-MM-dd'T'HH:mm:ss.SSS}","level":"%p","thread":"%thread","app_name":"${APP_NAME}","logger":"%logger{1}","traceId":"%X{traceId:-}","memberId":"%X{memberId:-}","message":"%replace(%msg){'\"','\\\"'}"}%n
+            </pattern>
         </encoder>
     </appender>
 

--- a/popi-reservation-service/src/main/java/com/lgcns/event/handler/MemberReservationEventHandler.java
+++ b/popi-reservation-service/src/main/java/com/lgcns/event/handler/MemberReservationEventHandler.java
@@ -22,13 +22,13 @@ public class MemberReservationEventHandler {
     private final MemberReservationService memberReservationService;
     private final MemberEnteredProducer memberEnteredProducer;
 
-    @Async
+    @Async("asyncTaskExecutor")
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handleMemberReservationUpdateEvent(MemberReservationUpdateEvent event) {
         tryUpdateEvent(event.memberReservationId(), event.waitTime(), 0);
     }
 
-    @Async
+    @Async("asyncTaskExecutor")
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handleMemberReservationNotificationEvent(MemberReservationNotificationEvent event) {
         memberReservationService.createReservationNotification(event);

--- a/popi-reservation-service/src/main/resources/logback-spring.xml
+++ b/popi-reservation-service/src/main/resources/logback-spring.xml
@@ -2,7 +2,7 @@
 <configuration>
     <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
 
-    <property name="APP_NAME" value="popi-reservation-service"/>
+    <property name="APP_NAME" value="reservation-service"/>
 
     <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>

--- a/popi-reservation-service/src/main/resources/logback-spring.xml
+++ b/popi-reservation-service/src/main/resources/logback-spring.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
+
+    <property name="APP_NAME" value="popi-reservation-service"/>
+
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>{"timestamp":"%d{yyyy-MM-dd'T'HH:mm:ss.SSS}","level":"%p","thread":"%thread","logger":"%logger{1}","traceId":"%X{traceId:-}","memberId":"%X{memberId:-}","message":"%replace(%msg){'\"','\\\"'}"}%n</pattern>
+        </encoder>
+    </appender>
+
+    <logger name="org.springframework" level="WARN"/>
+    <logger name="org.hibernate" level="WARN"/>
+    <logger name="com.zaxxer.hikari" level="WARN"/>
+
+    <root level="INFO">
+        <appender-ref ref="CONSOLE"/>
+    </root>
+
+</configuration>

--- a/popi-reservation-service/src/main/resources/logback-spring.xml
+++ b/popi-reservation-service/src/main/resources/logback-spring.xml
@@ -6,7 +6,9 @@
 
     <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>{"timestamp":"%d{yyyy-MM-dd'T'HH:mm:ss.SSS}","level":"%p","thread":"%thread","logger":"%logger{1}","traceId":"%X{traceId:-}","memberId":"%X{memberId:-}","message":"%replace(%msg){'\"','\\\"'}"}%n</pattern>
+            <pattern>
+                {"timestamp":"%d{yyyy-MM-dd'T'HH:mm:ss.SSS}","level":"%p","thread":"%thread","app_name":"${APP_NAME}","logger":"%logger{1}","traceId":"%X{traceId:-}","memberId":"%X{memberId:-}","message":"%replace(%msg){'\"','\\\"'}"}%n
+            </pattern>
         </encoder>
     </appender>
 


### PR DESCRIPTION
## 🌱 관련 이슈

- [LCR-344]

---
## 📌 작업 내용 및 특이사항

- 공통 로깅 구조 도입을 위한 AOP 기반 로깅 시스템을 구성했습니다.
- Service, Repository, Feign, KafkaProducer, Scheduler, Event 처리 영역에 대해 각각 개별 Aspect를 작성하여, 호출 시점의 로깅을 수행합니다.
- MDC(Mapped Diagnostic Context)를 활용하여 traceId, memberId를 로그에 자동 포함시킵니다.
  - traceId는 서비스 진입점인 Gateway에서 생성되어 요청 헤더로 전달되며, 각 마이크로서비스에서는 LoggingContextInjectionFilter를 통해 해당 값을 MDC에 주입합니다.
  - 비동기 처리에서도 동일한 traceId, memberId를 유지하기 위해 AsyncConfig 및 MdcTaskDecorator를 구현했습니다. AsyncConfig에서 등록한 Bean 이름을 통해 MemberReservationEventHandler와 같은 클래스에서 해당 TaskDecorator를 적용할 수 있습니다.
  - Scheduler 관련 작업은 Gateway를 거치지 않으므로, Aspect 내부에서 UUID 기반의 traceId를 별도로 생성하여 사용합니다.
- 서비스 레이어 진입점에서는 메서드 성공 여부와 관계없이 항상 로그가 생성되며, 그 외 영역에서는 CustomException과 Exception을 구분하여 처리합니다.
  - CustomException은 예측 가능한 예외로 판단하여 로그 레벨을 info로 기록합니다.
- 공통 로깅 유틸리티(LoggingUtil)를 popi-common 모듈에 구현하여, 성능 시간 측정 함수 및 에러 메시지 간략화 함수 등을 제공하도록 구성했습니다.
- 각 마이크로서비스에 logback-spring.xml 설정 파일을 공통 포맷으로 추가하여, 로그 포맷을 통일했습니다.

---
## 📚 참고사항
- 현재 구현된 Feign 로깅 관련 Aspect는, 향후 gRPC 기반 통신 구조로 전환 시 삭제할 예정입니다.
- 로그는 logback에 정의된 encoder에 따라 아래와 같은 형태로 출력됩니다.
  - 정상 응답 예시
  ```
  {
    "timestamp":"2025-06-15T18:55:33.476",
    "level":"INFO",
    "thread":"http-nio-auto-1-exec-2",
    "logger":"c.l.a.a.ServiceLoggingAspect",
    "traceId":"675c4e79-39d1-4da4-bcaa-56dda928bd81",
    "memberId":"3",
    "message":"[SERVICE] Method: MemberReservationServiceImpl.cancelMemberReservation, Duration: 87ms"
  }
  ```
  - 에러 응답 예시
  
  ```
  {
    "timestamp":"2025-06-15T18:57:42.404",
    "level":"INFO",
    "thread":"http-nio-auto-1-exec-4",
    "logger":"c.l.a.a.ServiceLoggingAspect",
    "traceId":"744d1158-957d-4281-80d6-1df1165f1cd1",
    "memberId":"3",
    "message":"[CustomException] Method: MemberReservationServiceImpl.cancelMemberReservation, Code: MEMBER_RESERVATION_NOT_FOUND, Message: 회원 예약을 찾을 수 없습니다., Duration: 12ms"
  }
  ```

[LCR-344]: https://lgcns-retail.atlassian.net/browse/LCR-344?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ